### PR TITLE
fix(folder-scan): keep orphan JPEGs alongside RAW+JPG pairs

### DIFF
--- a/analyzer/cli.py
+++ b/analyzer/cli.py
@@ -12,9 +12,7 @@ from kestrel_analyzer.logging_utils import get_log_path, log_event, log_exceptio
 from kestrel_analyzer.config import (
     DEFAULT_DETECTOR_NAME,
     DETECTOR_ONNX_PATHS,
-    JPEG_EXTENSIONS,
-    RAW_EXTENSIONS,
-    is_supported_image_file,
+    select_camera_images,
 )
 
 
@@ -185,19 +183,12 @@ def _resolve_detector_name(args) -> str:
 
 
 def _find_first_image(folder: str) -> str | None:
-    files = [
-        f
-        for f in os.listdir(folder)
-        if is_supported_image_file(f, RAW_EXTENSIONS)
-        and os.path.isfile(os.path.join(folder, f))
+    entries = [
+        name
+        for name in os.listdir(folder)
+        if os.path.isfile(os.path.join(folder, name))
     ]
-    if not files:
-        files = [
-            f
-            for f in os.listdir(folder)
-            if is_supported_image_file(f, JPEG_EXTENSIONS)
-            and os.path.isfile(os.path.join(folder, f))
-        ]
+    files = select_camera_images(entries)
     files.sort()
     if not files:
         return None

--- a/analyzer/folder_inspector.py
+++ b/analyzer/folder_inspector.py
@@ -14,28 +14,20 @@ except Exception:
     pd = None
 
 from kestrel_analyzer.config import (
-    RAW_EXTENSIONS,
-    JPEG_EXTENSIONS,
     KESTREL_DIR_NAME,
     DATABASE_NAME,
-    is_supported_image_file,
+    select_camera_images,
 )
 from kestrel_analyzer.database import load_database
 
 
 def _list_images_in_folder(folder: str) -> list:
     try:
-        files = [
-            f for f in os.listdir(folder)
-            if is_supported_image_file(f, RAW_EXTENSIONS)
-            and os.path.isfile(os.path.join(folder, f))
+        entries = [
+            name for name in os.listdir(folder)
+            if os.path.isfile(os.path.join(folder, name))
         ]
-        if not files:
-            files = [
-                f for f in os.listdir(folder)
-                if is_supported_image_file(f, JPEG_EXTENSIONS)
-                and os.path.isfile(os.path.join(folder, f))
-            ]
+        files = select_camera_images(entries)
         files.sort()
         return files
     except Exception:

--- a/analyzer/kestrel_analyzer/config.py
+++ b/analyzer/kestrel_analyzer/config.py
@@ -1,3 +1,4 @@
+import os
 from pathlib import Path
 from typing import Iterable
 
@@ -92,6 +93,36 @@ def is_supported_image_file(name: str, allowed_exts: Iterable[str]) -> bool:
     if dot < 0:
         return False
     return name[dot:].lower() in allowed_exts
+
+
+def select_camera_images(names: Iterable[str]) -> list[str]:
+    """Pick the canonical set of camera images from a directory listing.
+
+    Prefers RAW originals over JPEG companions: if both ``IMG_0001.CR3`` and
+    ``IMG_0001.JPG`` are present, the JPEG is dropped as a redundant in-camera
+    sidecar. JPEGs (and other JPEG-family formats such as PNG / TIFF) that
+    have no same-stem RAW partner are kept so mixed RAW+JPG/JPG-only shoots
+    are not silently truncated.
+
+    Stem matching is case-insensitive to handle Windows / macOS case-
+    folding filesystems where ``IMG_0001.CR3`` and ``img_0001.jpg`` refer
+    to the same capture. Hidden / AppleDouble files are filtered via
+    :func:`is_supported_image_file`.
+    """
+    raw_names: list[str] = []
+    jpeg_names: list[str] = []
+    for name in names:
+        if is_supported_image_file(name, RAW_EXTENSIONS):
+            raw_names.append(name)
+        elif is_supported_image_file(name, JPEG_EXTENSIONS):
+            jpeg_names.append(name)
+    raw_stems = {os.path.splitext(n)[0].lower() for n in raw_names}
+    orphan_jpegs = [
+        n for n in jpeg_names
+        if os.path.splitext(n)[0].lower() not in raw_stems
+    ]
+    return raw_names + orphan_jpegs
+
 
 DATABASE_NAME = "kestrel_database.csv"
 METADATA_FILENAME = "kestrel_metadata.json"

--- a/analyzer/kestrel_analyzer/pipeline.py
+++ b/analyzer/kestrel_analyzer/pipeline.py
@@ -14,8 +14,6 @@ import pandas as pd
 
 from .config import (
     DEFAULT_DETECTOR_NAME,
-    JPEG_EXTENSIONS,
-    RAW_EXTENSIONS,
     SPECIESCLASSIFIER_LABELS,
     SPECIESCLASSIFIER_PATH,
     QUALITYCLASSIFIER_PATH,
@@ -24,7 +22,7 @@ from .config import (
     KESTREL_DIR_NAME,
     METADATA_FILENAME,
     VERSION,
-    is_supported_image_file,
+    select_camera_images,
 )
 from .database import (
     load_database,
@@ -565,19 +563,12 @@ class AnalysisPipeline:
 
         try:
             stage_ctx["stage"] = "list_files"
-            files = [
-                f
-                for f in os.listdir(folder)
-                if is_supported_image_file(f, RAW_EXTENSIONS)
-                and os.path.isfile(os.path.join(folder, f))
+            entries = [
+                name
+                for name in os.listdir(folder)
+                if os.path.isfile(os.path.join(folder, name))
             ]
-            if not files:
-                files = [
-                    f
-                    for f in os.listdir(folder)
-                    if is_supported_image_file(f, JPEG_EXTENSIONS)
-                    and os.path.isfile(os.path.join(folder, f))
-                ]
+            files = select_camera_images(entries)
             files.sort()
             if not files:
                 if status_cb:

--- a/analyzer/tests/unit/test_config_helpers.py
+++ b/analyzer/tests/unit/test_config_helpers.py
@@ -11,6 +11,7 @@ from kestrel_analyzer.config import (
     JPEG_EXTENSIONS,
     RAW_EXTENSIONS,
     is_supported_image_file,
+    select_camera_images,
 )
 
 
@@ -75,3 +76,74 @@ class TestIsSupportedImageFile:
         """Filenames with extra dots like 'IMG.2026.05.16.ARW' should pass
         as long as the leading character isn't a dot."""
         assert is_supported_image_file("IMG.2026.05.16.ARW", RAW_EXTENSIONS)
+
+
+class TestSelectCameraImages:
+    """RAW+JPG dedup: prefer RAW, keep orphan JPEGs."""
+
+    def test_raw_only(self):
+        assert select_camera_images(["IMG_001.CR3", "IMG_002.CR3"]) == [
+            "IMG_001.CR3", "IMG_002.CR3",
+        ]
+
+    def test_jpeg_only(self):
+        assert select_camera_images(["DSC_001.JPG", "DSC_002.JPG"]) == [
+            "DSC_001.JPG", "DSC_002.JPG",
+        ]
+
+    def test_paired_jpeg_dropped(self):
+        result = select_camera_images([
+            "IMG_001.CR3", "IMG_001.JPG",
+            "IMG_002.CR3", "IMG_002.JPG",
+        ])
+        assert "IMG_001.JPG" not in result
+        assert "IMG_002.JPG" not in result
+        assert set(result) == {"IMG_001.CR3", "IMG_002.CR3"}
+
+    def test_orphan_jpeg_kept(self):
+        """User shoots RAW+JPG then switches to JPG-only mid-card.
+
+        Paired JPEGs drop out as in-camera sidecars; JPGs without a
+        same-stem RAW partner are kept so the JPG-only photos still get
+        analyzed instead of disappearing.
+        """
+        result = select_camera_images([
+            "IMG_001.CR3", "IMG_001.JPG",   # paired — JPG dropped
+            "IMG_002.CR3", "IMG_002.JPG",   # paired — JPG dropped
+            "IMG_003.JPG",                  # orphan — kept
+            "IMG_004.JPG",                  # orphan — kept
+        ])
+        assert set(result) == {
+            "IMG_001.CR3", "IMG_002.CR3",
+            "IMG_003.JPG", "IMG_004.JPG",
+        }
+
+    def test_case_insensitive_stem_match(self):
+        """Capture stems pair across case so case-folding filesystems work."""
+        result = select_camera_images(["IMG_001.CR3", "img_001.jpg"])
+        assert result == ["IMG_001.CR3"]
+
+    def test_hidden_and_appledouble_filtered(self):
+        result = select_camera_images([
+            ".DS_Store",
+            "._IMG_001.CR3",
+            "._IMG_001.JPG",
+            "IMG_001.CR3",
+        ])
+        assert result == ["IMG_001.CR3"]
+
+    def test_mixed_raw_formats_kept(self):
+        """Different cameras' RAWs in one folder all survive."""
+        result = select_camera_images([
+            "IMG_001.CR3",      # Canon
+            "DSC_002.NEF",      # Nikon
+            "DSC_003.ARW",      # Sony
+            "DSC_002.JPG",      # paired with NEF — dropped
+        ])
+        assert set(result) == {"IMG_001.CR3", "DSC_002.NEF", "DSC_003.ARW"}
+
+    def test_empty_input(self):
+        assert select_camera_images([]) == []
+
+    def test_no_supported_files(self):
+        assert select_camera_images(["notes.txt", "movie.mp4", "README"]) == []

--- a/analyzer/tests/unit/test_folder_inspector.py
+++ b/analyzer/tests/unit/test_folder_inspector.py
@@ -41,17 +41,40 @@ class TestInspectFolder:
         result = inspect_folder(str(tmp_path))
         assert result['total'] == 2
 
-    def test_raw_preferred_over_jpeg(self, tmp_path):
-        """Folder with both RAW and JPEG - RAW takes precedence."""
+    def test_raw_preferred_over_paired_jpeg(self, tmp_path):
+        """Folder with paired RAW+JPEG - RAW kept, paired JPEG dropped."""
         (tmp_path / "IMG_001.CR3").touch()
         (tmp_path / "IMG_002.CR3").touch()
         (tmp_path / "IMG_001.JPG").touch()
         (tmp_path / "IMG_002.JPG").touch()
-        (tmp_path / "IMG_003.JPG").touch()
 
         result = inspect_folder(str(tmp_path))
-        # Should count CR3 files, not JPEGs
         assert result['total'] == 2
+
+    def test_orphan_jpeg_kept_alongside_raw(self, tmp_path):
+        """Folder with RAW+JPEG pairs AND a JPEG-only photo - orphan kept.
+
+        Repros the RAW+JPG → JPG-only mid-shoot scenario from feedback #4:
+        photos with paired RAW+JPG resolve to the RAW; photos shot in
+        JPG-only mode are kept as standalone files instead of being
+        silently dropped.
+        """
+        (tmp_path / "IMG_001.CR3").touch()
+        (tmp_path / "IMG_002.CR3").touch()
+        (tmp_path / "IMG_001.JPG").touch()
+        (tmp_path / "IMG_002.JPG").touch()
+        (tmp_path / "IMG_003.JPG").touch()  # orphan — no matching RAW
+
+        result = inspect_folder(str(tmp_path))
+        assert result['total'] == 3
+
+    def test_case_insensitive_stem_match(self, tmp_path):
+        """Mixed-case stems on case-folding filesystems still pair up."""
+        (tmp_path / "IMG_001.CR3").touch()
+        (tmp_path / "img_001.jpg").touch()  # same capture, different case
+
+        result = inspect_folder(str(tmp_path))
+        assert result['total'] == 1
 
     def test_kestrel_dir_normalization(self, tmp_path):
         """Passing .kestrel/ dir as input - normalized to parent."""


### PR DESCRIPTION
## Summary

Folder discovery in `folder_inspector`, `pipeline`, and `cli` shared a
"list RAWs first; fall back to JPEGs only if there are no RAWs at all"
pattern:

```python
files = [raw for raw in os.listdir(folder) if ...RAW...]
if not files:
    files = [jpg for jpg in os.listdir(folder) if ...JPEG...]
```

If any RAW file existed, every JPEG was dropped — including JPEGs with
no matching RAW partner. From a user feedback report:

> Bug when handling RAW+JPGs both in folders. Right now, the logic
> seems to ignore all JPG files if any RAWs exist. This is fine for
> most cases, but sometimes if the user shoots with RAW+JPG mode, then
> switches to JPG-ONLY or RAW-ONLY mode, we will drop some photos.
> Perhaps we can add filename comparison?

Concretely: a user shoots RAW+JPG for 200 frames, switches the camera
to JPG-only for the next 100, and ends up with one folder containing
200 RAW+JPG pairs plus 100 standalone JPEGs. Kestrel previously dropped
all 300 JPEGs from the analyzed set — the 100 JPG-only frames vanished
entirely.

## Fix

Add `select_camera_images` to `kestrel_analyzer/config.py`. It:

- Pairs JPEGs to RAWs by case-insensitive stem and drops the JPEG when
  a same-stem RAW exists (`IMG_001.CR3` wins over `IMG_001.JPG` /
  `img_001.jpg`).
- Keeps JPEGs that have no matching RAW so JPG-only frames survive.
- Reuses the existing `is_supported_image_file` predicate so hidden
  files and macOS `._`-AppleDouble companions stay filtered.

Replaces the three duplicate blocks in `folder_inspector.py`,
`kestrel_analyzer/pipeline.py`, and `cli.py` with one call so the
behavior is consistent across folder summary counts, the analysis
pipeline, and the CLI's first-image lookup.

Behavior unchanged for RAW-only or JPG-only folders.

## Test plan

- [x] Added `TestSelectCameraImages` (9 cases) covering RAW-only,
      JPG-only, paired-dropped, orphan-kept, case-insensitive stem
      match, AppleDouble filtering, mixed RAW formats, and empty input.
- [x] Updated `test_folder_inspector.py`: split the previous
      `test_raw_preferred_over_jpeg` into a paired-only case and added
      `test_orphan_jpeg_kept_alongside_raw` (the regression this PR
      fixes) and `test_case_insensitive_stem_match`.
- [x] `pytest tests/unit/test_config_helpers.py tests/unit/test_folder_inspector.py`
      → 39 passed.
- [x] Broader unit run (excluding modules that require cv2/PIL in the
      triage container): 279 passed, 1 pre-existing failure on
      `tests/unit/test_reject_move.py::TestRawJpgMixFixtures::test_move_raw_with_real_jpg_companion`
      that also fails on the dev tip — unrelated to this change.
- [ ] On-device verification: open a folder containing RAW+JPG pairs
      plus standalone JPEGs and confirm the folder count matches the
      expected `(raw_count + orphan_jpg_count)`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01EuncnpuyfQZx5HC5EGfesv)_