### PR TITLE
Fix UnicodeDecodeError when reading labels.txt on Japanese Windows

### DIFF
--- a/analyzer/kestrel_analyzer/ml/bird_species.py
+++ b/analyzer/kestrel_analyzer/ml/bird_species.py
@@ -16,7 +16,7 @@ class BirdSpeciesClassifier:
                 f"Failed to import onnxruntime: {e}\n"
                 "Try reinstalling: pip uninstall onnxruntime; pip install onnxruntime"
             ) from e
-        with open(labels_path, "r") as f:
+        with open(labels_path, "r", encoding="utf-8-sig") as f:
             self.labels = np.array([l.strip() for l in f.readlines()])
         providers = gpu_providers() if use_gpu else ["CPUExecutionProvider"]
         try:


### PR DESCRIPTION
Use utf-8-sig encoding to correctly handle UTF-8 with BOM label files, which previously caused cp932 decode failures on Japanese locale systems.

## Issue detail
On Japanese Windows systems, default enconding is cp932(Shift-JIS), which make `open` function of Python to read any file as cp932 encofing. However labels.txt included in the dist uses UTF-8 with BOM, which had following error on `Add to Queue` button
```
[
  {
    "timestamp_utc": "2026-05-07T16:49:34.190743Z",
    "level": "info",
    "event": "analysis_start",
    "analyzer": "visualizer-queue",
    "folder": "E:\\5",
    "file_count": 498,
    "detector_name": "mdv5a",
    "detection_threshold": 0.25,
    "parallel_prefetch": 3
  },
  {
    "timestamp_utc": "2026-05-07T16:49:34.237817Z",
    "level": "error",
    "stage": "load_models",
    "context": {
      "folder": "E:\\5",
      "analyzer": "visualizer-queue"
    },
    "exception_type": "UnicodeDecodeError",
    "exception_message": "'cp932' codec can't decode byte 0xef in position 0: illegal multibyte sequence",
    "traceback": "Traceback (most recent call last):\n  File \"kestrel_analyzer\\pipeline.py\", line 552, in process_folder\n    self.load_models(status_cb=status_cb, max_bird_crops=max_bird_crops)\n  File \"kestrel_analyzer\\pipeline.py\", line 372, in load_models\n    self.species_clf = BirdSpeciesClassifier(\n                       ^^^^^^^^^^^^^^^^^^^^^^\n  File \"kestrel_analyzer\\ml\\bird_species.py\", line 20, in __init__\n    self.labels = np.array([l.strip() for l in f.readlines()])\n                                               ^^^^^^^^^^^^^\nUnicodeDecodeError: 'cp932' codec can't decode byte 0xef in position 0: illegal multibyte sequence\n"
  }
]
```

What I confirmed:
1. Installed production app from Microsoft Store and confirmed this issue happens
1. Cloned the main branch and build from the source on my Windows11, confirmed that same issue happens
2. Applied my fix and confirmed the issue is resolved

I believe that this change should not cause any issues on any other machine as long as label.txt encoding doesn't change (which should stay same, right?)
Unfortunetely I don't have any other testing environment so I can't coduct furthur testing.