### PR TITLE
fix(windows): set DefWindowProcW argtypes to stop residual LPARAM overflow

### DIFF
--- a/analyzer/shutdown_watch.py
+++ b/analyzer/shutdown_watch.py
@@ -160,13 +160,21 @@ def _install_windows(callback: Callable[[], None]) -> bool:
     # LPARAM, and LRESULT so the callback works correctly on 64-bit Windows.
     # wintypes.WPARAM / wintypes.LPARAM are defined as 32-bit c_uint / c_long
     # in Python's ctypes, which causes an OverflowError when the OS delivers
-    # a message whose LPARAM holds a 64-bit pointer value.
+    # a message whose LPARAM holds a 64-bit pointer value. The same pointer-
+    # sized types must also be declared on DefWindowProcW — without an
+    # explicit argtypes ctypes falls back to c_int for integer arguments,
+    # so forwarding a 64-bit lparam still overflows on the outbound call.
     WNDPROC = ctypes.WINFUNCTYPE(
         ctypes.c_ssize_t,   # LRESULT = LONG_PTR
         wintypes.HWND, wintypes.UINT,
         ctypes.c_size_t,    # WPARAM = UINT_PTR
         ctypes.c_ssize_t,   # LPARAM = LONG_PTR
     )
+    user32.DefWindowProcW.argtypes = [
+        wintypes.HWND, wintypes.UINT,
+        ctypes.c_size_t,    # WPARAM = UINT_PTR
+        ctypes.c_ssize_t,   # LPARAM = LONG_PTR
+    ]
     user32.DefWindowProcW.restype = ctypes.c_ssize_t
 
     def _wnd_proc(hwnd, msg, wparam, lparam):


### PR DESCRIPTION
## Summary

PR #64 fixed the inbound `WNDPROC` callback so a 64-bit `LPARAM` from
Windows didn't overflow `c_long` when marshalled into Python. It also
set `DefWindowProcW.restype` to `c_ssize_t` — but it left
`DefWindowProcW.argtypes` unset.

Without an explicit `argtypes`, `ctypes` uses its default conversion for
integer arguments, which is `c_int` (32-bit). So when `_wnd_proc`
forwards an unhandled message back to `DefWindowProcW`, the same
64-bit `LPARAM` value that the WNDPROC fix accepted on the way in now
overflows on the way back out. The crash trace from the field matches
exactly:

```
Exception ignored on calling ctypes callback function: <function _install_windows.<locals>._wnd_proc>
  File "shutdown_watch.py", line 181, in _wnd_proc
ctypes.ArgumentError: argument 4: OverflowError: int too long to convert
```

Line 181 in the post-#64 file is `return user32.DefWindowProcW(hwnd, msg, wparam, lparam)`,
and "argument 4" is `lparam`.

The downstream effect is the one #64 was supposed to fix: the callback
body never runs for the affected messages, so `WM_QUERYENDSESSION` /
`WM_ENDSESSION` never reach the `callback()` that sets
`EXIT_REASON_KEY='os_shutdown'`. The next launch then reads
`EXIT_REASON_KEY='unknown'` and surfaces the unclean-shutdown recovery
dialog, which is what the recent Windows crash reports on
`v(Great-Horned Owl)` are.

## Fix

Declare `argtypes` on `DefWindowProcW` using the same pointer-sized
types as the WNDPROC: `HWND, UINT, c_size_t (WPARAM), c_ssize_t (LPARAM)`.
That matches the kernel ABI so the outbound call survives a 64-bit
`lparam` round-trip.

## Test plan

- [x] Module imports cleanly on non-Windows (Linux verified).
- [x] Source inspection confirms `argtypes` is now set alongside
      `restype`.
- [ ] On a 64-bit Windows machine: launch Kestrel, leave it running,
      and confirm the "Exception ignored on calling ctypes callback
      function" lines no longer appear in
      `~/.kestrel/logs/kestrel_runtime_*.log`.
- [ ] On Windows: initiate a system shutdown/sign-out, confirm the
      next launch does NOT show the unclean-shutdown recovery prompt.


---
_Generated by [Claude Code](https://claude.ai/code/session_01EuncnpuyfQZx5HC5EGfesv)_