### PR TITLE
fix(sam-hq): cache batch decode runtime failure to avoid repeated CoreML retries

### DIFF
--- a/analyzer/kestrel_analyzer/ml/speciesnet_sam_hq.py
+++ b/analyzer/kestrel_analyzer/ml/speciesnet_sam_hq.py
@@ -751,6 +751,13 @@ class OnnxSamPredictor:
         self._decoder_requires_padded_im_size = "padded_im_size" in self._decoder_input_shapes
         self._supports_prompt_batching = self._detect_prompt_batch_support()
         self._batch_unsupported_logged = False
+        # Some execution providers (notably CoreMLExecutionProvider on macOS)
+        # advertise dynamic batch shapes via the ONNX graph but reject batched
+        # prompt input at runtime with "Unable to compute the prediction".
+        # When that happens we permanently downgrade to per-box decode for the
+        # rest of the session — otherwise every multi-detection image pays a
+        # failed batch attempt before falling back.
+        self._batch_decode_runtime_failed = False
         _provs = self._enc_session.get_providers()
         self.device = "ONNX/GPU" if is_gpu_active(_provs) else "ONNX/CPU"
         _active = _provs[0] if _provs else "unknown"
@@ -953,7 +960,7 @@ class OnnxSamPredictor:
             return []
         if len(boxes_xyxy) == 1:
             return [self.decode_box(image_embeddings, interm_embeddings, boxes_xyxy[0], resized_hw, original_hw)]
-        if not self._supports_prompt_batching:
+        if not self._supports_prompt_batching or self._batch_decode_runtime_failed:
             if not self._batch_unsupported_logged:
                 debug(
                     "[SAM-HQ] decoder ONNX export has fixed batch=1 on prompt inputs; "
@@ -1433,7 +1440,15 @@ class SpeciesNetSAMHQWrapper:
                         f"decoded={len(sam_results)} mode=per-box(fixed-batch-model)"
                     )
             except Exception as e:
-                warn(f"[SAM-HQ] batch decode failed, falling back to per-box decode: {e}")
+                if not getattr(self.predictor, "_batch_decode_runtime_failed", False):
+                    warn(
+                        f"[SAM-HQ] batch decode failed at runtime; downgrading to "
+                        f"per-box decode for the rest of this session: {e}"
+                    )
+                    try:
+                        self.predictor._batch_decode_runtime_failed = True
+                    except Exception:
+                        pass
                 sam_results = []
                 for c in sam_decode_candidates:
                     try:

--- a/analyzer/tests/unit/test_sam_hq_batch_fallback.py
+++ b/analyzer/tests/unit/test_sam_hq_batch_fallback.py
@@ -1,0 +1,67 @@
+"""Unit tests for SAM-HQ runtime batch-decode fallback caching.
+
+Verifies that once a batch decode_boxes() call fails at runtime (typical
+CoreMLExecutionProvider symptom on macOS), the predictor remembers and
+routes subsequent multi-box calls straight to per-box decode without
+re-attempting the batched path.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from kestrel_analyzer.ml.speciesnet_sam_hq import OnnxSamPredictor
+
+
+pytestmark = pytest.mark.unit
+
+
+class _StubPredictor:
+    """Minimal OnnxSamPredictor stand-in that records which decode path ran."""
+
+    def __init__(self, supports_prompt_batching: bool):
+        self._supports_prompt_batching = supports_prompt_batching
+        self._batch_decode_runtime_failed = False
+        self._batch_unsupported_logged = False
+        self.per_box_calls = 0
+        self.batched_calls = 0
+
+    def decode_box(self, *_args, **_kwargs):
+        self.per_box_calls += 1
+        return (object(), 0.5)
+
+    # Reuse the real routing logic so we test the actual code path.
+    decode_boxes = OnnxSamPredictor.decode_boxes
+
+
+def test_decode_boxes_routes_to_per_box_when_runtime_failed_flag_set():
+    pred = _StubPredictor(supports_prompt_batching=True)
+    pred._batch_decode_runtime_failed = True
+    boxes = [(0, 0, 10, 10), (20, 20, 30, 30), (40, 40, 50, 50)]
+
+    results = pred.decode_boxes(None, None, boxes, (256, 256), (400, 400))
+
+    assert len(results) == 3
+    assert pred.per_box_calls == 3
+    assert pred._batch_unsupported_logged is True
+
+
+def test_decode_boxes_routes_to_per_box_when_static_unsupported():
+    pred = _StubPredictor(supports_prompt_batching=False)
+    boxes = [(0, 0, 10, 10), (20, 20, 30, 30)]
+
+    pred.decode_boxes(None, None, boxes, (256, 256), (400, 400))
+
+    assert pred.per_box_calls == 2
+
+
+def test_decode_boxes_single_box_always_per_box_regardless_of_flag():
+    pred = _StubPredictor(supports_prompt_batching=True)
+    pred._batch_decode_runtime_failed = False
+
+    pred.decode_boxes(None, None, [(0, 0, 10, 10)], (256, 256), (400, 400))
+
+    assert pred.per_box_calls == 1


### PR DESCRIPTION
## Summary

`OnnxSamPredictor._detect_prompt_batch_support` inspects the SAM-HQ decoder ONNX graph and reports `True` when batch dims are dynamic, so `decode_boxes()` tries a single batched ONNX call for all box prompts on an image. On macOS with `CoreMLExecutionProvider` this batched call is rejected at runtime:

```
[SAM-HQ] batch decode failed, falling back to per-box decode:
[ONNXRuntimeError] : 1 : FAIL : Non-zero status code returned while running
CoreMLExecutionProvider_..._2 node. Status Message: Error executing model:
Unable to compute the prediction using a neural network model. It can be an
invalid input data or broken/unsupported model (error code: -1).
```

The wrapper at `analyzer/kestrel_analyzer/ml/speciesnet_sam_hq.py:1435` already catches the exception and falls back to per-box decode — so masks are still produced correctly — but the fallback decision is not remembered. Every multi-detection scene in the run pays a failed batch attempt and a noisy `warn`-level log line before the fallback runs. In one observed macOS session this exact warning was emitted dozens of times for a single 469-file analysis.

## Fix

Add `_batch_decode_runtime_failed` to `OnnxSamPredictor`. When the wrapper's `except` handler catches the first batched-decode failure it sets that flag on the predictor and downgrades the message to "downgrading to per-box decode for the rest of this session". `decode_boxes()` then routes straight to per-box for every subsequent multi-box call. The static-shape detection path (`_supports_prompt_batching = False`) is unchanged.

Scope is intentionally narrow:

- `OnnxSamPredictor.__init__` — one new instance attribute.
- `OnnxSamPredictor.decode_boxes` — one additional `or` clause on the existing per-box guard.
- `SpeciesNetSAMHQWrapper.run_image` `except Exception as e:` — set the flag once, soften the repeated warning.

No change to mask-decode math, no change to provider selection, no change to Windows/Linux behavior. The per-mask `try/except` in the per-box fallback loop is preserved so one bad box still can't kill the whole image.

## Test plan

- [x] `pytest tests/unit/test_sam_hq_batch_fallback.py` — three new unit tests covering: runtime-failed flag routes to per-box, static-unsupported still routes to per-box, single-box always per-box. Uses a stub predictor that borrows the real `decode_boxes` method, so no ONNX models needed.
- [ ] Manual macOS smoke on a multi-detection scene: confirm exactly one warn line per session and no observable change in mask output vs. current per-box fallback.
- [ ] Windows/Linux: no behavioral change expected (batched path still preferred until it actually fails at runtime, which it doesn't on CUDA/CPU EPs for this graph).

---
_Generated by [Claude Code](https://claude.ai/code/session_0121Nzef3Td8v4st1sYX8oLd)_