### PR TITLE
fix(enumeration): skip macOS AppleDouble (._*) companion files

### DIFF
--- a/analyzer/cli.py
+++ b/analyzer/cli.py
@@ -14,6 +14,7 @@ from kestrel_analyzer.config import (
     DETECTOR_ONNX_PATHS,
     JPEG_EXTENSIONS,
     RAW_EXTENSIONS,
+    is_supported_image_file,
 )
 
 
@@ -187,15 +188,15 @@ def _find_first_image(folder: str) -> str | None:
     files = [
         f
         for f in os.listdir(folder)
-        if os.path.isfile(os.path.join(folder, f))
-        and os.path.splitext(f)[1].lower() in RAW_EXTENSIONS
+        if is_supported_image_file(f, RAW_EXTENSIONS)
+        and os.path.isfile(os.path.join(folder, f))
     ]
     if not files:
         files = [
             f
             for f in os.listdir(folder)
-            if os.path.isfile(os.path.join(folder, f))
-            and os.path.splitext(f)[1].lower() in JPEG_EXTENSIONS
+            if is_supported_image_file(f, JPEG_EXTENSIONS)
+            and os.path.isfile(os.path.join(folder, f))
         ]
     files.sort()
     if not files:

--- a/analyzer/folder_inspector.py
+++ b/analyzer/folder_inspector.py
@@ -13,7 +13,13 @@ try:
 except Exception:
     pd = None
 
-from kestrel_analyzer.config import RAW_EXTENSIONS, JPEG_EXTENSIONS, KESTREL_DIR_NAME, DATABASE_NAME
+from kestrel_analyzer.config import (
+    RAW_EXTENSIONS,
+    JPEG_EXTENSIONS,
+    KESTREL_DIR_NAME,
+    DATABASE_NAME,
+    is_supported_image_file,
+)
 from kestrel_analyzer.database import load_database
 
 
@@ -21,12 +27,14 @@ def _list_images_in_folder(folder: str) -> list:
     try:
         files = [
             f for f in os.listdir(folder)
-            if os.path.isfile(os.path.join(folder, f)) and os.path.splitext(f)[1].lower() in RAW_EXTENSIONS
+            if is_supported_image_file(f, RAW_EXTENSIONS)
+            and os.path.isfile(os.path.join(folder, f))
         ]
         if not files:
             files = [
                 f for f in os.listdir(folder)
-                if os.path.isfile(os.path.join(folder, f)) and os.path.splitext(f)[1].lower() in JPEG_EXTENSIONS
+                if is_supported_image_file(f, JPEG_EXTENSIONS)
+                and os.path.isfile(os.path.join(folder, f))
             ]
         files.sort()
         return files

--- a/analyzer/kestrel_analyzer/config.py
+++ b/analyzer/kestrel_analyzer/config.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from typing import Iterable
 
 VERSION = "2.0.4"
 
@@ -63,6 +64,34 @@ RAW_EXTENSIONS = [
     ".mrw",                 # Minolta / Konica Minolta
 ]
 JPEG_EXTENSIONS = [".jpg", ".jpeg", ".png", '.tiff', '.tif']
+
+
+def is_supported_image_file(name: str, allowed_exts: Iterable[str]) -> bool:
+    """True if ``name`` is a real image filename that should be processed.
+
+    Filters out:
+      * Hidden files (anything starting with ``.``), including macOS
+        ``.DS_Store`` and dot-prefixed app metadata.
+      * macOS AppleDouble companion files (``._<filename>``), which are
+        created automatically when macOS writes to a non-HFS/APFS volume
+        (exFAT/NTFS external drives, SMB shares) to preserve extended
+        attributes. They carry the same extension as the real file
+        (e.g. ``._IMG_0142.ARW``) so an extension-only filter lets them
+        through, but they contain ~4 KB of metadata — not image data —
+        so LibRaw rejects every one of them with "Unsupported file
+        format or not RAW file". Both prefixes are covered by the
+        leading-dot test.
+
+    Pass ``allowed_exts`` as an iterable of lowercase extensions
+    (including the leading dot), e.g. ``RAW_EXTENSIONS`` or
+    ``set(RAW_EXTENSIONS) | set(JPEG_EXTENSIONS)``.
+    """
+    if not name or name[0] == '.':
+        return False
+    dot = name.rfind('.')
+    if dot < 0:
+        return False
+    return name[dot:].lower() in allowed_exts
 
 DATABASE_NAME = "kestrel_database.csv"
 METADATA_FILENAME = "kestrel_metadata.json"

--- a/analyzer/kestrel_analyzer/pipeline.py
+++ b/analyzer/kestrel_analyzer/pipeline.py
@@ -24,6 +24,7 @@ from .config import (
     KESTREL_DIR_NAME,
     METADATA_FILENAME,
     VERSION,
+    is_supported_image_file,
 )
 from .database import (
     load_database,
@@ -567,15 +568,15 @@ class AnalysisPipeline:
             files = [
                 f
                 for f in os.listdir(folder)
-                if os.path.isfile(os.path.join(folder, f))
-                and os.path.splitext(f)[1].lower() in RAW_EXTENSIONS
+                if is_supported_image_file(f, RAW_EXTENSIONS)
+                and os.path.isfile(os.path.join(folder, f))
             ]
             if not files:
                 files = [
                     f
                     for f in os.listdir(folder)
-                    if os.path.isfile(os.path.join(folder, f))
-                    and os.path.splitext(f)[1].lower() in JPEG_EXTENSIONS
+                    if is_supported_image_file(f, JPEG_EXTENSIONS)
+                    and os.path.isfile(os.path.join(folder, f))
                 ]
             files.sort()
             if not files:

--- a/analyzer/kestrel_analyzer/validation.py
+++ b/analyzer/kestrel_analyzer/validation.py
@@ -251,13 +251,17 @@ def _check_folder_inspection(ctx: _Ctx) -> tuple[bool, str]:
         return False, f"total={total} (need >=2 images)"
     # Cache sample image paths for downstream checks
     try:
-        from kestrel_analyzer.config import RAW_EXTENSIONS, JPEG_EXTENSIONS
+        from kestrel_analyzer.config import RAW_EXTENSIONS, JPEG_EXTENSIONS, is_supported_image_file
     except ImportError:
-        from analyzer.kestrel_analyzer.config import RAW_EXTENSIONS, JPEG_EXTENSIONS  # type: ignore
+        from analyzer.kestrel_analyzer.config import (  # type: ignore
+            RAW_EXTENSIONS,
+            JPEG_EXTENSIONS,
+            is_supported_image_file,
+        )
     all_exts = set(RAW_EXTENSIONS) | set(JPEG_EXTENSIONS)
     files = sorted(
         f for f in ctx.images_dir.iterdir()
-        if f.is_file() and f.suffix.lower() in all_exts
+        if f.is_file() and is_supported_image_file(f.name, all_exts)
     )
     ctx.sample_images = files[:2]
     return True, f"total={total}, has_kestrel={result.get('has_kestrel', False)}"

--- a/analyzer/kestrel_telemetry.py
+++ b/analyzer/kestrel_telemetry.py
@@ -587,7 +587,7 @@ def collect_folder_stats(item_path: str, files_this_session: int, total_files: i
     dict with keys: file_sizes_kb, file_formats
     """
     try:
-        from kestrel_analyzer.config import RAW_EXTENSIONS, JPEG_EXTENSIONS
+        from kestrel_analyzer.config import RAW_EXTENSIONS, JPEG_EXTENSIONS, is_supported_image_file
 
         file_sizes_kb: List[float] = []
         file_formats: Dict[str, int] = {}
@@ -605,12 +605,12 @@ def collect_folder_stats(item_path: str, files_this_session: int, total_files: i
         for fname in entries:
             if len(file_sizes_kb) >= MAX_ENTRIES:
                 break
+            if not is_supported_image_file(fname, all_exts):
+                continue
             fpath = os.path.join(item_path, fname)
             if not os.path.isfile(fpath):
                 continue
             ext = os.path.splitext(fname)[1].lower()
-            if ext not in all_exts:
-                continue
             try:
                 size_kb = os.path.getsize(fpath) / 1024.0
                 file_sizes_kb.append(round(size_kb, 1))

--- a/analyzer/tests/unit/test_config_helpers.py
+++ b/analyzer/tests/unit/test_config_helpers.py
@@ -1,0 +1,77 @@
+"""Unit tests for config.is_supported_image_file()."""
+
+from pathlib import Path
+import sys
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from kestrel_analyzer.config import (
+    JPEG_EXTENSIONS,
+    RAW_EXTENSIONS,
+    is_supported_image_file,
+)
+
+
+pytestmark = pytest.mark.unit
+
+
+class TestIsSupportedImageFile:
+    """Predicate filters real images from hidden/AppleDouble companions."""
+
+    def test_real_arw_passes(self):
+        assert is_supported_image_file("IMG_0141.ARW", RAW_EXTENSIONS)
+
+    def test_real_arw_lowercase_passes(self):
+        assert is_supported_image_file("img_0141.arw", RAW_EXTENSIONS)
+
+    def test_real_jpeg_passes(self):
+        assert is_supported_image_file("DSC_0001.JPG", JPEG_EXTENSIONS)
+
+    def test_apple_double_arw_filtered(self):
+        """The actual crash trigger — Sony A1 trace was full of these."""
+        assert not is_supported_image_file("._IMG_0141.ARW", RAW_EXTENSIONS)
+
+    def test_apple_double_with_long_name(self):
+        name = (
+            "._2026.05.16_Vorerst_Letzte_Bilder_der_Alpha_1_"
+            "UNKNOWN_CAMERA_GPS_0141.ARW"
+        )
+        assert not is_supported_image_file(name, RAW_EXTENSIONS)
+
+    def test_hidden_file_filtered(self):
+        assert not is_supported_image_file(".hidden.NEF", RAW_EXTENSIONS)
+
+    def test_ds_store_filtered(self):
+        """macOS .DS_Store has no matching extension anyway, but the
+        leading-dot guard also catches it."""
+        assert not is_supported_image_file(".DS_Store", RAW_EXTENSIONS)
+        assert not is_supported_image_file(".DS_Store", JPEG_EXTENSIONS)
+
+    def test_unknown_extension_filtered(self):
+        assert not is_supported_image_file("notes.txt", RAW_EXTENSIONS)
+        assert not is_supported_image_file("video.mp4", JPEG_EXTENSIONS)
+
+    def test_no_extension_filtered(self):
+        assert not is_supported_image_file("LICENSE", RAW_EXTENSIONS)
+
+    def test_empty_name_filtered(self):
+        assert not is_supported_image_file("", RAW_EXTENSIONS)
+
+    def test_combined_extension_set_works(self):
+        all_exts = set(RAW_EXTENSIONS) | set(JPEG_EXTENSIONS)
+        assert is_supported_image_file("IMG.CR3", all_exts)
+        assert is_supported_image_file("IMG.JPG", all_exts)
+        assert not is_supported_image_file("._IMG.CR3", all_exts)
+        assert not is_supported_image_file("._IMG.JPG", all_exts)
+
+    def test_filename_starting_with_underscore_passes(self):
+        """Real Sony filenames like '_DSC7969.ARW' (leading underscore,
+        not dot) should still pass."""
+        assert is_supported_image_file("_DSC7969.ARW", RAW_EXTENSIONS)
+
+    def test_filename_with_dots_in_basename_passes(self):
+        """Filenames with extra dots like 'IMG.2026.05.16.ARW' should pass
+        as long as the leading character isn't a dot."""
+        assert is_supported_image_file("IMG.2026.05.16.ARW", RAW_EXTENSIONS)

--- a/analyzer/tests/unit/test_folder_inspector.py
+++ b/analyzer/tests/unit/test_folder_inspector.py
@@ -147,3 +147,50 @@ class TestInspectFolders:
 
         # Shallower path should come first
         assert paths.index(str(shallow)) < paths.index(str(deep))
+
+
+class TestAppleDoubleFiltering:
+    """Tests that macOS AppleDouble (``._``-prefixed) companion files are
+    excluded from enumeration. macOS creates these automatically when
+    writing to non-HFS/APFS volumes (exFAT/NTFS USB drives, network
+    shares) to preserve extended attributes. They share the same
+    extension as the real file (e.g. ``._IMG_0142.ARW``) so an
+    extension-only filter lets them through, but they contain ~4 KB of
+    metadata, not image data, and LibRaw rejects every one of them."""
+
+    def test_apple_double_files_skipped_raw(self, tmp_path):
+        """A folder with both real ARWs and AppleDouble companions counts only the real files."""
+        (tmp_path / "IMG_0141.ARW").touch()
+        (tmp_path / "IMG_0142.ARW").touch()
+        (tmp_path / "._IMG_0141.ARW").write_bytes(b'\x00\x05\x16\x07' + b'\x00' * 100)
+        (tmp_path / "._IMG_0142.ARW").write_bytes(b'\x00\x05\x16\x07' + b'\x00' * 100)
+
+        result = inspect_folder(str(tmp_path))
+        assert result['total'] == 2  # only the real ARWs
+
+    def test_apple_double_jpegs_skipped(self, tmp_path):
+        """JPEG fallback path also filters ._ companions."""
+        (tmp_path / "IMG_001.JPG").touch()
+        (tmp_path / "._IMG_001.JPG").write_bytes(b'\x00' * 50)
+        (tmp_path / "._IMG_999.JPG").write_bytes(b'\x00' * 50)
+
+        result = inspect_folder(str(tmp_path))
+        assert result['total'] == 1
+
+    def test_hidden_files_skipped(self, tmp_path):
+        """Dot-prefixed files (`.foo.CR3`, `.DS_Store`) are skipped too."""
+        (tmp_path / "IMG_001.CR3").touch()
+        (tmp_path / ".hidden.CR3").touch()
+        (tmp_path / ".DS_Store").write_bytes(b'\x00' * 10)
+
+        result = inspect_folder(str(tmp_path))
+        assert result['total'] == 1
+
+    def test_folder_with_only_apple_doubles_returns_zero(self, tmp_path):
+        """A folder containing nothing but ._ companions reports 0 images."""
+        (tmp_path / "._IMG_0141.ARW").write_bytes(b'\x00' * 100)
+        (tmp_path / "._IMG_0142.ARW").write_bytes(b'\x00' * 100)
+        (tmp_path / "._IMG_0143.ARW").write_bytes(b'\x00' * 100)
+
+        result = inspect_folder(str(tmp_path))
+        assert result['total'] == 0


### PR DESCRIPTION
## Summary

Addresses a Sony Alpha 1 "crash" report. The ARW files themselves were never the problem — every Sony body I could grab from raw.pixls.us (A900 DSLR, A7 original, A7M4 in all 3 compression modes, A7RM5 lossless + lossy, A7SM3, A6700, A9M3, A1 in all 3 compression modes — 12 samples, 2014→2024) decodes cleanly through `read_image` + the full pipeline path.

The trace gives it away:

```
._<filename>.ARW  →  "Image read returned None for both img and raw_obj"
```

Filenames starting with `._`, on a `/Volumes/...` mount point. That's a macOS user reading from a non-HFS/APFS external drive (typically a USB SSD formatted exFAT). When macOS writes to those volumes it creates a `._<filename>` **AppleDouble companion file** alongside each real file to preserve extended attributes. The companions:

- carry the same extension as the real file (e.g. `._IMG_0142.ARW`)
- contain ~4 KB of macOS metadata, **not image data**
- get caught by Kestrel's extension-only file filter
- fail every LibRaw decode with `b'Unsupported file format or not RAW file'`

Reproduced verbatim:
```python
read_image_for_pipeline('._IMG.ARW')  # -> (None, None)
# which the pipeline turns into:
"Image read returned None for both img and raw_obj"
```

## Fix

Adds a tiny `is_supported_image_file(name, ext_set)` predicate in `config.py` that filters out anything starting with `.` (covers both `._foo` AppleDouble files and `.DS_Store`/`.hidden.NEF`-style dotfiles) plus the existing extension check.

Wires it into the five enumeration sites that all duplicated the same suffix-only filter:

| File | Site |
|---|---|
| `analyzer/folder_inspector.py` | `_list_images_in_folder` (visualizer/folder UI) |
| `analyzer/kestrel_analyzer/pipeline.py` | `run()` file listing |
| `analyzer/cli.py` | `_find_first_image` (--validate sample picker) |
| `analyzer/kestrel_analyzer/validation.py` | `_check_folder_inspection` |
| `analyzer/kestrel_telemetry.py` | folder telemetry |

## Verification

Reproduced the failure shape (8 real ARWs + 8 `._` companions) and confirmed:

- Before: `_list_images_in_folder` returns 16 (8 real + 8 garbage)
- After: returns 8 (real only)
- `inspect_folder.total` correctly reports 8

Sony tests against real files unchanged — all 12 ARW samples spanning 16 years of bodies still decode + extract EXIF cleanly through both `read_image` and the full pipeline path.

## Test plan

- [x] `pytest analyzer/tests/unit/test_config_helpers.py` — 13/13 pass (predicate behavior)
- [x] `pytest analyzer/tests/unit/test_folder_inspector.py` — 15/15 pass (4 new AppleDouble tests + existing 11)
- [x] `pytest analyzer/tests/unit/` — 256/256 pass (excluding pre-existing `test_reject_move` failure unrelated to this PR)
- [x] `pytest analyzer/tests/integration/test_exif_read.py analyzer/tests/integration/test_raw_decode.py` — 21/21 pass
- [x] End-to-end repro against a synthetic AppleDouble-poisoned folder

## Sony ARW test matrix (no regressions)

All 12 samples — pre-fix and post-fix — decode through `read_image` and metered pipeline:

| Body | Variant | Year | Decode | EXIF |
|---|---|---|---|---|
| DSLR-A900 | full-frame DSLR | 2008 | ✅ | ✅ |
| ILCE-7 | original A7 14-bit uncompressed | 2013 | ✅ | ✅ |
| ILCE-1 | A1 uncompressed/lossless/compressed | 2021 | ✅ × 3 | ✅ × 3 |
| ILCE-7M4 | A7 IV uncompressed/lossless/lossy | 2021 | ✅ × 3 | ✅ × 3 |
| ILCE-7SM3 | A7S III | 2020 | ✅ | ✅ |
| ILCE-7RM5 | A7R V lossless + lossy | 2022 | ✅ × 2 | ✅ × 2 |
| ILCE-6700 | A6700 APS-C | 2023 | ✅ | ✅ |
| ILCE-9M3 | A9 III (global shutter) | 2024 | ✅ | ✅ |

Sample URLs available on [raw.pixls.us/data/Sony/](https://raw.pixls.us/data/Sony/).