### PR TITLE
fix(ml): utf-8-sig label-file decode; pipeline: emit per-image traceback to runtime log

### DIFF
--- a/analyzer/kestrel_analyzer/ml/bird_species.py
+++ b/analyzer/kestrel_analyzer/ml/bird_species.py
@@ -17,7 +17,7 @@ class BirdSpeciesClassifier:
         coord: ProviderCoordinator,
         models_dir: str | None = None,
     ):
-        with open(labels_path, "r") as f:
+        with open(labels_path, "r", encoding="utf-8-sig") as f:
             self.labels = np.array([l.strip() for l in f.readlines()])
         # Registered with the coordinator so a DML/CoreML failure that demotes
         # the wrapper's sessions also rebuilds this one — otherwise every

--- a/analyzer/kestrel_analyzer/ml/speciesnet_sam_hq.py
+++ b/analyzer/kestrel_analyzer/ml/speciesnet_sam_hq.py
@@ -279,7 +279,7 @@ class OnnxClassifier:
     def __init__(self, onnx_path: Path, labels_path: Path, coord: ProviderCoordinator):
         self._session = ResilientOnnxSession("classifier", onnx_path, coord)
         self.providers_used = self._session.get_providers()
-        with open(labels_path) as f:
+        with open(labels_path, "r", encoding="utf-8-sig") as f:
             self._labels = [line.strip() for line in f]
         _active = self.providers_used[0] if self.providers_used else "unknown"
         debug(f"[OnnxClassifier] {len(self._labels)} labels  Active provider: {_active}  all providers: {self.providers_used}")

--- a/analyzer/kestrel_analyzer/pipeline.py
+++ b/analyzer/kestrel_analyzer/pipeline.py
@@ -4,6 +4,7 @@ import os
 import queue
 import threading
 import time
+import traceback
 import warnings
 from typing import Callable, Dict, Generator, Optional
 
@@ -46,18 +47,19 @@ from .raw_exif import get_capture_time
 from .logging_utils import get_log_path, log_event, log_exception, log_warning
 
 try:
-    from ..settings_utils import load_persisted_settings, debug as _debug, info as _info
+    from ..settings_utils import load_persisted_settings, debug as _debug, info as _info, error as _error
 except (ImportError, ValueError):
     # Top-level package case: cli.py adds analyzer/ to sys.path and imports
     # ``kestrel_analyzer`` as a root package, so the relative ``..`` walks
     # beyond it. The bare-name fallback works because ``settings_utils`` is
     # then directly importable from sys.path.
     try:
-        from settings_utils import load_persisted_settings, debug as _debug, info as _info  # type: ignore
+        from settings_utils import load_persisted_settings, debug as _debug, info as _info, error as _error  # type: ignore
     except ImportError:
         load_persisted_settings = None
         def _debug(*_a, **_kw): pass
         def _info(*_a, **_kw): pass
+        def _error(*_a, **_kw): pass
 from .ml.speciesnet_sam_hq import SpeciesNetSAMHQWrapper
 from .ml.provider_coordinator import ResilienceConfig
 from .ml.bird_species import BirdSpeciesClassifier
@@ -1398,6 +1400,17 @@ class AnalysisPipeline:
                             "image_path": image_path,
                             "analyzer": analyzer_name,
                         },
+                    )
+                    # Mirror the full traceback into the runtime stderr log.
+                    # ``log_exception`` already records it in the per-folder
+                    # JSON, but bug reports usually attach only the runtime
+                    # tail — without this line the user-visible payload is
+                    # just ``str(e)`` and the originating library/call is
+                    # invisible.
+                    _error(
+                        f"[queue:{os.path.basename(folder)}] {raw_file}"
+                        f" stage={stage_ctx['stage']}"
+                        f" {type(e).__name__}: {e}\n{traceback.format_exc()}"
                     )
                     if error_cb:
                         error_cb(raw_file, e)


### PR DESCRIPTION
Two small, unrelated hygiene fixes for diagnosing the Latin-1 EXIF crash reports.

## (1) `utf-8-sig` for bundled label files

`analyzer/models/labels.txt` and `analyzer/models/speciesnet/…labels…txt` are bundled as **UTF-8 with a BOM**. The current `open(labels_path, "r")` (no `encoding=`) falls back to `locale.getpreferredencoding()` — on Spanish / CJK Windows installs that's `cp1252` / `cp932` / `gbk`, not UTF-8. The BOM bytes (`\xef\xbb\xbf`) round-trip as visible garbage prefixed to the first label, and any future non-ASCII species name would either mojibake or raise `UnicodeDecodeError` depending on locale.

Same fix the abandoned `copilot/fix-issue-40-non-functioning-characters` branch already drafted (commit `f59618d`): swap both call sites to `encoding="utf-8-sig"` so the BOM is stripped and content stays UTF-8 regardless of locale.

Affected files:
- `analyzer/kestrel_analyzer/ml/bird_species.py:20`
- `analyzer/kestrel_analyzer/ml/speciesnet_sam_hq.py:282` (`OnnxClassifier.__init__`)

This runs once per analysis session in `load_models`, not per image — so it isn't the per-image `0xe1 at position 334` we were chasing. But it's a real latent bug for Spanish/CJK users and the fix already exists, so worth landing.

## (2) Mirror per-image tracebacks into the runtime stderr log

`AnalysisPipeline._run`'s per-image `except` block records the full traceback via `log_exception` into the per-folder JSON error log, but the runtime stderr tail only gets the short `status_cb(f"Error {raw_file}: {e}")` line. Crash reports in the wild attach the runtime tail — not the JSON — so when `'utf-8' codec can't decode byte 0xe1 in position 334` arrived for hundreds of images, we had `str(e)` but no call site. After this change `traceback.format_exc()` lands in the runtime log too, so the next report will tell us which library/frame raised.

Implementation:
- Import `traceback` and the `error` leveled logger from `settings_utils`.
- After the existing `log_exception(...)` call, emit a single
  `_error(f"[queue:{basename}] {raw_file} stage={stage} {ExceptionType}: {msg}\n{traceback.format_exc()}")` line.
- No behavior change, no duplicate JSON write — just a stderr mirror.

## Test plan

- [x] `python -m pytest tests/test_security_visualizer_js_xss.py tests/unit/test_raw_exif.py -q` — 19 passed.
- [x] AST-parsed all three modified files clean.
- [x] Verified `utf-8-sig` strips the BOM correctly with a synthetic UTF-8-with-BOM labels file containing `Cámara`.
- [ ] Next analysis crash report should contain a `[serve][ERROR] [queue:…] <file> stage=read_image UnicodeDecodeError: …\n<full traceback>` block in the runtime tail — that will identify whether the leak is from rawpy / PIL / pandas / our own code.


---
_Generated by [Claude Code](https://claude.ai/code/session_01L38nhFzPfmmymEBiZieP68)_