### PR TITLE
Replace heavy in-progress folder styling with hourglass emoji

### DIFF
--- a/analyzer/css/folder-tree.css
+++ b/analyzer/css/folder-tree.css
@@ -308,20 +308,14 @@
   color: var(--bad);
 }
 
-/* In-progress analysis styling (subtle purple indicator with text) */
-.tree-node-row.in-progress {
-  background: rgba(179, 153, 204, 0.08);
-  border-left: 3px solid #b399cc;
-  padding-left: 6px;
-}
-.tree-node-row.in-progress .tree-label {
-  color: #d4a3ff !important;
-  font-style: italic;
-}
-.tree-node-row.in-progress .tree-label::after {
-  content: ' (analysis in progress)';
-  margin-left: 6px;
-  font-size: 0.9em;
+/* In-progress hourglass indicator (mirrors .tree-perch-feather pattern) */
+.tree-in-progress-hourglass {
+  font-size: 11px;
+  margin-left: 1px;
+  margin-right: 3px;
+  display: inline-block;
+  line-height: 1;
+  vertical-align: middle;
   opacity: 0.85;
 }
 

--- a/analyzer/js/folder-tree.js
+++ b/analyzer/js/folder-tree.js
@@ -468,6 +468,14 @@
       icon.className = 'tree-icon';
       icon.textContent = node.has_kestrel ? '📂' : '📁';
 
+      // Hourglass overlay — surfaces "this folder is being analyzed" at a glance.
+      const inProgressHourglass = isInProgress ? document.createElement('span') : null;
+      if (inProgressHourglass) {
+        inProgressHourglass.className = 'tree-in-progress-hourglass';
+        inProgressHourglass.textContent = '⏳';
+        inProgressHourglass.title = 'Analysis in progress';
+      }
+
       // Label
       const label = document.createElement('span');
       label.className = 'tree-label';
@@ -507,6 +515,7 @@
 
       row.appendChild(arrow);
       row.appendChild(icon);
+      if (inProgressHourglass) row.appendChild(inProgressHourglass);
       row.appendChild(label);
       row.appendChild(countSpan);
       row.appendChild(cbCol);

--- a/analyzer/js/queue.js
+++ b/analyzer/js/queue.js
@@ -1037,22 +1037,29 @@
     // Legacy alias for any straggling callers.
     const rescanFolderTree = rescanFolderRoot;
 
-    /** Update UI to reflect in-progress folders with special styling and always-present checkboxes. */
+    /** Update UI to reflect in-progress folders with hourglass indicator and checkboxes. */
     function updateInProgressFoldersInTree() {
       try {
         const norm = p => (p || '').replace(/\\/g, '/');
-        for (const inProgPath of _inProgressFolderPaths) {
-          const normPath = norm(inProgPath);
-          const rows = Array.from(document.querySelectorAll('#folderTree .tree-node-row'));
-          for (const row of rows) {
-            const rp = norm(row.dataset.path || '');
-            if (rp !== normPath) continue;
-            
-            // Mark as in-progress with purple styling
+        const rows = Array.from(document.querySelectorAll('#folderTree .tree-node-row'));
+        for (const row of rows) {
+          const rp = norm(row.dataset.path || '');
+          const isNowInProgress = _inProgressFolderPaths.has(rp);
+
+          if (isNowInProgress) {
             row.classList.add('in-progress');
-            _tempKestrelPaths.add(normPath); // prevent checkbox removal on next rescan
-            
-            // Ensure checkbox exists (even if .kestrel doesn't)
+            _tempKestrelPaths.add(rp);
+
+            if (!row.querySelector('.tree-in-progress-hourglass')) {
+              const hg = document.createElement('span');
+              hg.className = 'tree-in-progress-hourglass';
+              hg.textContent = '⏳';
+              hg.title = 'Analysis in progress';
+              const iconEl = row.querySelector('.tree-icon');
+              if (iconEl && iconEl.nextSibling) iconEl.parentNode.insertBefore(hg, iconEl.nextSibling);
+              else if (iconEl) iconEl.parentNode.appendChild(hg);
+            }
+
             if (!row.querySelector('.tree-cb')) {
               const cb = document.createElement('input');
               cb.type = 'checkbox';
@@ -1066,11 +1073,14 @@
                 _updateAutoRefreshTimers();
                 debouncedAutoLoad();
               });
-              // Find icon and insert before it
               const icon = row.querySelector('.tree-icon');
               if (icon && icon.parentNode) icon.parentNode.insertBefore(cb, icon);
               else row.insertBefore(cb, row.firstChild);
             }
+          } else if (row.classList.contains('in-progress')) {
+            row.classList.remove('in-progress');
+            const hg = row.querySelector('.tree-in-progress-hourglass');
+            if (hg) hg.remove();
           }
         }
       } catch (e) { console.warn('[tree] updateInProgressFoldersInTree error:', e); }


### PR DESCRIPTION
## Summary
- Replaces the heavy purple in-progress folder styling (background, border, italic text, `(analysis in progress)` pseudo-element) with a lightweight hourglass emoji (⏳), matching the feather emoji (🪶) pattern used for Perch-shared folders.
- Adds proper cleanup: the hourglass is now removed from tree rows when analysis finishes, fixing a case where the old `.in-progress` class could linger until the next full tree re-render.
- The `updateInProgressFoldersInTree()` function now iterates all rows once (instead of nested loops per in-progress path), improving efficiency and handling both add and remove in a single pass.

## Test plan
- [ ] Start a local analysis job and confirm the hourglass ⏳ appears next to the folder icon in the tree
- [ ] Confirm no purple background, border, italic text, or "(analysis in progress)" text appears
- [ ] Let the analysis finish and confirm the hourglass disappears
- [ ] Verify folders shared on Perch still show the feather 🪶 as before

https://claude.ai/code/session_01TeCRUWoDTQasr1y3rR44yY

---
_Generated by [Claude Code](https://claude.ai/code/session_01TeCRUWoDTQasr1y3rR44yY)_