### PR TITLE
feat(formats): extend RAW support to 11 new camera formats + fix RAF/X3F EXIF

### DIFF
--- a/analyzer/kestrel_analyzer/config.py
+++ b/analyzer/kestrel_analyzer/config.py
@@ -40,12 +40,11 @@ WILDLIFE_CATEGORIES = [
 # automatically enables it for pipeline discovery, folder inspection, RAW
 # preview routing, and editor-launch allowlisting.
 #
-# Caveat: .raf (Fujifilm) and .x3f (Sigma) decode via rawpy but lack capture-time
-# extraction in raw_exif.py. Scene grouping for these formats falls back to
-# AKAZE feature similarity (no timestamp shortcut). See raw_exif.UNSUPPORTED_EXTENSIONS.
+# Every extension below has both rawpy/LibRaw decode support and an in-house
+# capture-time extractor in raw_exif.py — no exiftool dependency.
 RAW_EXTENSIONS = [
     ".cr2", ".cr3",         # Canon
-    ".nef",                 # Nikon
+    ".nef", ".nrw",         # Nikon (DSLR/Z + Coolpix)
     ".arw", ".srw",         # Sony / Samsung NX
     ".dng",                 # Adobe / generic
     ".orf",                 # Olympus
@@ -54,6 +53,14 @@ RAW_EXTENSIONS = [
     ".sr2",                 # Sony (older)
     ".raf",                 # Fujifilm
     ".x3f",                 # Sigma
+    ".3fr", ".fff",         # Hasselblad
+    ".iiq",                 # Phase One
+    ".mos",                 # Leaf
+    ".rwl",                 # Leica
+    ".erf",                 # Epson
+    ".dcr", ".kdc",         # Kodak (DCS / EasyShare)
+    ".mef",                 # Mamiya
+    ".mrw",                 # Minolta / Konica Minolta
 ]
 JPEG_EXTENSIONS = [".jpg", ".jpeg", ".png", '.tiff', '.tif']
 

--- a/analyzer/kestrel_analyzer/raw_exif.py
+++ b/analyzer/kestrel_analyzer/raw_exif.py
@@ -2,15 +2,16 @@
 Image capture time extractor.
 
 RAW formats (no dependencies required):
-  CR3 (Canon ISOBMFF), CR2, NEF, ARW, DNG, ORF, RW2, PEF, SR2
-  and any other TIFF-based RAW format.
+  CR3 (Canon ISOBMFF), CR2, NEF, NRW, ARW, DNG, ORF, RW2, PEF, SR2, SRW,
+  ERF (Epson), DCR/KDC (Kodak), MEF (Mamiya), 3FR/FFF (Hasselblad),
+  IIQ (Phase One), MOS (Leaf), RWL (Leica), MRW (Minolta),
+  RAF (Fujifilm), X3F (Sigma).
 
 JPEG/processed formats (requires Pillow):
   JPEG, PNG, TIFF
-
-Unsupported: RAF (Fujifilm), X3F (Sigma)
 """
 
+import re
 import struct
 from datetime import datetime
 from pathlib import Path
@@ -18,13 +19,81 @@ from pathlib import Path
 DATETIME_ORIGINAL_TAG = 0x9003
 DATETIME_TAG = 0x0132
 EXIF_IFD_TAG = 0x8769
+XMP_TAG = 0x02bc
 
 DATE_FORMAT = "%Y:%m:%d %H:%M:%S"
+
+# Accepted datetime serializations encountered in the wild.
+# - Standard EXIF: "2022:11:20 15:38:30"
+# - ISO 8601:      "2019-05-31T14:59:00" (Hasselblad FFF SubIFD, MOS XMP)
+# - ISO 8601 sp:   "2019-05-31 14:59:00"
+_DATETIME_FORMATS = (
+    "%Y:%m:%d %H:%M:%S",
+    "%Y-%m-%dT%H:%M:%S",
+    "%Y-%m-%d %H:%M:%S",
+)
 
 CANON_METADATA_UUID = bytes.fromhex('85c0b687820f11e08111f4ce462b6a48')
 
 PILLOW_EXTENSIONS = {'.jpg', '.jpeg', '.png', '.tif', '.tiff'}
-UNSUPPORTED_EXTENSIONS = {'.raf', '.x3f'}
+# All formats listed in config.RAW_EXTENSIONS now have in-house EXIF support.
+# Kept as an empty set for backward compatibility with callers that import it.
+UNSUPPORTED_EXTENSIONS: set[str] = set()
+
+
+def _parse_datetime(raw_str: str) -> datetime:
+    """Parse a capture-time string into a datetime.
+
+    Handles the standard EXIF form ("YYYY:MM:DD HH:MM:SS") plus ISO 8601
+    variants seen in Hasselblad FFF SubIFDs and XMP packets. Strips any
+    trailing 'Z', timezone offset (`+02:00`/`-05:00`), or sub-second
+    fraction (`.67`) before parsing.
+
+    Raises ValueError if no format matches.
+    """
+    s = raw_str.strip().rstrip('\x00').strip()
+    if not s:
+        raise ValueError("empty datetime string")
+
+    if s.endswith('Z'):
+        s = s[:-1]
+    # Trailing TZ offset: only consider +/- that appears AFTER the time
+    # portion (position 19+). Date separators '-' inside the first 10
+    # characters must not be stripped.
+    if len(s) > 19:
+        for marker in ('+', '-'):
+            idx = s.rfind(marker)
+            if idx >= 19:
+                s = s[:idx]
+                break
+    # Trailing fractional seconds
+    if len(s) > 19 and s[19] == '.':
+        s = s[:19]
+    s = s.strip()
+
+    for fmt in _DATETIME_FORMATS:
+        try:
+            return datetime.strptime(s, fmt)
+        except ValueError:
+            continue
+    raise ValueError(f"Unrecognised datetime format: {raw_str!r}")
+
+
+# XMP-embedded date markers — used as a last resort when a TIFF has no
+# DateTime tag but does have an XMP packet (tag 0x02bc). Common in Leaf MOS.
+_XMP_DATE_PATTERNS = (
+    re.compile(rb'<exif:DateTimeOriginal>([^<]+)</exif:DateTimeOriginal>'),
+    re.compile(rb'<xmp:CreateDate>([^<]+)</xmp:CreateDate>'),
+    re.compile(rb'<photoshop:DateCreated>([^<]+)</photoshop:DateCreated>'),
+)
+
+
+def _extract_xmp_datetime(xmp_bytes: bytes) -> str | None:
+    for pat in _XMP_DATE_PATTERNS:
+        m = pat.search(xmp_bytes)
+        if m:
+            return m.group(1).decode('ascii', errors='ignore').strip()
+    return None
 
 
 # ---------------------------------------------------------------------------
@@ -85,6 +154,8 @@ def _walk_ifd(f, endian: str, offset: int, tiff_start: int, _depth: int = 0) -> 
 
     exif_ifd_offset = None
     datetime_fallback = None
+    xmp_offset = None
+    xmp_count = 0
 
     for _ in range(num_entries):
         entry = f.read(12)
@@ -107,6 +178,13 @@ def _walk_ifd(f, endian: str, offset: int, tiff_start: int, _depth: int = 0) -> 
         elif tag == EXIF_IFD_TAG:
             exif_ifd_offset = tiff_start + struct.unpack(endian + 'I', raw_value)[0]
 
+        elif tag == XMP_TAG and count > 16:
+            # XMP packet — record it as a last-resort fallback. Stored as
+            # bytes (type 1) or undefined (type 7); count bytes live at the
+            # offset stored in raw_value.
+            xmp_offset = tiff_start + struct.unpack(endian + 'I', raw_value)[0]
+            xmp_count = count
+
     if exif_ifd_offset:
         pos = f.tell()
         result = _walk_ifd(f, endian, exif_ifd_offset, tiff_start, _depth + 1)
@@ -114,7 +192,23 @@ def _walk_ifd(f, endian: str, offset: int, tiff_start: int, _depth: int = 0) -> 
         if result:
             return result
 
-    return datetime_fallback
+    if datetime_fallback:
+        return datetime_fallback
+
+    # Last resort: read XMP packet and pull a date from it (e.g. Leaf MOS,
+    # which has no DateTime IFD entry at all).
+    if xmp_offset and xmp_count:
+        pos = f.tell()
+        try:
+            f.seek(xmp_offset)
+            xmp_bytes = f.read(min(xmp_count, 1024 * 1024))
+            xmp_val = _extract_xmp_datetime(xmp_bytes)
+            if xmp_val:
+                return xmp_val
+        finally:
+            f.seek(pos)
+
+    return None
 
 
 def _read_ascii(f, endian: str, type_: int, count: int, raw_value: bytes, tiff_start: int) -> str | None:
@@ -210,6 +304,170 @@ def _walk_canon_uuid(f, end: int) -> str | None:
 
 
 # ---------------------------------------------------------------------------
+# MRW parser (Minolta DiMAGE / Konica Minolta Dynax)
+# ---------------------------------------------------------------------------
+#
+# Container layout (offsets relative to file start):
+#   0x00  \x00MRM
+#   0x04  uint32 BE  outer-block payload length
+#   0x08+ sequence of sub-blocks: \x00<TAG> + uint32 BE length + payload
+#         The \x00TTW sub-block ("TIFF Tag Wrapper") wraps a complete TIFF
+#         stream — DateTime/DateTimeOriginal live there.
+
+def _read_mrw_exif(f) -> str | None:
+    f.seek(0)
+    header = f.read(8)
+    if len(header) < 8 or header[:4] != b'\x00MRM':
+        return None
+    outer_size = struct.unpack('>I', header[4:8])[0]
+
+    pos = 8
+    end = 8 + outer_size
+    while pos < end - 8:
+        f.seek(pos)
+        block = f.read(8)
+        if len(block) < 8:
+            break
+        tag = block[:4]
+        size = struct.unpack('>I', block[4:8])[0]
+        if tag == b'\x00TTW':
+            # File handle is now positioned at the start of the TTW payload,
+            # which is itself a complete TIFF stream.
+            return _read_tiff_exif(f)
+        pos += 8 + size
+    return None
+
+
+# ---------------------------------------------------------------------------
+# RAF parser (Fujifilm)
+# ---------------------------------------------------------------------------
+#
+# Container layout:
+#   0x00  "FUJIFILMCCD-RAW " (16 bytes)
+#   0x10  format version  (e.g. "0201")
+#   0x14  camera id
+#   0x1c  model (32 bytes, null-padded)
+#   0x3c  directory version
+#   0x54  uint32 BE  embedded-JPEG offset
+#   0x58  uint32 BE  embedded-JPEG size
+# The embedded JPEG is a regular JFIF with an APP1 EXIF marker — the EXIF
+# block's TIFF payload starts right after "Exif\x00\x00".
+
+def _read_raf_exif(f) -> str | None:
+    f.seek(0)
+    if f.read(16) != b'FUJIFILMCCD-RAW ':
+        return None
+    f.seek(0x54)
+    offs = f.read(8)
+    if len(offs) < 8:
+        return None
+    jpeg_offset = struct.unpack('>I', offs[:4])[0]
+    jpeg_size = struct.unpack('>I', offs[4:8])[0]
+    if jpeg_size <= 0 or jpeg_offset <= 0:
+        return None
+    return _read_exif_in_jpeg(f, jpeg_offset, jpeg_size)
+
+
+# ---------------------------------------------------------------------------
+# X3F parser (Sigma Foveon)
+# ---------------------------------------------------------------------------
+#
+# Container layout:
+#   0x00  "FOVb"
+#   ...   header + raw image data
+#   EOF-4 uint32 LE  directory offset
+#   @dir  "SECd" + uint32 LE version + uint32 LE n_entries +
+#         entries[N] of { uint32 offset, uint32 length, char[4] type }
+#
+# IMA2 entries are image sections (SECi header). image_type==18 marks the
+# embedded preview JPEG, which carries a standard EXIF APP1 segment.
+
+def _read_x3f_exif(f) -> str | None:
+    f.seek(0)
+    if f.read(4) != b'FOVb':
+        return None
+
+    f.seek(0, 2)
+    file_size = f.tell()
+    if file_size < 32:
+        return None
+
+    f.seek(file_size - 4)
+    dir_offset = struct.unpack('<I', f.read(4))[0]
+    if not (0 < dir_offset < file_size - 12):
+        return None
+
+    f.seek(dir_offset)
+    if f.read(4) != b'SECd':
+        return None
+    f.read(4)  # version
+    n_entries = struct.unpack('<I', f.read(4))[0]
+    if n_entries > 64:
+        return None
+
+    entries = []
+    for _ in range(n_entries):
+        e = f.read(12)
+        if len(e) < 12:
+            break
+        offset = struct.unpack('<I', e[0:4])[0]
+        length = struct.unpack('<I', e[4:8])[0]
+        type_ = e[8:12]
+        entries.append((offset, length, type_))
+
+    for offset, length, type_ in entries:
+        if type_ != b'IMA2' or length < 32:
+            continue
+        if offset + length > file_size:
+            continue
+        f.seek(offset)
+        sec_head = f.read(28)
+        if len(sec_head) < 28 or sec_head[:4] != b'SECi':
+            continue
+        # SECi layout: magic(4) + version(4) + image_type(4) + image_format(4)
+        # + cols(4) + rows(4) + row_size(4). For embedded previews the format
+        # field is 18 (JPEG); the older thumb-type-only path also sets 11.
+        image_format = struct.unpack('<I', sec_head[12:16])[0]
+        if image_format not in (11, 18):
+            continue
+        # JPEG payload follows the 28-byte SECi header.
+        jpeg_offset = offset + 28
+        jpeg_size = length - 28
+        result = _read_exif_in_jpeg(f, jpeg_offset, jpeg_size)
+        if result:
+            return result
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Embedded-JPEG EXIF helper (used by RAF and X3F)
+# ---------------------------------------------------------------------------
+
+def _read_exif_in_jpeg(f, jpeg_offset: int, jpeg_size: int) -> str | None:
+    """Locate the APP1/EXIF marker inside an embedded JPEG and parse its
+    TIFF payload. Scans up to the first 64 KB of the JPEG (EXIF APP1 is
+    always near the front)."""
+    f.seek(jpeg_offset)
+    head = f.read(2)
+    if head != b'\xff\xd8':
+        return None
+
+    scan_limit = min(jpeg_size, 65536)
+    f.seek(jpeg_offset)
+    chunk = f.read(scan_limit)
+
+    # Find the first APP1 marker whose payload begins with "Exif\x00\x00".
+    idx = chunk.find(b'\xff\xe1', 2)
+    while idx >= 0:
+        # APP1 layout: FF E1 <len:2 BE> "Exif\x00\x00" <tiff...>
+        if idx + 10 <= len(chunk) and chunk[idx + 4:idx + 10] == b'Exif\x00\x00':
+            f.seek(jpeg_offset + idx + 10)
+            return _read_tiff_exif(f)
+        idx = chunk.find(b'\xff\xe1', idx + 2)
+    return None
+
+
+# ---------------------------------------------------------------------------
 # Format detection
 # ---------------------------------------------------------------------------
 
@@ -233,6 +491,21 @@ def _is_tiff_based(f) -> bool:
     return f.read(4) in TIFF_MAGICS
 
 
+def _is_raf(f) -> bool:
+    f.seek(0)
+    return f.read(16) == b'FUJIFILMCCD-RAW '
+
+
+def _is_x3f(f) -> bool:
+    f.seek(0)
+    return f.read(4) == b'FOVb'
+
+
+def _is_mrw(f) -> bool:
+    f.seek(0)
+    return f.read(4) == b'\x00MRM'
+
+
 # ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
@@ -242,7 +515,9 @@ def get_capture_time(filepath: str | Path) -> datetime:
     Extract the capture datetime from an image file.
 
     Supports:
-      - RAW: CR3, CR2, NEF, ARW, DNG, ORF, RW2, PEF, SR2 (no extra dependencies)
+      - RAW: CR3, CR2, NEF, NRW, ARW, SRW, DNG, ORF, RW2, PEF, SR2,
+             ERF, DCR, KDC, MEF, 3FR, FFF, IIQ, MOS, RWL, MRW, RAF, X3F
+             (no extra dependencies)
       - JPEG/PNG/TIFF: requires Pillow
 
     Returns a datetime object.
@@ -252,26 +527,27 @@ def get_capture_time(filepath: str | Path) -> datetime:
     filepath = Path(filepath)
     ext = filepath.suffix.lower()
 
-    if ext in UNSUPPORTED_EXTENSIONS:
-        raise ValueError(
-            f"{ext.upper()} ({filepath.name}) is not supported. "
-            "RAF (Fujifilm) and X3F (Sigma) are not implemented."
-        )
-
     if ext in PILLOW_EXTENSIONS:
         raw_str = _read_pillow_exif(filepath)
         if not raw_str:
             raise ValueError(f"No capture time found in {filepath.name}")
-        try:
-            return datetime.strptime(raw_str.strip(), DATE_FORMAT)
-        except ValueError:
-            raise ValueError(f"Unrecognised datetime format: {raw_str!r}")
+        return _parse_datetime(raw_str)
 
-    # RAW formats — native parser
+    # RAW formats — native parser. Magic-byte sniffing routes to the right
+    # container parser; the extension is only a hint.
     with open(filepath, 'rb') as f:
         if _is_cr3(f):
             f.seek(0)
             raw_str = _read_cr3_exif(f)
+        elif _is_raf(f):
+            f.seek(0)
+            raw_str = _read_raf_exif(f)
+        elif _is_x3f(f):
+            f.seek(0)
+            raw_str = _read_x3f_exif(f)
+        elif _is_mrw(f):
+            f.seek(0)
+            raw_str = _read_mrw_exif(f)
         elif _is_tiff_based(f):
             f.seek(0)
             raw_str = _read_tiff_exif(f)
@@ -292,10 +568,7 @@ def get_capture_time(filepath: str | Path) -> datetime:
     if not raw_str:
         raise ValueError(f"Could not extract capture time from {filepath.name}")
 
-    try:
-        return datetime.strptime(raw_str.strip(), DATE_FORMAT)
-    except ValueError:
-        raise ValueError(f"Unrecognised datetime format: {raw_str!r}")
+    return _parse_datetime(raw_str)
 
 
 # Convenience alias

--- a/analyzer/tests/conftest.py
+++ b/analyzer/tests/conftest.py
@@ -31,14 +31,37 @@ def set_a_path(fixtures_dir):
 
 @pytest.fixture
 def set_b_paths(fixtures_dir):
-    """Dict of {ext: path} for diverse RAW formats in set_b_formats/."""
+    """Dict of {ext: path} for diverse RAW formats in set_b_formats/.
+
+    Picks up any RAW sample that's actually checked in (or dropped in
+    locally for manual testing). Extensions that don't appear in
+    set_b_formats/ are silently skipped, so adding new format coverage
+    doesn't require a fixture commit."""
     test_sets_dir = fixtures_dir / "test_sets" / "set_b_formats"
     result = {}
+    extensions = [
+        ".cr2", ".cr3",
+        ".nef", ".nrw",
+        ".arw", ".srw",
+        ".dng",
+        ".orf", ".rw2", ".pef", ".sr2",
+        ".raf", ".x3f",
+        ".3fr", ".fff",
+        ".iiq", ".mos",
+        ".rwl", ".erf",
+        ".dcr", ".kdc",
+        ".mef", ".mrw",
+    ]
     if test_sets_dir.exists():
-        for ext in [".cr2", ".cr3", ".nef", ".arw", ".dng", ".orf", ".rw2", ".pef"]:
+        for ext in extensions:
             for file in test_sets_dir.glob(f"*{ext}"):
                 result[ext] = file
                 break
+            else:
+                # Case-insensitive: some samples ship with upper-case extensions
+                for file in test_sets_dir.glob(f"*{ext.upper()}"):
+                    result[ext] = file
+                    break
     return result
 
 

--- a/analyzer/tests/unit/test_raw_exif.py
+++ b/analyzer/tests/unit/test_raw_exif.py
@@ -1,0 +1,246 @@
+"""Unit tests for raw_exif container parsers.
+
+These tests build minimal synthetic byte structures for each container
+format so the parsers can be exercised without checking in 100+ MB of
+camera RAW samples. End-to-end coverage against real samples lives in
+the integration suite (test_exif_read.py + set_b_formats/ fixtures).
+"""
+
+import io
+import struct
+from datetime import datetime
+from pathlib import Path
+import sys
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from kestrel_analyzer import raw_exif
+
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# Helpers — synthetic byte assembly
+# ---------------------------------------------------------------------------
+
+def _build_tiff(datetime_original: bytes | None = None,
+                datetime_tag: bytes | None = None,
+                xmp_packet: bytes | None = None,
+                endian: str = '<') -> bytes:
+    """Build a minimal TIFF with optional DateTime/DateTimeOriginal/XMP."""
+    end = endian
+    out = io.BytesIO()
+    if end == '<':
+        out.write(b'II\x2a\x00')
+    else:
+        out.write(b'MM\x00\x2a')
+    out.write(struct.pack(end + 'I', 8))  # IFD0 at offset 8
+
+    entries = []  # (tag, type, count, value_bytes_or_offset_placeholder)
+    blobs = []   # extra payload to append after IFD0 + next-offset
+
+    def add_ascii_entry(tag, payload):
+        s = payload + b'\x00'  # NUL terminator
+        if len(s) <= 4:
+            entries.append((tag, 2, len(s), s.ljust(4, b'\x00')))
+        else:
+            entries.append((tag, 2, len(s), None))
+            blobs.append(s)
+
+    def add_xmp_entry(tag, payload):
+        if len(payload) <= 4:
+            entries.append((tag, 1, len(payload), payload.ljust(4, b'\x00')))
+        else:
+            entries.append((tag, 1, len(payload), None))
+            blobs.append(payload)
+
+    if datetime_original:
+        add_ascii_entry(raw_exif.DATETIME_ORIGINAL_TAG, datetime_original)
+    if datetime_tag:
+        add_ascii_entry(raw_exif.DATETIME_TAG, datetime_tag)
+    if xmp_packet:
+        add_xmp_entry(raw_exif.XMP_TAG, xmp_packet)
+
+    # Compute total IFD size: 2 bytes count + 12 bytes/entry + 4 bytes next-offset
+    ifd_size = 2 + 12 * len(entries) + 4
+    blob_offset_cursor = 8 + ifd_size
+
+    out.write(struct.pack(end + 'H', len(entries)))
+    blob_index = 0
+    for tag, type_, count, value in entries:
+        if value is None:
+            value_field = struct.pack(end + 'I', blob_offset_cursor)
+            blob_offset_cursor += len(blobs[blob_index])
+            blob_index += 1
+        else:
+            value_field = value
+        out.write(struct.pack(end + 'HHI', tag, type_, count) + value_field)
+    out.write(struct.pack(end + 'I', 0))  # no next IFD
+    for b in blobs:
+        out.write(b)
+    return out.getvalue()
+
+
+def _build_mrw(tiff_blob: bytes) -> bytes:
+    """Wrap a TIFF blob inside an MRW container with PRD + TTW sub-blocks."""
+    prd = b'\x00PRD' + struct.pack('>I', 8) + b'\x00' * 8
+    ttw = b'\x00TTW' + struct.pack('>I', len(tiff_blob)) + tiff_blob
+    payload = prd + ttw
+    return b'\x00MRM' + struct.pack('>I', len(payload)) + payload
+
+
+def _build_jpeg_with_exif(tiff_blob: bytes) -> bytes:
+    """Wrap a TIFF blob inside a minimal JPEG carrying an APP1 EXIF marker."""
+    app1_payload = b'Exif\x00\x00' + tiff_blob
+    # APP1 size includes the 2-byte size field itself but not the marker.
+    app1 = b'\xff\xe1' + struct.pack('>H', len(app1_payload) + 2) + app1_payload
+    return b'\xff\xd8' + app1 + b'\xff\xd9'
+
+
+def _build_raf(jpeg_blob: bytes) -> bytes:
+    """Build a minimal RAF container with an embedded JPEG."""
+    header = bytearray(0x80)
+    header[0:16] = b'FUJIFILMCCD-RAW '
+    header[16:20] = b'0201'
+    header[20:28] = b'TESTCAMA'
+    header[28:60] = b'TestModel'.ljust(32, b'\x00')
+    header[60:64] = b'0100'
+    jpeg_offset = len(header)
+    struct.pack_into('>I', header, 0x54, jpeg_offset)
+    struct.pack_into('>I', header, 0x58, len(jpeg_blob))
+    return bytes(header) + jpeg_blob
+
+
+def _build_x3f(jpeg_blob: bytes, image_format: int = 18, image_type: int = 2) -> bytes:
+    """Build a minimal X3F with one IMA2 section wrapping a JPEG preview.
+
+    SECi layout: magic(4) version(4) type(4) format(4) cols(4) rows(4) row_size(4).
+    The parser keys off `format` (18 = JPEG)."""
+    sec_i = (b'SECi' + struct.pack('<I', 0x20000)
+             + struct.pack('<I', image_type)
+             + struct.pack('<I', image_format)
+             + struct.pack('<I', 16) + struct.pack('<I', 16) + struct.pack('<I', 0))
+    ima2 = sec_i + jpeg_blob
+
+    file_header = b'FOVb' + b'\x00' * 40
+    image_offset = len(file_header)
+    image_length = len(ima2)
+    body = file_header + ima2
+
+    dir_offset = len(body)
+    sec_d = (b'SECd' + struct.pack('<I', 0x20000) + struct.pack('<I', 1)
+             + struct.pack('<I', image_offset) + struct.pack('<I', image_length) + b'IMA2')
+    return body + sec_d + struct.pack('<I', dir_offset)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestParseDatetime:
+    def test_standard_exif(self):
+        assert raw_exif._parse_datetime("2022:11:20 15:38:30") == datetime(2022, 11, 20, 15, 38, 30)
+
+    def test_iso8601_t(self):
+        assert raw_exif._parse_datetime("2019-05-31T14:59:00") == datetime(2019, 5, 31, 14, 59, 0)
+
+    def test_iso8601_trailing_z(self):
+        assert raw_exif._parse_datetime("2013-07-24T17:50:30Z") == datetime(2013, 7, 24, 17, 50, 30)
+
+    def test_iso8601_with_timezone(self):
+        assert raw_exif._parse_datetime("2022:11:20 15:38:30+02:00") == datetime(2022, 11, 20, 15, 38, 30)
+
+    def test_strip_subseconds(self):
+        assert raw_exif._parse_datetime("2023:06:02 18:53:25.67+02:00") == datetime(2023, 6, 2, 18, 53, 25)
+
+    def test_invalid_raises(self):
+        with pytest.raises(ValueError):
+            raw_exif._parse_datetime("not a date")
+
+
+class TestMrwParser:
+    def test_basic(self, tmp_path):
+        tiff = _build_tiff(datetime_original=b"2010:07:29 11:43:16")
+        mrw = _build_mrw(tiff)
+        path = tmp_path / "test.MRW"
+        path.write_bytes(mrw)
+        assert raw_exif.get_capture_time(path) == datetime(2010, 7, 29, 11, 43, 16)
+
+    def test_rejects_non_mrw(self, tmp_path):
+        path = tmp_path / "not-mrw.MRW"
+        path.write_bytes(b'NOPE' + b'\x00' * 100)
+        with pytest.raises((ValueError, Exception)):
+            raw_exif.get_capture_time(path)
+
+
+class TestRafParser:
+    def test_basic(self, tmp_path):
+        tiff = _build_tiff(datetime_original=b"2022:11:20 15:38:30")
+        jpeg = _build_jpeg_with_exif(tiff)
+        raf = _build_raf(jpeg)
+        path = tmp_path / "test.RAF"
+        path.write_bytes(raf)
+        assert raw_exif.get_capture_time(path) == datetime(2022, 11, 20, 15, 38, 30)
+
+    def test_rejects_non_raf(self, tmp_path):
+        path = tmp_path / "not-raf.RAF"
+        path.write_bytes(b'NOTAFUJIFILMHEADER')
+        with pytest.raises((ValueError, Exception)):
+            raw_exif.get_capture_time(path)
+
+
+class TestX3fParser:
+    def test_preview_jpeg(self, tmp_path):
+        tiff = _build_tiff(datetime_original=b"2018:04:09 11:49:15")
+        jpeg = _build_jpeg_with_exif(tiff)
+        x3f = _build_x3f(jpeg, image_format=18)
+        path = tmp_path / "test.X3F"
+        path.write_bytes(x3f)
+        assert raw_exif.get_capture_time(path) == datetime(2018, 4, 9, 11, 49, 15)
+
+    def test_thumb_jpeg(self, tmp_path):
+        tiff = _build_tiff(datetime_original=b"2017:01:02 03:04:05")
+        jpeg = _build_jpeg_with_exif(tiff)
+        x3f = _build_x3f(jpeg, image_format=11)
+        path = tmp_path / "test.X3F"
+        path.write_bytes(x3f)
+        assert raw_exif.get_capture_time(path) == datetime(2017, 1, 2, 3, 4, 5)
+
+
+class TestTiffXmpFallback:
+    def test_no_datetime_but_xmp_create_date(self, tmp_path):
+        """MOS-style: no DateTime entries, only an XMP packet."""
+        xmp = (b'<?xpacket begin?>'
+               b'<x:xmpmeta xmlns:xmp="http://ns.adobe.com/xap/1.0/">'
+               b'<rdf:Description>'
+               b'<xmp:CreateDate>2013-07-24T17:50:30Z</xmp:CreateDate>'
+               b'</rdf:Description>'
+               b'</x:xmpmeta>'
+               b'<?xpacket end?>')
+        tiff = _build_tiff(xmp_packet=xmp)
+        path = tmp_path / "test.MOS"
+        path.write_bytes(tiff)
+        assert raw_exif.get_capture_time(path) == datetime(2013, 7, 24, 17, 50, 30)
+
+
+class TestIso8601InSubIfd:
+    """FFF-style: DateTimeOriginal lives in EXIF SubIFD as ISO 8601."""
+
+    def test_iso8601_in_ifd(self, tmp_path):
+        tiff = _build_tiff(datetime_original=b"2019-05-31T14:59:00")
+        path = tmp_path / "test.FFF"
+        path.write_bytes(tiff)
+        assert raw_exif.get_capture_time(path) == datetime(2019, 5, 31, 14, 59, 0)
+
+
+class TestUnsupportedExtensionsCleared:
+    """Ensure RAF/X3F are no longer in the unsupported set."""
+
+    def test_raf_not_unsupported(self):
+        assert '.raf' not in raw_exif.UNSUPPORTED_EXTENSIONS
+
+    def test_x3f_not_unsupported(self):
+        assert '.x3f' not in raw_exif.UNSUPPORTED_EXTENSIONS


### PR DESCRIPTION
## Summary

Extends ProjectKestrel's `RAW_EXTENSIONS` from 12 to 23 formats, with full in-house EXIF capture-time support — no exiftool dependency. Every new format was validated against real samples from [raw.pixls.us](https://raw.pixls.us/) and [rawsamples.ch](https://rawsamples.ch/) using both baseline tests:

1. **RAW DECODE** via `rawpy.imread().postprocess()` (LibRaw 0.22.1)
2. **EXIF timestamp extraction** via `raw_exif.get_capture_time()`

## Test matrix

| Ext | Camera | Sample URL | DECODE | EXIF | Extracted timestamp |
|---|---|---|---|---|---|
| `.nrw` | Nikon Coolpix P1000 | [DSCN1113.NRW](https://raw.pixls.us/data/Nikon/COOLPIX%20P1000/DSCN1113.NRW) | ✅ | ✅ | 2019-07-07 05:25:06 |
| `.nef` | Nikon Z9 (14-bit lossless) | [Nikon_Z_9_Lossless.NEF](https://raw.pixls.us/data/Nikon/Z%209/Nikon_-_NIKON_Z_9_-_14bit_compressed_%28Lossless%29.NEF) | ✅ | ✅ | 2022-02-05 13:45:03 |
| `.nef` | Nikon Z8 (HE compression) | [Z8_high_efficiency_low.NEF](https://raw.pixls.us/data/Nikon/Z%208/Nikon_Z8_high_efficiency_low.NEF) | ❌ DECODE FAIL¹ | ✅ | 2023-06-02 18:53:25 |
| `.nef` | Nikon Z9 (HE compression) | [Z_9_Lossy_High_Efficiency.NEF](https://raw.pixls.us/data/Nikon/Z%209/Nikon_-_NIKON_Z_9_-_14bit_compressed_%28Lossy_High_Efficiency%29.NEF) | ❌ DECODE FAIL¹ | ✅ | 2022-02-05 13:48:11 |
| `.raf` | Fujifilm X-T5 | [DSCF0021.RAF](https://raw.pixls.us/data/Fujifilm/X-T5/DSCF0021.RAF) | ✅ | ✅ (new) | 2022-11-20 15:38:30 |
| `.x3f` | Sigma sd Quattro H | [SDIM0061.X3F](https://raw.pixls.us/data/Sigma/sd%20Quattro%20H/SDIM0061.X3F) | ✅ | ✅ (new) | 2018-04-09 11:49:15 |
| `.3fr` | Hasselblad X1D II 50C | [MKW_20200429_0004569.3FR](https://raw.pixls.us/data/Hasselblad/X1D%20II%2050C/MKW_20200429_0004569.3FR) | ✅ | ✅ | 2020-04-29 20:09:17 |
| `.fff` | Hasselblad X1D II 50C | [x1d-II-sample-02.fff](https://raw.pixls.us/data/Hasselblad/X1D%20II%2050C/x1d-II-sample-02.fff) | ✅ | ✅ | 2019-05-31 14:59:00 |
| `.iiq` | Phase One IQ3 100MP | [Phase_One_IQ3_100MP_IIQ_L.IIQ](https://raw.pixls.us/data/Phase%20One/IQ3%20100MP/Phase_One_IQ3_100MP_IIQ_L.IIQ) | ✅ | ✅ | 2018-04-29 10:30:33 |
| `.mos` | Leaf Aptus 75 | [RAW_APTUS_75.MOS](https://raw.pixls.us/data/Leaf/Aptus%2075/RAW_APTUS_75.MOS) | ✅ | ✅ | 2013-07-24 17:50:30 |
| `.rwl` | Leica D-Lux 7 | [L1023208.RWL](https://raw.pixls.us/data/Leica/D-Lux%207/L1023208.RWL) | ✅ | ✅ | 2020-12-08 15:23:00 |
| `.erf` | Epson R-D1 | [RAW_EPSON_RD1.ERF](http://www.rawsamples.ch/raws/epson/rd1/RAW_EPSON_RD1.ERF) | ✅ | ✅ | 2007-08-06 13:33:27 |
| `.dcr` | Kodak DCS Pro 14nx | [D7465857.DCR](https://raw.pixls.us/data/Kodak/DCS%20Pro%2014nx/D7465857.DCR) | ✅ | ✅ | 2009-06-22 18:16:37 |
| `.kdc` | Kodak EasyShare Z981 | [100_1548.KDC](https://raw.pixls.us/data/Kodak/EasyShare%20Z981/100_1548.KDC) | ✅ | ✅ | 2019-10-13 13:35:46 |
| `.mef` | Mamiya ZD | [RAW_MAMIYA_ZD.MEF](https://raw.pixls.us/data/Mamiya/ZD/RAW_MAMIYA_ZD.MEF) | ✅ | ✅ | 2007-04-09 08:24:12 |
| `.mrw` | Minolta Dynax 7D | [PICT3410.MRW](https://raw.pixls.us/data/Minolta/Dynax%207D/PICT3410.MRW) | ✅ | ✅ | 2010-07-29 11:43:16 |
| `.srw` | Samsung NX1 (was already in config) | [2016-07-23-142101_sam_9364.srw](https://raw.pixls.us/data/Samsung/NX1/2016-07-23-142101_sam_9364.srw) | ✅ | ✅ | 2016-07-23 14:21:01 |

**Result**: EXIF 17/17 pass, DECODE 15/17 pass.

¹ The two HE NEFs fail decode because Nikon's "High Efficiency" / HE* compression (introduced with the Z8/Z9) requires a codec LibRaw 0.22.1 doesn't ship with by default. This is a LibRaw limitation, not a regression. The EXIF still extracts correctly through the generic TIFF path, so files are categorised but not analysed.

## Implementation details

### `analyzer/kestrel_analyzer/config.py`
Added 11 new extensions to `RAW_EXTENSIONS`. Single source of truth — pipeline discovery, folder inspection, editor allowlisting, and validation all pick them up automatically.

### `analyzer/kestrel_analyzer/raw_exif.py`
New container parsers, all using the existing TIFF walker as the final stage:

- **MRW** (`_read_mrw_exif`): walks `\x00MRM` block stream, recurses into `\x00TTW` which wraps a full TIFF.
- **RAF** (`_read_raf_exif`): reads embedded-JPEG offset/size at file offsets `0x54`/`0x58`, parses the APP1 EXIF payload.
- **X3F** (`_read_x3f_exif`): walks the `SECd` directory at EOF, finds an `IMA2` section with `image_format==18` (JPEG preview), parses its APP1 EXIF.
- **MOS** XMP fallback: extended `_walk_ifd` to capture tag `0x02bc` (XMP packet) and regex out `xmp:CreateDate` / `exif:DateTimeOriginal` / `photoshop:DateCreated`. Only used when no IFD DateTime tag is present.

Datetime parsing is now lenient — `_parse_datetime` handles the standard EXIF form, ISO 8601 with `T` or space separator, optional trailing `Z`, optional `+02:00`/`-05:00` timezone, and optional `.fff` subseconds. This fixes Hasselblad FFF (ISO 8601 in EXIF SubIFD), Leaf MOS XMP, and Nikon Z subsecond datetimes.

`UNSUPPORTED_EXTENSIONS` is now empty (RAF + X3F removed) but kept as a public symbol for backward compatibility with any importers.

### `analyzer/tests/unit/test_raw_exif.py` (new)
16 unit tests covering each container parser with synthetic minimal-byte fixtures — no large binary samples needed in CI. Builds tiny TIFF blobs in-memory and wraps them in MRW/RAF/X3F containers.

### `analyzer/tests/conftest.py`
`set_b_paths` fixture now picks up any of the 23 supported extensions if present in `tests/fixtures/test_sets/set_b_formats/`. Existing extensions still resolved; new ones are picked up automatically when fixtures are dropped in.

## Test plan

- [x] `pytest analyzer/tests/unit/test_raw_exif.py` — 16/16 pass
- [x] `pytest analyzer/tests/integration/test_exif_read.py analyzer/tests/integration/test_raw_decode.py` — 21/21 pass (existing CR2/CR3 fixtures still green)
- [x] Manual run against 17 real RAW samples (table above) — EXIF 17/17 pass, decode 15/17 pass
- [x] Cross-validated extracted timestamps against `exiftool -DateTimeOriginal` for every sample

## Out of scope

- Bundling exiftool was explicitly off-limits per task brief.
- Nikon HE/HE* decode requires a LibRaw rebuild with the TicoRAW codec licensed by intoPIX — separate effort, tracked as a follow-up.

---
_Generated by [Claude Code](https://claude.ai/code/session_017MVUtu8k9cWXX1ReYThbTB)_