### PR TITLE
chore(deps): bump onnxruntime, opencv-python, and pandas to latest

### DIFF
--- a/requirements-macos.txt
+++ b/requirements-macos.txt
@@ -2,7 +2,7 @@
 # torch, torchvision, tensorflow removed: all ML inference uses ONNX Runtime.
 # onnxruntime on macOS includes CoreMLExecutionProvider for GPU/Neural Engine
 # acceleration via Apple Core ML. No separate package needed (unlike DirectML on Windows).
-onnxruntime==1.23.2
+onnxruntime==1.26.0
 
 numpy==2.4.4
 
@@ -10,11 +10,11 @@ numpy==2.4.4
 certifi
 
 # Computer Vision
-opencv-python==4.11.0.86
+opencv-python==4.13.0.92
 rawpy==0.27.0
 
 # Data Processing
-pandas==2.2.2
+pandas==3.0.3
 
 # Utilities
 PyExifTool==0.5.6

--- a/requirements-windows.txt
+++ b/requirements-windows.txt
@@ -11,18 +11,20 @@
 # in .github/workflows/main.yml.
 
 # Core ML/AI Dependencies
-# onnxruntime-directml has no 1.23.2 release; 1.23.0 is the nearest match to
-# the 1.23.2 pin used for macOS / local dev (same minor series).
+# onnxruntime-directml lags the upstream onnxruntime release cadence; 1.24.4
+# is the latest published Windows DirectML build. macOS / local dev pin
+# onnxruntime==1.26.0 (CPU + CoreML); the two packages share the same
+# `onnxruntime` module so only one can be installed at a time.
 onnxruntime-directml==1.24.4
 
 numpy==2.4.4
 
 # Computer Vision
-opencv-python==4.11.0.86
+opencv-python==4.13.0.92
 rawpy==0.27.0
 
 # Data Processing
-pandas==2.2.2
+pandas==3.0.3
 
 # Utilities
 PyExifTool==0.5.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,16 +1,16 @@
 # Core ML/AI Dependencies
 # Note: use onnxruntime-directml instead of onnxruntime to enable DirectML GPU
 # acceleration on Windows (any DX12-compatible GPU). They are mutually exclusive.
-onnxruntime==1.23.2
+onnxruntime==1.26.0
 
 numpy==2.4.4
 
 # Computer Vision
-opencv-python==4.11.0.86
+opencv-python==4.13.0.92
 rawpy==0.27.0
 
 # Data Processing
-pandas==2.2.2
+pandas==3.0.3
 
 # Utilities
 PyExifTool==0.5.6


### PR DESCRIPTION
## Summary

Bumps the three dependencies that had meaningful upstream releases available:

| Package | Before | After | Scope |
| --- | --- | --- | --- |
| `onnxruntime` | 1.23.2 | **1.26.0** | Linux + macOS |
| `opencv-python` | 4.11.0.86 | **4.13.0.92** | All platforms |
| `pandas` | 2.2.2 | **3.0.3** | All platforms (major version bump) |

Everything else in the requirements files (`numpy`, `rawpy`, `PyExifTool`, `requests`, `pywebview`, `pyinstaller`, `exifread`, `pillow`, `msvc-runtime`) is already pinned to the latest available release on PyPI, so there is nothing to bump there.

`onnxruntime-directml` stays at **1.24.4** — that is still the latest published Windows DirectML build, and it lags the upstream `onnxruntime` release cadence. The explanatory comment in `requirements-windows.txt` was stale (it still referenced the old 1.23.2 pin), so it has been refreshed to reflect the new state.

## Verification

Linux sandbox, full non-UI suite, run after each bump and again with all three applied:

```
pytest analyzer/tests/ -m "not ui"
→ 8 failed, 344 passed, 8 skipped, 2 deselected, 42 errors
```

The 8 failures and 42 errors are the **pre-existing baseline** in the sandbox — they are caused by the LFS-tracked ONNX model weights (`mdv5a.onnx`, `speciesNet_v4.0.1a.onnx`, `sam_hq_vit_tiny_*.onnx`, …) not being fetched in this environment. The exact same set of tests fail before any bump and after all three bumps, so none of the three upgrades introduce a regression in the Linux suite. The pandas-2 `FutureWarning` about silent downcasting on `.fillna` is also gone under pandas 3.0.3.

What this PR does **not** verify:

- **Windows PyInstaller bundle.** opencv-python often regresses on PyInstaller's bundled hooks (numpy DLL location moves, `cv2/data/*.xml` cascade files going missing, etc.). The Linux suite imports `cv2` but does not freeze it, so the Windows dev-build workflow is the real signal here.
- **macOS bundle.** Same caveat — `requirements-macos.txt` is bumped in lockstep, but the only thing that exercises it end-to-end is `build-macos-dev.yml`.
- **Integration tests against real ML models.** All ONNX-model-loading tests need the LFS weights, which neither this sandbox nor `dev-windows-build.yml`'s pre-build pytest step fetch in full. The frozen-binary `--validate` step in the dev-build workflow is what actually runs ML inference, so that is the gate to watch.

## Test plan

- [ ] Trigger `dev-windows-build.yml` on this branch and confirm:
  - [ ] `pip install -r requirements-windows.txt` resolves (onnxruntime-directml 1.24.4 + numpy 2.4.4 + the bumped opencv/pandas).
  - [ ] PyInstaller `ProjectKestrel.spec` builds without missing-hook errors for opencv-python 4.13.
  - [ ] Frozen `--validate` step passes (`ok=true` in `validate-result.json`).
  - [ ] Frozen UI probe step passes (`ok=true` in `ui-probe-result.json`).
- [ ] Optionally trigger `build-macos-dev.yml` for the same checks on macOS / `requirements-macos.txt`.
- [ ] If Windows build fails on opencv-python 4.13: drop that bump only, keep onnxruntime + pandas.

https://claude.ai/code/session_01HdvuH44282ifHooMnunuvW

---
_Generated by [Claude Code](https://claude.ai/code/session_01HdvuH44282ifHooMnunuvW)_