### PR TITLE
CI: fix smoke-test path checking kestrel_database.csv not metadata.csv

### DIFF
--- a/.github/workflows/build-macos-dev.yml
+++ b/.github/workflows/build-macos-dev.yml
@@ -50,9 +50,9 @@ jobs:
 
           .venv2/bin/python analyzer/cli.py "${SMOKE_DIR}" --no-gpu --parallel-prefetch 1
 
-          META_PATH="${SMOKE_DIR}/.kestrel/metadata.csv"
+          META_PATH="${SMOKE_DIR}/.kestrel/kestrel_database.csv"
           if [ ! -f "${META_PATH}" ]; then
-            echo "Source CLI smoke test did not produce metadata.csv"
+            echo "Source CLI smoke test did not produce kestrel_database.csv"
             exit 1
           fi
           PROCESSED_ROWS=$(( $(wc -l < "${META_PATH}") - 1 ))
@@ -93,9 +93,9 @@ jobs:
 
           analyzer/dist/ProjectKestrel/ProjectKestrel --cli "${SMOKE_DIR}" --no-gpu --parallel-prefetch 1
 
-          META_PATH="${SMOKE_DIR}/.kestrel/metadata.csv"
+          META_PATH="${SMOKE_DIR}/.kestrel/kestrel_database.csv"
           if [ ! -f "${META_PATH}" ]; then
-            echo "Smoke test did not produce metadata.csv"
+            echo "Smoke test did not produce kestrel_database.csv"
             exit 1
           fi
           PROCESSED_ROWS=$(( $(wc -l < "${META_PATH}") - 1 ))

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -52,9 +52,9 @@ jobs:
 
           .venv2/bin/python analyzer/cli.py "${SMOKE_DIR}" --no-gpu --parallel-prefetch 1
 
-          META_PATH="${SMOKE_DIR}/.kestrel/metadata.csv"
+          META_PATH="${SMOKE_DIR}/.kestrel/kestrel_database.csv"
           if [ ! -f "${META_PATH}" ]; then
-            echo "Source CLI smoke test did not produce metadata.csv"
+            echo "Source CLI smoke test did not produce kestrel_database.csv"
             exit 1
           fi
           PROCESSED_ROWS=$(( $(wc -l < "${META_PATH}") - 1 ))
@@ -95,9 +95,9 @@ jobs:
 
           analyzer/dist/ProjectKestrel/ProjectKestrel --cli "${SMOKE_DIR}" --no-gpu --parallel-prefetch 1
 
-          META_PATH="${SMOKE_DIR}/.kestrel/metadata.csv"
+          META_PATH="${SMOKE_DIR}/.kestrel/kestrel_database.csv"
           if [ ! -f "${META_PATH}" ]; then
-            echo "Smoke test did not produce metadata.csv"
+            echo "Smoke test did not produce kestrel_database.csv"
             exit 1
           fi
           PROCESSED_ROWS=$(( $(wc -l < "${META_PATH}") - 1 ))

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -116,9 +116,9 @@ jobs:
 
           & ".\.venv2\Scripts\python.exe" "analyzer\cli.py" $smokeDir --no-gpu --parallel-prefetch 1
 
-          $metadataPath = Join-Path $smokeDir ".kestrel\metadata.csv"
+          $metadataPath = Join-Path $smokeDir ".kestrel\kestrel_database.csv"
           if (!(Test-Path $metadataPath)) {
-            throw "Source CLI smoke test did not produce metadata.csv"
+            throw "Source CLI smoke test did not produce kestrel_database.csv"
           }
           $processedRows = (Get-Content $metadataPath | Measure-Object -Line).Lines - 1
           if ($processedRows -lt 2) {
@@ -149,9 +149,9 @@ jobs:
 
           & "analyzer\dist\ProjectKestrel\ProjectKestrel.exe" --cli $smokeDir --no-gpu --parallel-prefetch 1
 
-          $metadataPath = Join-Path $smokeDir ".kestrel\metadata.csv"
+          $metadataPath = Join-Path $smokeDir ".kestrel\kestrel_database.csv"
           if (!(Test-Path $metadataPath)) {
-            throw "Smoke test did not produce metadata.csv"
+            throw "Smoke test did not produce kestrel_database.csv"
           }
           $processedRows = (Get-Content $metadataPath | Measure-Object -Line).Lines - 1
           if ($processedRows -lt 2) {


### PR DESCRIPTION
All three workflow smoke tests were checking for `.kestrel/metadata.csv`
but the analyzer writes `.kestrel/kestrel_database.csv` (DATABASE_NAME in
config.py). This caused every source-CLI smoke test to fail immediately
after successful image analysis, blocking the build entirely.

https://claude.ai/code/session_01A8V1dFw3BKUS7oVm6HgRy3