### PR TITLE
feat(ui): add searchable dropdown for family tags

### DIFF
--- a/analyzer/api_bridge.py
+++ b/analyzer/api_bridge.py
@@ -990,6 +990,29 @@ class Api:
             error(f'[API] search_birds error: {e}')
             return {'success': False, 'error': str(e), 'results': []}
 
+    def search_families(self, query='', regions=None, limit=20):
+        """Region-filtered fuzzy search across unique bird families."""
+        try:
+            try:
+                from kestrel_analyzer.bird_catalog import family_entry_to_dict
+            except ImportError:
+                from analyzer.kestrel_analyzer.bird_catalog import family_entry_to_dict
+            cat = self._get_bird_catalog()
+            if cat is None:
+                return {'success': False, 'error': 'catalog unavailable', 'results': []}
+            q = '' if query is None else str(query)
+            sel = regions if isinstance(regions, (list, tuple)) else ['NA']
+            try:
+                n = int(limit)
+            except (TypeError, ValueError):
+                n = 20
+            n = max(1, min(100, n))
+            results = cat.search_families(q, sel, limit=n)
+            return {'success': True, 'results': [family_entry_to_dict(f) for f in results]}
+        except Exception as e:
+            error(f'[API] search_families error: {e}')
+            return {'success': False, 'error': str(e), 'results': []}
+
     def lookup_birds(self, names=None):
         """Resolve a list of canonical names (already-applied pills) to records.
 

--- a/analyzer/css/grid.css
+++ b/analyzer/css/grid.css
@@ -304,7 +304,8 @@
    Uses position: fixed (instead of absolute relative to .chip-input-wrap)
    to escape the overflow-x: auto clipping on .scene-topbar-tags. The
    coordinates are set in JS via getBoundingClientRect on the input. */
-.chip-input-wrap--species { position: relative; }
+.chip-input-wrap--species,
+.chip-input-wrap--family { position: relative; }
 .chip-input-dropdown {
   position: fixed;
   background: #1a2a44;

--- a/analyzer/js/scene-dialog.js
+++ b/analyzer/js/scene-dialog.js
@@ -1014,6 +1014,54 @@
       dropdownEl.style.display = '';
     }
 
+    const FAMILY_COMBO_MAX = 12;
+    let _familyComboRequestSeq = 0;
+
+    async function _searchFamiliesForCombo(query) {
+      const id = ++_familyComboRequestSeq;
+      if (!hasPywebviewApi || !window.pywebview?.api?.search_families) {
+        return { id, items: [] };
+      }
+      const regions = _getCurrentBirdRegions();
+      try {
+        const res = await window.pywebview.api.search_families(String(query || ''), regions, FAMILY_COMBO_MAX);
+        const items = (res && res.success && Array.isArray(res.results)) ? res.results : [];
+        return { id, items };
+      } catch (e) {
+        kdebug('[search_families] failed:', e);
+        return { id, items: [] };
+      }
+    }
+
+    function _renderFamilyComboDropdown(dropdownEl, items, highlightIdx) {
+      if (!dropdownEl) return;
+      if (!items || items.length === 0) {
+        dropdownEl.innerHTML = '';
+        dropdownEl.style.display = 'none';
+        return;
+      }
+      const html = items.map((entry, i) => {
+        const name = entry.family_common || '';
+        const sci  = entry.family_sci || '';
+        const order = entry.order || '';
+        const cls = i === highlightIdx ? 'chip-combo-item chip-combo-item--active' : 'chip-combo-item';
+        const sciHtml = sci
+          ? `<span class="chip-combo-sci"><em>${escapeHtml(sci)}</em></span>` : '';
+        const orderHtml = order ? `<span class="chip-combo-family">${escapeHtml(order)}</span>` : '';
+        return (
+          `<div class="${cls}" data-combo-index="${i}" data-combo-name="${escapeHtml(name)}">` +
+            `<div class="chip-combo-left">` +
+              `<span class="chip-combo-name">${escapeHtml(name)}</span>` +
+              sciHtml +
+            `</div>` +
+            `<div class="chip-combo-right">${orderHtml}</div>` +
+          `</div>`
+        );
+      }).join('');
+      dropdownEl.innerHTML = html;
+      dropdownEl.style.display = '';
+    }
+
     /** Look up the family display name for a species name (case-insensitive).
      *  Returns { canonical, family } if matched, or null for free-form input.
      *  Prefers the cached bird-catalog record (richer info) and falls back to
@@ -1149,7 +1197,7 @@
         html += _buildSuggestedTagButton('family', suggestions.family);
       }
       if (_activeTagInputType === 'family' && _activeTagInputSceneId === String(scene.id)) {
-        html += `<span class="chip-input-wrap"><input type="text" class="chip-input" id="inlineTagInput" placeholder="Family..." /><button class="chip-commit-btn" title="Save">✓</button></span>`;
+        html += `<span class="chip-input-wrap chip-input-wrap--family"><input type="text" class="chip-input" id="inlineTagInput" placeholder="Family..." autocomplete="off" /><button class="chip-commit-btn" title="Save">✓</button><div class="chip-input-dropdown" id="inlineTagDropdown" style="display:none"></div></span>`;
       } else {
         html += `<button class="scene-chip-add" data-add-type="family" title="Add family tag">+</button>`;
       }
@@ -1277,12 +1325,13 @@
         };
       }
 
-      // Wire inline input (with combobox behavior for species)
+      // Wire inline input (with combobox behavior for species and family)
       const inp = el('#inlineTagInput');
       if (inp) {
         const dropdown = tagsEl.querySelector('#inlineTagDropdown');
         const isSpeciesInput = _activeTagInputType === 'species';
-        // Combobox state — only meaningful for species inputs.
+        const isFamilyInput = _activeTagInputType === 'family';
+        const hasCombo = (isSpeciesInput || isFamilyInput) && !!dropdown;
         let comboItems = [];
         let comboIndex = -1;
 
@@ -1291,31 +1340,34 @@
           const rect = inp.getBoundingClientRect();
           dropdown.style.left = Math.round(rect.left) + 'px';
           dropdown.style.top = Math.round(rect.bottom + 4) + 'px';
-          // Width: at least the input's width, but allow it to grow up to the
-          // CSS max-width for longer species names.
           dropdown.style.minWidth = Math.max(Math.round(rect.width), 240) + 'px';
         };
 
         const refreshDropdown = async () => {
-          if (!isSpeciesInput || !dropdown) return;
-          // The async fetch returns its own request id; only the most recent
-          // request is allowed to repaint the dropdown, so quick typing
-          // doesn't flash older results on top of newer ones.
-          const pending = await _searchSpeciesForCombo(inp.value);
+          if (!hasCombo) return;
+          const pending = isSpeciesInput
+            ? await _searchSpeciesForCombo(inp.value)
+            : await _searchFamiliesForCombo(inp.value);
           if (!dropdown.isConnected) return;
-          if (pending.id !== _comboRequestSeq) return;
+          const seqRef = isSpeciesInput ? _comboRequestSeq : _familyComboRequestSeq;
+          if (pending.id !== seqRef) return;
           comboItems = pending.items;
           comboIndex = comboItems.length > 0 ? 0 : -1;
-          _renderSpeciesComboDropdown(dropdown, comboItems, comboIndex);
+          const renderFn = isSpeciesInput ? _renderSpeciesComboDropdown : _renderFamilyComboDropdown;
+          renderFn(dropdown, comboItems, comboIndex);
           if (comboItems.length > 0) positionDropdown();
+        };
+
+        const renderCombo = () => {
+          const renderFn = isSpeciesInput ? _renderSpeciesComboDropdown : _renderFamilyComboDropdown;
+          renderFn(dropdown, comboItems, comboIndex);
         };
 
         const updateHighlight = (newIdx) => {
           if (!comboItems.length) return;
           const n = comboItems.length;
           comboIndex = ((newIdx % n) + n) % n;
-          _renderSpeciesComboDropdown(dropdown, comboItems, comboIndex);
-          // Scroll the active row into view if the dropdown is scrollable.
+          renderCombo();
           const active = dropdown?.querySelector('.chip-combo-item--active');
           if (active && active.scrollIntoView) {
             active.scrollIntoView({ block: 'nearest' });
@@ -1382,18 +1434,16 @@
           }
         };
 
-        // Dropdown items are full record objects; ``commit()`` accepts either a
-        // string (typed value) or a record (selected from the dropdown). This
-        // helper normalises both to the canonical common name.
         const _comboValueOf = (item) => {
           if (item == null) return undefined;
           if (typeof item === 'string') return item;
           if (typeof item.canonical_common_name === 'string') return item.canonical_common_name;
+          if (typeof item.family_common === 'string') return item.family_common;
           return undefined;
         };
 
         inp.onkeydown = (e) => {
-          if (isSpeciesInput && (e.key === 'ArrowDown' || e.key === 'ArrowUp')) {
+          if (hasCombo && (e.key === 'ArrowDown' || e.key === 'ArrowUp')) {
             if (!comboItems.length) return;
             e.preventDefault();
             updateHighlight(comboIndex + (e.key === 'ArrowDown' ? 1 : -1));
@@ -1401,10 +1451,7 @@
           }
           if (e.key === 'Enter') {
             e.preventDefault();
-            // If a dropdown row is highlighted, commit that record's canonical
-            // name. Otherwise commit the typed value (allowing free-form
-            // species like "Eurasian Wren" if it isn't in the catalog).
-            const chosen = (isSpeciesInput && comboIndex >= 0 && comboIndex < comboItems.length)
+            const chosen = (hasCombo && comboIndex >= 0 && comboIndex < comboItems.length)
               ? _comboValueOf(comboItems[comboIndex])
               : undefined;
             commit(chosen);
@@ -1417,23 +1464,20 @@
             renderTopbarTags(scene);
           }
         };
-        if (isSpeciesInput) {
+        if (hasCombo) {
           inp.oninput = () => { refreshDropdown(); };
           inp.onfocus = () => { refreshDropdown(); };
-          // Mousedown (not click) so the selection registers BEFORE the input
-          // loses focus and the blur-commit timer has a chance to fire.
           if (dropdown) {
             dropdown.onmousedown = (e) => {
               const row = e.target.closest('.chip-combo-item');
               if (!row) return;
-              e.preventDefault(); // keep input focused so blur-commit doesn't race
+              e.preventDefault();
               const idx = parseInt(row.dataset.comboIndex || '-1', 10);
               if (idx >= 0 && idx < comboItems.length) {
                 commit(_comboValueOf(comboItems[idx]));
               }
             };
           }
-          // Initial population on render.
           refreshDropdown();
         }
         inp.onblur = (e) => {

--- a/analyzer/kestrel_analyzer/bird_catalog.py
+++ b/analyzer/kestrel_analyzer/bird_catalog.py
@@ -77,6 +77,21 @@ class BirdRecord:
         return not selected.isdisjoint(self.regions)
 
 
+@dataclass(frozen=True)
+class FamilyEntry:
+    family_common: str
+    family_sci: str
+    order: str
+    regions: frozenset[str]
+
+    def matches_any_region(self, selected: frozenset[str]) -> bool:
+        if not selected:
+            return False
+        if "Worldwide" in self.regions:
+            return True
+        return not selected.isdisjoint(self.regions)
+
+
 def _parse_regions(s: str) -> frozenset[str]:
     if not s:
         return frozenset()
@@ -253,6 +268,43 @@ def score_record(query: str, rec: BirdRecord) -> int:
     return 0
 
 
+def score_family(query: str, entry: FamilyEntry) -> int:
+    """Score a family entry against a search query. Same tier logic as
+    ``score_record`` but limited to family_common and family_sci fields."""
+    q = (query or "").strip().lower()
+    if not q:
+        return 0
+
+    common = entry.family_common.lower()
+    sci = entry.family_sci.lower()
+
+    if q == common:
+        return _SCORE_COMMON_EXACT
+    if q == sci:
+        return _SCORE_SCI_EXACT
+
+    if common.startswith(q):
+        return _SCORE_COMMON_PREFIX
+    if sci.startswith(q):
+        return _SCORE_SCI_PREFIX
+
+    qt = _tokens(q)
+    if qt and _token_prefix_match(qt, _tokens(common)):
+        return _SCORE_TOKEN_PREFIX
+
+    common_compact = "".join(c for c in common if c.isalnum() or c == "'")
+    q_compact = "".join(c for c in q if c.isalnum() or c == "'")
+    if q_compact and _is_subsequence(q_compact, common_compact):
+        return _SCORE_SUBSEQUENCE
+
+    if q in common:
+        return _SCORE_SUBSTRING
+    if q in sci:
+        return _SCORE_SCI_SUBSTRING
+
+    return 0
+
+
 class BirdCatalog:
     """In-memory catalog wrapper with region filtering and ranked search."""
 
@@ -266,12 +318,27 @@ class BirdCatalog:
         # family_sci subtext on a family-tier pill without needing a
         # sibling species record to be present in the same scene.
         self._family_common_to_sci: dict[str, str] = {}
+        # Aggregated family entries for the family combobox search.
+        _fam_regions: dict[str, set[str]] = {}
+        _fam_order: dict[str, str] = {}
         for r in self._records:
             self._by_common[r.canonical_common_name.lower()] = r
             if r.alpha_4:
                 self._by_alpha.setdefault(r.alpha_4.lower(), r)
             if r.family_common and r.family_sci:
                 self._family_common_to_sci.setdefault(r.family_common, r.family_sci)
+            if r.family_common:
+                _fam_regions.setdefault(r.family_common, set()).update(r.regions)
+                if r.order:
+                    _fam_order.setdefault(r.family_common, r.order)
+        self._families: list[FamilyEntry] = []
+        for fc, sci in self._family_common_to_sci.items():
+            self._families.append(FamilyEntry(
+                family_common=fc,
+                family_sci=sci,
+                order=_fam_order.get(fc, ""),
+                regions=frozenset(_fam_regions.get(fc, ())),
+            ))
 
     @property
     def records(self) -> list[BirdRecord]:
@@ -343,6 +410,27 @@ class BirdCatalog:
         scored.sort(key=lambda t: (-t[0], t[1]))
         return [rec for _, _, rec in scored[:limit]]
 
+    def search_families(self, query: str, regions: Iterable[str], limit: int = 20) -> list[FamilyEntry]:
+        """Region-filtered fuzzy search across unique families."""
+        sel = frozenset(r for r in regions if r)
+        if not sel:
+            return []
+        q = (query or "").strip()
+        if not q:
+            in_region = [f for f in self._families if f.matches_any_region(sel)]
+            in_region.sort(key=lambda f: f.family_common.lower())
+            return in_region[:limit]
+
+        scored: list[tuple[int, str, FamilyEntry]] = []
+        for entry in self._families:
+            if not entry.matches_any_region(sel):
+                continue
+            s = score_family(q, entry)
+            if s > 0:
+                scored.append((s, entry.family_common.lower(), entry))
+        scored.sort(key=lambda t: (-t[0], t[1]))
+        return [entry for _, _, entry in scored[:limit]]
+
 
 _catalog_singleton: BirdCatalog | None = None
 
@@ -367,4 +455,14 @@ def record_to_dict(rec: BirdRecord) -> dict:
         "alpha_4": rec.alpha_4,
         "aliases": list(rec.aliases),
         "is_model_species": rec.is_model_species,
+    }
+
+
+def family_entry_to_dict(entry: FamilyEntry) -> dict:
+    """JSON-serializable representation of a family entry."""
+    return {
+        "family_common": entry.family_common,
+        "family_sci": entry.family_sci,
+        "order": entry.order,
+        "regions": sorted(entry.regions),
     }


### PR DESCRIPTION
## Summary

- Adds a fuzzy-search dropdown to the family tag input, mirroring the existing species combobox UX
- Typing into the family field now shows matching families from the bird catalog with their scientific names (always visible in the dropdown for discoverability) and taxonomic order, filtered by the user's selected biogeographic regions
- Reuses the same scoring tiers as species search (exact → prefix → token-prefix → subsequence → substring) adapted for family_common and family_sci fields

## Changes

**Backend (`bird_catalog.py`)**
- New `FamilyEntry` dataclass aggregating unique families with their merged region sets
- `score_family()` scoring function (same tier logic as `score_record`, without alpha/alias tiers)
- `BirdCatalog.search_families()` method with region filtering and ranked results

**Backend (`api_bridge.py`)**
- New `search_families` API endpoint called by the frontend combobox

**Frontend (`scene-dialog.js`)**
- `_searchFamiliesForCombo()` and `_renderFamilyComboDropdown()` functions
- Family input now renders with a dropdown container and `autocomplete="off"`
- Combobox wiring (arrow keys, Enter, Escape, click, blur) generalized to handle both species and family inputs via a `hasCombo` flag
- `_comboValueOf()` extended to handle family entries (`family_common` key)
- Scientific names always shown in the family dropdown for easy identification

**CSS (`grid.css`)**
- `.chip-input-wrap--family` gets `position: relative` for fixed-position dropdown escape

## Cherry-pick note

This commit is structured as a single self-contained commit for clean cherry-picking onto `perch-dev-v2`.

## Test plan

- [ ] Open a scene with the species/family tag bar
- [ ] Click the family (+) button — verify the dropdown appears with alphabetical families
- [ ] Type "Hawk" — verify "Hawks, Eagles, and Kites" appears with *Accipitridae* in italics
- [ ] Use arrow keys to navigate, Enter to select — verify the family pill is added
- [ ] Click a dropdown row — verify the family pill is added
- [ ] Type a partial scientific name (e.g., "Accip") — verify the matching family appears
- [ ] Press Escape — verify the input closes without adding
- [ ] Verify species dropdown still works identically
- [ ] Toggle biogeographic regions in Settings — verify family results update accordingly
- [ ] Verify the commit cherry-picks cleanly onto `perch-dev-v2`

https://claude.ai/code/session_0113nrPebzxWqHw5TChaLCZX

---
_Generated by [Claude Code](https://claude.ai/code/session_0113nrPebzxWqHw5TChaLCZX)_