### PR TITLE
fix(ui): remove 'Loading Kestrel Analyzer' overlay

### DIFF
--- a/analyzer/js/state.js
+++ b/analyzer/js/state.js
@@ -282,12 +282,8 @@
       } catch (e) { console.warn('showToast failed', e); }
     }
 
-    function showLoadingAnalyzer() {
-      const o = document.getElementById('loadingOverlay'); if (!o) return; o.classList.remove('hidden'); o.style.pointerEvents = 'auto';
-    }
-    function hideLoadingAnalyzer() {
-      const o = document.getElementById('loadingOverlay'); if (!o) return; o.classList.add('hidden'); o.style.pointerEvents = 'none';
-    }
+    function showLoadingAnalyzer() { }
+    function hideLoadingAnalyzer() { }
 
     async function _waitForPipelineReady(timeoutMs = 30000) {
       const start = Date.now();

--- a/analyzer/visualizer.html
+++ b/analyzer/visualizer.html
@@ -427,16 +427,6 @@
     </div>
   </dialog>
 
-  <!-- Loading overlay shown while analyzer is importing models -->
-  <div id="loadingOverlay" class="hidden"
-    style="position:fixed;right:18px;bottom:72px;display:flex;align-items:center;justify-content:center;z-index:20010;pointer-events:none;">
-    <div
-      style="background:rgba(10,12,15,0.96);border:1px solid #2a3040;padding:10px 14px;border-radius:10px;color:var(--text);pointer-events:auto;box-shadow:0 6px 18px rgba(0,0,0,.5);min-width:240px;">
-      <div style="font-weight:700;margin-bottom:4px;font-size:13px">Loading Kestrel Analyzer…</div>
-      <div style="color:var(--muted);font-size:12px">Models are loading. Analysis will start shortly.</div>
-    </div>
-  </div>
-
   <!-- Toast notification container -->
   <div id="toastContainer" style="position:fixed;right:18px;bottom:18px;z-index:20000;pointer-events:none"></div>
 


### PR DESCRIPTION
## Summary

- Remove the "Loading Kestrel Analyzer…" overlay that appeared when starting local analysis — it was clunky and unnecessary UI clutter
- Remove the overlay HTML element from `visualizer.html` and stub out the `showLoadingAnalyzer`/`hideLoadingAnalyzer` functions in `state.js`
- Cherry-picked from `claude/tender-pascal-FWv4i` (commit 8f547c2)

## Test plan

- [ ] Start a local analysis run and confirm no loading overlay appears
- [ ] Verify analysis still starts and completes normally without the overlay

https://claude.ai/code/session_01WZR3qy8E8hZUBYyC13KebP

---
_Generated by [Claude Code](https://claude.ai/code/session_01WZR3qy8E8hZUBYyC13KebP)_