### PR TITLE
Add hourglass indicator + auto-refresh for cloud compute jobs

### DIFF
--- a/analyzer/css/folder-tree.css
+++ b/analyzer/css/folder-tree.css
@@ -308,20 +308,14 @@
   color: var(--bad);
 }
 
-/* In-progress analysis styling (subtle purple indicator with text) */
-.tree-node-row.in-progress {
-  background: rgba(179, 153, 204, 0.08);
-  border-left: 3px solid #b399cc;
-  padding-left: 6px;
-}
-.tree-node-row.in-progress .tree-label {
-  color: #d4a3ff !important;
-  font-style: italic;
-}
-.tree-node-row.in-progress .tree-label::after {
-  content: ' (analysis in progress)';
-  margin-left: 6px;
-  font-size: 0.9em;
+/* In-progress hourglass indicator (mirrors .tree-perch-feather pattern) */
+.tree-in-progress-hourglass {
+  font-size: 11px;
+  margin-left: 1px;
+  margin-right: 3px;
+  display: inline-block;
+  line-height: 1;
+  vertical-align: middle;
   opacity: 0.85;
 }
 

--- a/analyzer/js/cloud-compute.js
+++ b/analyzer/js/cloud-compute.js
@@ -43,6 +43,7 @@
     // 'incomplete' set — the desktop normalises those to 'done'|'failed'|
     // 'cancelled' before we ever see them.
     const _CC_TERMINAL_STATUSES = new Set(['done', 'failed', 'cancelled']);
+    window._ccInProgressFolderPaths = new Set();
 
     function _ccPickFirstSelectedFolder() {
       // Pull the first checked folder from the Phase 3 dialog state (the
@@ -677,6 +678,12 @@
         panel.classList.add('hidden');
         body.innerHTML = '';
         _ccPrevJobSnapshot = new Map();
+        if (window._ccInProgressFolderPaths && window._ccInProgressFolderPaths.size > 0) {
+          window._ccInProgressFolderPaths = new Set();
+          try {
+            if (typeof updateInProgressFoldersInTree === 'function') updateInProgressFoldersInTree();
+          } catch {}
+        }
         return;
       }
       panel.classList.remove('hidden');
@@ -717,6 +724,23 @@
         // Fire-and-forget; maybeStartNextCloudJob serialises itself.
         maybeStartNextCloudJob();
       }
+
+      // ── Update cloud in-progress folder set for tree hourglass indicators ─
+      const norm = p => (p || '').replace(/\\/g, '/');
+      const ccInProg = new Set();
+      for (const j of jobs) {
+        if (!_CC_TERMINAL_STATUSES.has(j.status) && j.folderPath) ccInProg.add(norm(j.folderPath));
+      }
+      for (const p of pending) {
+        if (p.path) ccInProg.add(norm(p.path));
+      }
+      window._ccInProgressFolderPaths = ccInProg;
+      try {
+        if (typeof updateInProgressFoldersInTree === 'function') {
+          updateInProgressFoldersInTree();
+          if (typeof _updateAutoRefreshTimers === 'function') _updateAutoRefreshTimers();
+        }
+      } catch {}
 
       // Drain pack-merged events and trigger folder rescan so new photos show
       // in the gallery as packs arrive — same UX as local live update. Uses

--- a/analyzer/js/folder-tree.js
+++ b/analyzer/js/folder-tree.js
@@ -476,6 +476,14 @@
         perchFeather.title = 'Published to Perch';
       }
 
+      // Hourglass overlay — surfaces "this folder is being analyzed" at a glance.
+      const inProgressHourglass = isInProgress ? document.createElement('span') : null;
+      if (inProgressHourglass) {
+        inProgressHourglass.className = 'tree-in-progress-hourglass';
+        inProgressHourglass.textContent = '⏳';
+        inProgressHourglass.title = 'Analysis in progress';
+      }
+
       // Label
       const label = document.createElement('span');
       label.className = 'tree-label';
@@ -516,6 +524,7 @@
       row.appendChild(arrow);
       row.appendChild(icon);
       if (perchFeather) row.appendChild(perchFeather);
+      if (inProgressHourglass) row.appendChild(inProgressHourglass);
       row.appendChild(label);
       row.appendChild(countSpan);
       row.appendChild(cbCol);

--- a/analyzer/js/folder-tree.js
+++ b/analyzer/js/folder-tree.js
@@ -424,7 +424,8 @@
 
       const norm = p => (p || '').replace(/\\/g, '/');
       const normPath = norm(node.path);
-      const isInProgress = _inProgressFolderPaths.has(normPath);
+      const isInProgress = _inProgressFolderPaths.has(normPath)
+        || (window._ccInProgressFolderPaths && window._ccInProgressFolderPaths.has(normPath));
 
       const effectiveHasKestrel = subtreeHasKestrel(node) || isInProgress; // Show checkbox for in-progress too
       const outdated = isVersionOutdated(node);

--- a/analyzer/js/queue.js
+++ b/analyzer/js/queue.js
@@ -1037,22 +1037,29 @@
     // Legacy alias for any straggling callers.
     const rescanFolderTree = rescanFolderRoot;
 
-    /** Update UI to reflect in-progress folders with special styling and always-present checkboxes. */
+    /** Update UI to reflect in-progress folders with hourglass indicator and checkboxes. */
     function updateInProgressFoldersInTree() {
       try {
         const norm = p => (p || '').replace(/\\/g, '/');
-        for (const inProgPath of _inProgressFolderPaths) {
-          const normPath = norm(inProgPath);
-          const rows = Array.from(document.querySelectorAll('#folderTree .tree-node-row'));
-          for (const row of rows) {
-            const rp = norm(row.dataset.path || '');
-            if (rp !== normPath) continue;
-            
-            // Mark as in-progress with purple styling
+        const rows = Array.from(document.querySelectorAll('#folderTree .tree-node-row'));
+        for (const row of rows) {
+          const rp = norm(row.dataset.path || '');
+          const isNowInProgress = _inProgressFolderPaths.has(rp);
+
+          if (isNowInProgress) {
             row.classList.add('in-progress');
-            _tempKestrelPaths.add(normPath); // prevent checkbox removal on next rescan
-            
-            // Ensure checkbox exists (even if .kestrel doesn't)
+            _tempKestrelPaths.add(rp);
+
+            if (!row.querySelector('.tree-in-progress-hourglass')) {
+              const hg = document.createElement('span');
+              hg.className = 'tree-in-progress-hourglass';
+              hg.textContent = '⏳';
+              hg.title = 'Analysis in progress';
+              const iconEl = row.querySelector('.tree-icon');
+              if (iconEl && iconEl.nextSibling) iconEl.parentNode.insertBefore(hg, iconEl.nextSibling);
+              else if (iconEl) iconEl.parentNode.appendChild(hg);
+            }
+
             if (!row.querySelector('.tree-cb')) {
               const cb = document.createElement('input');
               cb.type = 'checkbox';
@@ -1066,11 +1073,14 @@
                 _updateAutoRefreshTimers();
                 debouncedAutoLoad();
               });
-              // Find icon and insert before it
               const icon = row.querySelector('.tree-icon');
               if (icon && icon.parentNode) icon.parentNode.insertBefore(cb, icon);
               else row.insertBefore(cb, row.firstChild);
             }
+          } else if (row.classList.contains('in-progress')) {
+            row.classList.remove('in-progress');
+            const hg = row.querySelector('.tree-in-progress-hourglass');
+            if (hg) hg.remove();
           }
         }
       } catch (e) { console.warn('[tree] updateInProgressFoldersInTree error:', e); }

--- a/analyzer/js/queue.js
+++ b/analyzer/js/queue.js
@@ -1044,7 +1044,8 @@
         const rows = Array.from(document.querySelectorAll('#folderTree .tree-node-row'));
         for (const row of rows) {
           const rp = norm(row.dataset.path || '');
-          const isNowInProgress = _inProgressFolderPaths.has(rp);
+          const isNowInProgress = _inProgressFolderPaths.has(rp)
+            || (window._ccInProgressFolderPaths && window._ccInProgressFolderPaths.has(rp));
 
           if (isNowInProgress) {
             row.classList.add('in-progress');
@@ -1055,9 +1056,10 @@
               hg.className = 'tree-in-progress-hourglass';
               hg.textContent = '⏳';
               hg.title = 'Analysis in progress';
-              const iconEl = row.querySelector('.tree-icon');
-              if (iconEl && iconEl.nextSibling) iconEl.parentNode.insertBefore(hg, iconEl.nextSibling);
-              else if (iconEl) iconEl.parentNode.appendChild(hg);
+              const featherEl = row.querySelector('.tree-perch-feather');
+              const anchorEl = featherEl || row.querySelector('.tree-icon');
+              if (anchorEl && anchorEl.nextSibling) anchorEl.parentNode.insertBefore(hg, anchorEl.nextSibling);
+              else if (anchorEl) anchorEl.parentNode.appendChild(hg);
             }
 
             if (!row.querySelector('.tree-cb')) {
@@ -1176,16 +1178,18 @@
           return;
         }
         
+        const ccPaths = window._ccInProgressFolderPaths || new Set();
         for (const [path, timerId] of _autoRefreshTimers.entries()) {
-          const isStillInProgress = _inProgressFolderPaths.has(path);
+          const isStillInProgress = _inProgressFolderPaths.has(path) || ccPaths.has(path);
           const isStillChecked = _isPathChecked(path);
           if (!isStillInProgress || !isStillChecked) {
             clearInterval(timerId);
             _autoRefreshTimers.delete(path);
           }
         }
-        
-        for (const inProgPath of _inProgressFolderPaths) {
+
+        const allInProgress = new Set([..._inProgressFolderPaths, ...ccPaths]);
+        for (const inProgPath of allInProgress) {
           if (_isPathChecked(inProgPath) && !_autoRefreshTimers.has(inProgPath)) {
             const capturedPath = inProgPath;
             const timerId = setInterval(async () => {
@@ -1208,7 +1212,8 @@
         function traverse(n) {
           if (!n) return;
           const np = (n.path || '').replace(/\\/g, '/');
-          if (n.has_kestrel && !_inProgressFolderPaths.has(np)) count++;
+          const ccPaths = window._ccInProgressFolderPaths || new Set();
+          if (n.has_kestrel && !_inProgressFolderPaths.has(np) && !ccPaths.has(np)) count++;
           (n.children || []).forEach(c => traverse(c));
         }
         for (const root of _getAllRoots()) traverse(root);


### PR DESCRIPTION
## Summary
- Cherry-picks the in-progress styling refactor from #67 (hourglass emoji replacing heavy purple CSS)
- Ports the local analysis in-progress tracking system to cloud compute jobs:
  - Maintains `_ccInProgressFolderPaths` set, updated on each 4s cloud panel render tick
  - Folders with active/pending cloud jobs show ⏳ in the folder tree (same as local analysis)
  - Auto-refresh timers are set up for checked cloud compute folders so the gallery updates as packs arrive
  - Hourglass is cleaned up when jobs reach terminal status or the panel empties
  - Hourglass is positioned after the feather emoji (🪶) when both indicators are present
- `updateInProgressFoldersInTree()` and `_updateAutoRefreshTimers()` now consider both local and cloud in-progress sets

## Test plan
- [ ] Start a cloud compute job and confirm ⏳ appears next to the folder in the tree
- [ ] Confirm pending (queued) cloud jobs also show ⏳
- [ ] Check the folder checkbox while cloud job is active — verify gallery auto-refreshes as packs arrive
- [ ] Let the cloud job complete — verify ⏳ disappears
- [ ] Run a local analysis alongside — verify both local and cloud in-progress folders show ⏳ independently
- [ ] Verify feather 🪶 and hourglass ⏳ coexist correctly on a Perch-linked folder being analyzed

https://claude.ai/code/session_01TeCRUWoDTQasr1y3rR44yY

---
_Generated by [Claude Code](https://claude.ai/code/session_01TeCRUWoDTQasr1y3rR44yY)_