### PR TITLE
fix: unicode-safe Windows folder picker (#40) + correct CSP rationale (#39)

### DIFF
--- a/analyzer/api_bridge.py
+++ b/analyzer/api_bridge.py
@@ -72,6 +72,127 @@ except ImportError:
 
 HOST = '127.0.0.1'
 
+
+def _win_choose_directory(title: str) -> str:
+    """Open the Windows shell folder picker via ``SHBrowseForFolderW``.
+
+    Used by ``choose_directory`` on Windows so paths with non-ASCII
+    characters (CJK, Cyrillic, etc.) survive the round-trip back to Python.
+    Returns an empty string when the user cancels. Caller handles fallback
+    if this raises (e.g. on a non-Windows interpreter).
+    """
+    import ctypes
+    from ctypes import wintypes
+
+    BIF_RETURNONLYFSDIRS = 0x0001
+    BIF_NEWDIALOGSTYLE = 0x0040
+    BIF_USENEWUI = BIF_NEWDIALOGSTYLE | 0x0010
+
+    class BROWSEINFOW(ctypes.Structure):
+        _fields_ = [
+            ('hwndOwner', wintypes.HWND),
+            ('pidlRoot', ctypes.c_void_p),
+            ('pszDisplayName', wintypes.LPWSTR),
+            ('lpszTitle', wintypes.LPCWSTR),
+            ('ulFlags', wintypes.UINT),
+            ('lpfn', ctypes.c_void_p),
+            ('lParam', wintypes.LPARAM),
+            ('iImage', ctypes.c_int),
+        ]
+
+    shell32 = ctypes.windll.shell32
+    ole32 = ctypes.windll.ole32
+
+    # MAX_PATH is 260 but the modern dialog can return longer paths; oversize.
+    buf = ctypes.create_unicode_buffer(1024)
+    bi = BROWSEINFOW()
+    bi.hwndOwner = None
+    bi.pidlRoot = None
+    bi.pszDisplayName = ctypes.cast(buf, wintypes.LPWSTR)
+    bi.lpszTitle = title
+    bi.ulFlags = BIF_RETURNONLYFSDIRS | BIF_USENEWUI
+
+    # COM init is required by the new-style folder dialog.
+    ole32.CoInitialize(None)
+    try:
+        pidl = shell32.SHBrowseForFolderW(ctypes.byref(bi))
+        if not pidl:
+            return ''
+        path_buf = ctypes.create_unicode_buffer(1024)
+        try:
+            if not shell32.SHGetPathFromIDListW(pidl, path_buf):
+                return ''
+            return path_buf.value or ''
+        finally:
+            ole32.CoTaskMemFree(pidl)
+    finally:
+        ole32.CoUninitialize()
+
+
+def _win_choose_open_file(title: str, filters=(('All Files', '*.*'),)) -> str:
+    """Open the Windows shell file-open dialog via ``GetOpenFileNameW``.
+
+    Same Unicode rationale as ``_win_choose_directory``. ``filters`` is a
+    sequence of ``(label, pattern)`` tuples.
+    """
+    import ctypes
+    from ctypes import wintypes
+
+    OFN_EXPLORER = 0x00080000
+    OFN_FILEMUSTEXIST = 0x00001000
+    OFN_PATHMUSTEXIST = 0x00000800
+    OFN_HIDEREADONLY = 0x00000004
+    OFN_NOCHANGEDIR = 0x00000008
+
+    class OPENFILENAMEW(ctypes.Structure):
+        _fields_ = [
+            ('lStructSize', wintypes.DWORD),
+            ('hwndOwner', wintypes.HWND),
+            ('hInstance', wintypes.HINSTANCE),
+            ('lpstrFilter', wintypes.LPCWSTR),
+            ('lpstrCustomFilter', wintypes.LPWSTR),
+            ('nMaxCustFilter', wintypes.DWORD),
+            ('nFilterIndex', wintypes.DWORD),
+            ('lpstrFile', wintypes.LPWSTR),
+            ('nMaxFile', wintypes.DWORD),
+            ('lpstrFileTitle', wintypes.LPWSTR),
+            ('nMaxFileTitle', wintypes.DWORD),
+            ('lpstrInitialDir', wintypes.LPCWSTR),
+            ('lpstrTitle', wintypes.LPCWSTR),
+            ('Flags', wintypes.DWORD),
+            ('nFileOffset', wintypes.WORD),
+            ('nFileExtension', wintypes.WORD),
+            ('lpstrDefExt', wintypes.LPCWSTR),
+            ('lCustData', wintypes.LPARAM),
+            ('lpfnHook', ctypes.c_void_p),
+            ('lpTemplateName', wintypes.LPCWSTR),
+            ('pvReserved', ctypes.c_void_p),
+            ('dwReserved', wintypes.DWORD),
+            ('FlagsEx', wintypes.DWORD),
+        ]
+
+    # Filter string is double-NUL terminated, with each entry as label\0pattern\0.
+    filter_parts = []
+    for label, pattern in filters:
+        filter_parts.append(f'{label} ({pattern})')
+        filter_parts.append(pattern)
+    filter_str = '\0'.join(filter_parts) + '\0\0'
+
+    path_buf = ctypes.create_unicode_buffer(1024)
+    ofn = OPENFILENAMEW()
+    ofn.lStructSize = ctypes.sizeof(OPENFILENAMEW)
+    ofn.lpstrFilter = filter_str
+    ofn.lpstrFile = ctypes.cast(path_buf, wintypes.LPWSTR)
+    ofn.nMaxFile = 1024
+    ofn.lpstrTitle = title
+    ofn.Flags = OFN_EXPLORER | OFN_FILEMUSTEXIST | OFN_PATHMUSTEXIST | OFN_HIDEREADONLY | OFN_NOCHANGEDIR
+
+    comdlg32 = ctypes.windll.comdlg32
+    if not comdlg32.GetOpenFileNameW(ctypes.byref(ofn)):
+        return ''
+    return path_buf.value or ''
+
+
 _ALLOWED_ROOT = os.environ.get('KESTREL_ALLOWED_ROOT')
 if _ALLOWED_ROOT:
     _ALLOWED_ROOT = os.path.abspath(os.path.expanduser(_ALLOWED_ROOT))
@@ -554,30 +675,52 @@ class Api:
         Returns: absolute path to selected folder, or None if cancelled.
         """
         try:
-            if sys.platform == 'darwin':
-                script = 'POSIX path of (choose folder with prompt "Select folder containing analyzed photos")'
-                result = subprocess.run(
-                    ['osascript', '-e', script],
-                    capture_output=True,
-                    text=True,
-                    timeout=120
-                )
-                folder = result.stdout.strip() if result.returncode == 0 else ''
-            else:
-                # tkinter filedialog works on both Windows and Linux
-                import tkinter as tk
-                from tkinter import filedialog
-                root = tk.Tk()
-                root.withdraw()
-                root.attributes('-topmost', True)
-                folder = filedialog.askdirectory(title="Select folder containing analyzed photos")
-                root.destroy()
-
+            folder = self._open_native_folder_dialog()
             info(f'[API] choose_directory -> {folder!r}' if folder else '[API] choose_directory -> cancelled')
             return folder or None
         except Exception as e:
             error(f'[API] choose_directory error: {e}')
             return None
+
+    def _open_native_folder_dialog(self) -> str:
+        """Open a native folder picker and return the selected path (or '').
+
+        On Windows we call ``SHBrowseForFolderW`` directly via ctypes instead
+        of ``tkinter.filedialog.askdirectory``. Tk's wrapper round-trips the
+        selected path through interpreters that, under non-UTF-8 system code
+        pages (e.g. CJK locales), can collapse non-ASCII characters to
+        replacement chars before the string returns to Python. The W-suffixed
+        shell entry point is fully Unicode (UTF-16) and round-trips Chinese,
+        Japanese, etc. correctly — see issue #40, where a path like
+        ``C:\\Picture\\... 猫头鹰\\116ND810`` was reaching ``os.path.isdir``
+        as mojibake and silently failing folder-tree population.
+        """
+        if sys.platform.startswith('win'):
+            try:
+                return _win_choose_directory('Select folder containing analyzed photos') or ''
+            except Exception as e:
+                warn(f'[API] SHBrowseForFolderW failed, falling back to tkinter: {e}')
+
+        if sys.platform == 'darwin':
+            script = 'POSIX path of (choose folder with prompt "Select folder containing analyzed photos")'
+            result = subprocess.run(
+                ['osascript', '-e', script],
+                capture_output=True,
+                text=True,
+                timeout=120,
+            )
+            return result.stdout.strip() if result.returncode == 0 else ''
+
+        # Linux / fallback. tkinter on X11 handles Unicode via Tk 8.6+.
+        import tkinter as tk
+        from tkinter import filedialog
+        root = tk.Tk()
+        root.withdraw()
+        root.attributes('-topmost', True)
+        try:
+            return filedialog.askdirectory(title='Select folder containing analyzed photos') or ''
+        finally:
+            root.destroy()
 
     def open_file_explorer(self, folder_path):
         """Open a folder in the native file explorer."""
@@ -606,6 +749,19 @@ class Api:
         Returns: absolute path to selected file, or None if cancelled.
         """
         try:
+            # Issue #40: on Windows we call the Unicode shell file-open dialog
+            # directly via ctypes (``GetOpenFileNameW``) instead of tkinter so
+            # paths like ``C:\\用户\\...\\app.exe`` round-trip without mojibake.
+            if sys.platform.startswith('win'):
+                try:
+                    picked = _win_choose_open_file(
+                        title='Select application executable',
+                        filters=(('Executables', '*.exe'), ('All Files', '*.*')),
+                    )
+                    return picked or None
+                except Exception as e:
+                    warn(f'[API] GetOpenFileNameW failed, falling back to tkinter: {e}')
+
             if sys.platform == 'darwin':
                 import subprocess as _sp
                 script = 'POSIX path of (choose file of type {"app","APPL"} with prompt "Select an application")'
@@ -613,22 +769,20 @@ class Api:
                 if result.returncode == 0 and result.stdout.strip():
                     return result.stdout.strip()
                 return None
-            else:
-                import tkinter as tk
-                from tkinter import filedialog
-                root = tk.Tk()
-                root.withdraw()
-                root.attributes('-topmost', True)
-                if sys.platform.startswith('win'):
-                    filetypes = [('Executables', '*.exe'), ('All Files', '*.*')]
-                else:
-                    filetypes = [('All Files', '*.*')]
+
+            import tkinter as tk
+            from tkinter import filedialog
+            root = tk.Tk()
+            root.withdraw()
+            root.attributes('-topmost', True)
+            try:
                 filepath = filedialog.askopenfilename(
-                    title="Select application executable",
-                    filetypes=filetypes
+                    title='Select application executable',
+                    filetypes=[('All Files', '*.*')],
                 )
+            finally:
                 root.destroy()
-                return filepath if filepath else None
+            return filepath if filepath else None
         except Exception as e:
             error(f'[API] choose_application error: {e}')
             return None

--- a/analyzer/culling.html
+++ b/analyzer/culling.html
@@ -6,9 +6,10 @@
   <!-- Defense-in-depth CSP: matches the HTTP header set by visualizer.py's
        Handler.end_headers(). See FINDING-01 for the full rationale.
        'unsafe-eval' is required because pywebview 6.1's JS bridge generates
-       window.pywebview.api stubs with `new Function(...)`; without it the API
-       never materialises on macOS WKWebView (Windows WebView2 bypasses page
-       CSP for ExecuteScriptAsync, which masked the issue there). -->
+       window.pywebview.api stubs with `new Function(...)`; without it the
+       API never materialises and every button that calls into Python
+       silently no-ops. Affects both macOS WKWebView and recent Windows
+       Edge WebView2 runtimes (issue #39). -->
   <meta http-equiv="Content-Security-Policy"
         content="default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; media-src 'self' blob:; connect-src 'self' blob:; font-src 'self' data:; object-src 'none'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'" />
   <title>Culling Assistant — Project Kestrel</title>

--- a/analyzer/visualizer.html
+++ b/analyzer/visualizer.html
@@ -7,9 +7,10 @@
   <!-- Defense-in-depth CSP: matches the HTTP header set by visualizer.py's
        Handler.end_headers(). See FINDING-01 for the full rationale.
        'unsafe-eval' is required because pywebview 6.1's JS bridge generates
-       window.pywebview.api stubs with `new Function(...)`; without it the API
-       never materialises on macOS WKWebView (Windows WebView2 bypasses page
-       CSP for ExecuteScriptAsync, which masked the issue there). -->
+       window.pywebview.api stubs with `new Function(...)`; without it the
+       API never materialises and every button that calls into Python
+       silently no-ops. Affects both macOS WKWebView and recent Windows
+       Edge WebView2 runtimes (issue #39). -->
   <meta http-equiv="Content-Security-Policy"
         content="default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; media-src 'self' blob:; connect-src 'self' blob:; font-src 'self' data:; object-src 'none'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'" />
   <title>Project Kestrel</title>

--- a/analyzer/visualizer.py
+++ b/analyzer/visualizer.py
@@ -411,12 +411,16 @@ class Handler(SimpleHTTPRequestHandler):
         # ``window.pywebview.api.<method>`` stub with ``new Function(params,
         # body)``, which CSP treats as ``eval``. Without ``'unsafe-eval'``
         # the stubs are never created and ``window.pywebview.api`` ends up
-        # empty. Windows WebView2's ``ExecuteScriptAsync`` runs in a
-        # privileged context that bypasses page CSP, so the bug only
-        # manifests on macOS (WKWebView's ``evaluateJavaScript:`` enforces
-        # page CSP). Allowing ``'unsafe-eval'`` is required to keep the
-        # desktop bridge working on macOS until pywebview drops the
-        # dynamic-Function pattern. The CSP scope is otherwise the same.
+        # empty — buttons that route through the bridge silently no-op and
+        # the version badge stays on its ``Version: —`` placeholder.
+        # Originally believed to be macOS-only (WKWebView enforces page CSP
+        # on ``evaluateJavaScript:``) because older Edge WebView2 builds
+        # ran ``ExecuteScriptAsync`` in a privileged isolated world that
+        # bypassed page CSP. Issue #39 disproves that on Windows 10 with a
+        # recent WebView2 runtime: the same dead-bridge symptoms appear
+        # there too. Allowing ``'unsafe-eval'`` is required on every
+        # platform until pywebview drops the dynamic-Function pattern. The
+        # CSP scope is otherwise the same.
         self.send_header(
             'Content-Security-Policy',
             "default-src 'self'; "


### PR DESCRIPTION
## Summary

Closes #40, closes #39.

### #40 — folder/file pickers mangle CJK paths on Windows

`tkinter.filedialog.askdirectory` (and `askopenfilename`) on Windows downconverts
the selected path through the system ANSI codepage on non-UTF-8 locales, so a
folder like `C:\Picture\... 猫头鹰\116ND810` came back as mojibake and was then
rejected by `os.path.isdir`, leaving the folder tree empty with no error.

Fix: call the W-suffixed shell entry points directly via `ctypes`
(`SHBrowseForFolderW` for `choose_directory`, `GetOpenFileNameW` for
`choose_application`). These are fully Unicode (UTF-16) and round-trip CJK,
Cyrillic, etc. correctly.

Constraints honored:
- No new dependency (ctypes is stdlib).
- **No `pywebview.window.create_file_dialog`** — that API has known macOS
  issues. The JS bridge surface stays exactly the same; only the inside of
  the existing `Api.choose_directory` / `Api.choose_application` methods
  changes.
- macOS keeps using `osascript`; Linux / headless keeps tkinter (which is
  fine on X11 with Tk 8.6+).

### #39 — buttons dead / "Version: —" on Gambels-Quail (Windows 10)

Root cause was the strict CSP introduced in `506dfb8` (which made it into
Gambels-Quail) without `'unsafe-eval'`. pywebview 6.1's bridge generates each
`window.pywebview.api.<method>` stub with `new Function(params, body)`, which
CSP treats as `eval` — so the stubs never materialize and the entire API is
unreachable. Symptoms match the user report exactly: hover/CSS still works,
buttons silently no-op, version badge stays on its `Version: —` default.

The actual fix (adding `'unsafe-eval'`) is already on `dev` from `3e1f279`,
so this PR doesn't re-fix the CSP. What it does is **correct the rationale
comments** in `visualizer.py` / `visualizer.html` / `culling.html`, which
claimed Windows wasn't affected (because old WebView2 `ExecuteScriptAsync`
ran in a privileged context that bypassed page CSP). Issue #39's Windows 10
report shows recent WebView2 runtimes now enforce page CSP for injected
scripts too — the fix is required on every platform until pywebview drops
the dynamic-Function pattern.

User-impact note: once this lands and is released, the bug goes away. Users
currently stuck on Gambels-Quail can downgrade to Willow-Ptarmigan-F1 in the
meantime (which is what the reporter did).

## Test plan

- [x] `analyzer/tests/test_security_visualizer_js_xss.py` still passes (CSP
      doesn't affect the static XSS lints).
- [x] `python3 -c "ast.parse(open('api_bridge.py').read())"` — syntax OK.
- [x] Smoke-imported `api_bridge` with stubs; both new ctypes helpers and
      both modified `Api` methods resolve.
- [ ] Manual on Windows 10 with a Chinese folder name: pick
      `C:\…\猫头鹰\116ND810`, confirm it appears in the folder tree and
      `inspect_folder` returns a populated dict.
- [ ] Manual on Windows: pick a folder under an ASCII path, confirm no
      regression.
- [ ] Manual on macOS: confirm `osascript` path still works (no
      `create_file_dialog` codepath was added on macOS).
- [ ] Manual on Linux dev box: confirm tkinter fallback still works.
- [ ] Existing `tests/ui/test_pywebview_api.py` `--api-probe` test should
      keep passing on macOS/Windows CI (verifies the `unsafe-eval` CSP fix
      keeps the bridge alive).

---
_Generated by [Claude Code](https://claude.ai/code/session_01L38nhFzPfmmymEBiZieP68)_