### PR TITLE
fix(api_bridge): mirror sample sets to a per-session temp dir on all platforms

### DIFF
--- a/analyzer/api_bridge.py
+++ b/analyzer/api_bridge.py
@@ -1951,6 +1951,45 @@ class Api:
     #  Sample Sets API                                                     #
     # ------------------------------------------------------------------ #
 
+    @staticmethod
+    def _mirror_sample_set_to_user_dir(bundled_path: str, debug_info: list) -> str | None:
+        """Copy a bundled sample set into the per-user data dir on first use.
+
+        MSIX / Microsoft Store installs land under ``Program Files\\WindowsApps``
+        which is read-only to the running process, so writing back to
+        ``<set>/.kestrel/kestrel_database.csv`` raises ``PermissionError``. The
+        mirror lives at ``<user_data_dir>/sample_sets/<set>`` and is reused on
+        subsequent launches; the readonly DB is re-copied from the bundle each
+        time so the sample state resets per session, matching the in-place
+        behaviour on writable installs.
+        """
+        try:
+            try:
+                from settings_utils import _get_user_data_dir
+            except ImportError:
+                from analyzer.settings_utils import _get_user_data_dir
+            set_name = os.path.basename(os.path.normpath(bundled_path))
+            mirror_root = os.path.join(_get_user_data_dir(), 'sample_sets')
+            mirror = os.path.join(mirror_root, set_name)
+            if not os.path.isdir(mirror):
+                os.makedirs(mirror_root, exist_ok=True)
+                shutil.copytree(bundled_path, mirror)
+                debug_info.append(f'[mirror] copied {bundled_path} -> {mirror}')
+            else:
+                debug_info.append(f'[mirror] reusing existing mirror at {mirror}')
+            mirror_readonly = os.path.join(mirror, '.kestrel', 'kestrel_database_readonly.csv')
+            mirror_db = os.path.join(mirror, '.kestrel', 'kestrel_database.csv')
+            if os.path.isfile(mirror_readonly):
+                try:
+                    shutil.copy2(mirror_readonly, mirror_db)
+                    debug_info.append(f'[mirror] restored sample DB at mirror: {mirror_db}')
+                except OSError as e:
+                    debug_info.append(f'[mirror] mirror DB restore failed: {e}')
+            return mirror
+        except Exception as e:
+            debug_info.append(f'[mirror] failed to mirror {bundled_path}: {e}')
+            return None
+
     def get_sample_sets_paths(self):
         """Return absolute paths to bundled sample bird-photo sets.
 
@@ -2092,22 +2131,34 @@ class Api:
                 kestrel_dir = os.path.join(full, '.kestrel')
                 kestrel_exists = os.path.isdir(kestrel_dir)
                 debug_info.append(f'[api]   Item "{name}": is_dir={is_dir}, has .kestrel={kestrel_exists}')
-                
+
                 if is_dir and kestrel_exists:
                     readonly_src = os.path.join(kestrel_dir, 'kestrel_database_readonly.csv')
                     db_dst       = os.path.join(kestrel_dir, 'kestrel_database.csv')
                     readonly_exists = os.path.isfile(readonly_src)
                     debug_info.append(f'[api]     readonly_src: {readonly_src} exists={readonly_exists}')
-                    
+
                     if readonly_exists:
                         try:
                             shutil.copy2(readonly_src, db_dst)
                             debug_info.append(f'[api]     Restored sample DB: {db_dst}')
-                        except Exception as e:
+                        except PermissionError as e:
+                            # Bundled location is read-only (e.g. an MS Store /
+                            # Program Files\WindowsApps install). Mirror the
+                            # sample set into the user data dir on first use and
+                            # use that copy for both reads and writes.
+                            debug_info.append(
+                                f'[api]     In-place restore denied ({e.__class__.__name__}); '
+                                f'mirroring sample set to user data dir'
+                            )
+                            mirror = self._mirror_sample_set_to_user_dir(full, debug_info)
+                            if mirror is not None:
+                                full = mirror
+                        except OSError as e:
                             debug_info.append(f'[api]     Failed to restore DB: {e}')
                     else:
                         debug_info.append(f'[api]     No readonly DB found at {readonly_src}')
-                    
+
                     paths.append(full)
                     debug_info.append(f'[api]     Added path: {full}')
             

--- a/analyzer/api_bridge.py
+++ b/analyzer/api_bridge.py
@@ -15,6 +15,7 @@ import re
 import shutil
 import subprocess
 import sys
+import tempfile
 import time
 import webbrowser
 
@@ -1952,31 +1953,66 @@ class Api:
     # ------------------------------------------------------------------ #
 
     @staticmethod
-    def _mirror_sample_set_to_user_dir(bundled_path: str, debug_info: list) -> str | None:
-        """Copy a bundled sample set into the per-user data dir on first use.
+    def _sample_sets_temp_root() -> str:
+        """Return the temp root that holds this session's sample-set mirrors.
 
-        MSIX / Microsoft Store installs land under ``Program Files\\WindowsApps``
-        which is read-only to the running process, so writing back to
-        ``<set>/.kestrel/kestrel_database.csv`` raises ``PermissionError``. The
-        mirror lives at ``<user_data_dir>/sample_sets/<set>`` and is reused on
-        subsequent launches; the readonly DB is re-copied from the bundle each
-        time so the sample state resets per session, matching the in-place
-        behaviour on writable installs.
+        Lives under the OS temp dir so it is writable on every install layout
+        — including read-only bundles (MSIX / ``Program Files\\WindowsApps``,
+        macOS Gatekeeper App Translocation) — and is the natural home for
+        transient data that is regenerated each session.
+        """
+        return os.path.join(tempfile.gettempdir(), 'ProjectKestrel', 'sample_sets')
+
+    @classmethod
+    def cleanup_sample_set_mirrors(cls) -> None:
+        """Best-effort removal of the temp sample-set mirror tree.
+
+        Called on clean shutdown. Non-critical: each launch wipes and rebuilds
+        the mirror before use (see :meth:`_mirror_sample_set_to_temp`), so a
+        crash that skips this leaves only stale data the next session
+        overwrites anyway.
         """
         try:
-            try:
-                from settings_utils import _get_user_data_dir
-            except ImportError:
-                from analyzer.settings_utils import _get_user_data_dir
+            root = cls._sample_sets_temp_root()
+            if os.path.isdir(root):
+                shutil.rmtree(root, ignore_errors=True)
+        except Exception:
+            pass
+
+    @classmethod
+    def _mirror_sample_set_to_temp(cls, bundled_path: str, debug_info: list) -> str | None:
+        """Mirror a bundled sample set into a writable per-session temp dir.
+
+        Runs on **every** platform, by default. Two reasons:
+
+        * The bundled tree may be read-only (MSIX / ``WindowsApps``, macOS App
+          Translocation), where writing back to
+          ``<set>/.kestrel/kestrel_database.csv`` raises ``PermissionError``
+          (errno 13) or ``OSError`` EROFS (errno 30). A writable mirror sidesteps
+          both without special-casing the errno.
+        * Even on writable installs, a fresh per-session mirror gives the
+          tutorial a predictable clean slate each run and auto-refreshes if the
+          bundled set ever changes.
+
+        The prior mirror is wiped first (wipe-on-load) so edits from an earlier
+        tutorial session never leak into a new one. Returns the mirror path, or
+        ``None`` if mirroring failed — the caller then falls back to the bundled
+        path with an in-place restore.
+        """
+        try:
             set_name = os.path.basename(os.path.normpath(bundled_path))
-            mirror_root = os.path.join(_get_user_data_dir(), 'sample_sets')
+            mirror_root = cls._sample_sets_temp_root()
             mirror = os.path.join(mirror_root, set_name)
-            if not os.path.isdir(mirror):
-                os.makedirs(mirror_root, exist_ok=True)
-                shutil.copytree(bundled_path, mirror)
-                debug_info.append(f'[mirror] copied {bundled_path} -> {mirror}')
-            else:
-                debug_info.append(f'[mirror] reusing existing mirror at {mirror}')
+            # Wipe-on-load: always start from a clean copy of the bundle.
+            if os.path.isdir(mirror):
+                shutil.rmtree(mirror, ignore_errors=True)
+            os.makedirs(mirror_root, exist_ok=True)
+            # dirs_exist_ok=True keeps the refresh robust even if the wipe above
+            # could not fully remove a locked file from a prior session.
+            shutil.copytree(bundled_path, mirror, dirs_exist_ok=True)
+            debug_info.append(f'[mirror] copied {bundled_path} -> {mirror}')
+            # Reset the live DB from the readonly source inside the mirror so the
+            # sample state is pristine for this session.
             mirror_readonly = os.path.join(mirror, '.kestrel', 'kestrel_database_readonly.csv')
             mirror_db = os.path.join(mirror, '.kestrel', 'kestrel_database.csv')
             if os.path.isfile(mirror_readonly):
@@ -2134,33 +2170,36 @@ class Api:
 
                 if is_dir and kestrel_exists:
                     readonly_src = os.path.join(kestrel_dir, 'kestrel_database_readonly.csv')
-                    db_dst       = os.path.join(kestrel_dir, 'kestrel_database.csv')
                     readonly_exists = os.path.isfile(readonly_src)
                     debug_info.append(f'[api]     readonly_src: {readonly_src} exists={readonly_exists}')
 
-                    if readonly_exists:
-                        try:
-                            shutil.copy2(readonly_src, db_dst)
-                            debug_info.append(f'[api]     Restored sample DB: {db_dst}')
-                        except PermissionError as e:
-                            # Bundled location is read-only (e.g. an MS Store /
-                            # Program Files\WindowsApps install). Mirror the
-                            # sample set into the user data dir on first use and
-                            # use that copy for both reads and writes.
-                            debug_info.append(
-                                f'[api]     In-place restore denied ({e.__class__.__name__}); '
-                                f'mirroring sample set to user data dir'
-                            )
-                            mirror = self._mirror_sample_set_to_user_dir(full, debug_info)
-                            if mirror is not None:
-                                full = mirror
-                        except OSError as e:
-                            debug_info.append(f'[api]     Failed to restore DB: {e}')
+                    # Default path (all platforms): mirror the bundled set into a
+                    # writable per-session temp dir and hand the UI that copy. The
+                    # mirror resets its own live DB from the readonly source, so it
+                    # is a clean-slate sample set for this run.
+                    mirror = self._mirror_sample_set_to_temp(full, debug_info)
+                    if mirror is not None:
+                        paths.append(mirror)
+                        debug_info.append(f'[api]     Added mirror path: {mirror}')
                     else:
-                        debug_info.append(f'[api]     No readonly DB found at {readonly_src}')
-
-                    paths.append(full)
-                    debug_info.append(f'[api]     Added path: {full}')
+                        # Fallback: temp mirror unavailable. Use the bundled set
+                        # directly and reset its DB in place, as before. Any
+                        # residual OSError (e.g. a read-only bundle) is left to
+                        # surface in the trace for future triage rather than
+                        # silently swallowed.
+                        db_dst = os.path.join(kestrel_dir, 'kestrel_database.csv')
+                        if readonly_exists:
+                            try:
+                                shutil.copy2(readonly_src, db_dst)
+                                debug_info.append(f'[api]     Restored sample DB in place: {db_dst}')
+                            except OSError as e:
+                                debug_info.append(
+                                    f'[api]     In-place DB restore failed (mirror unavailable): {e}'
+                                )
+                        else:
+                            debug_info.append(f'[api]     No readonly DB found at {readonly_src}')
+                        paths.append(full)
+                        debug_info.append(f'[api]     Added bundled path: {full}')
             
             # Success path: one-line summary at INFO. Full trace only at DEBUG.
             for line in debug_info:

--- a/analyzer/tests/unit/test_api_bridge_pure.py
+++ b/analyzer/tests/unit/test_api_bridge_pure.py
@@ -492,3 +492,68 @@ class TestCCAnalysisSettingsSnapshot:
         out = api._cc_analysis_settings_snapshot()
         # All 5 above are invalid → the snapshot has no entries, returns None.
         assert out is None or out == {}
+
+
+class TestSampleSetMirror:
+    """Tests for ``_mirror_sample_set_to_user_dir`` — the read-only-install
+    fallback that lets sample sets work when bundled under
+    ``Program Files\\WindowsApps`` (MSIX) or any other location the user
+    cannot write to."""
+
+    def _make_sample_set(self, root, name, db_text="header\nrow\n"):
+        """Build a minimal sample-set fixture: <root>/<name>/.kestrel/{db,readonly_db}."""
+        set_dir = root / name
+        kestrel = set_dir / ".kestrel"
+        kestrel.mkdir(parents=True)
+        (kestrel / "kestrel_database_readonly.csv").write_text(db_text)
+        (kestrel / "kestrel_database.csv").write_text("stale\n")
+        (set_dir / "photo.jpg").write_bytes(b"\xff\xd8\xff\xe0")  # JPEG header
+        return set_dir
+
+    def test_mirror_copies_tree_and_restores_db(self, api, tmp_path, monkeypatch):
+        """First-use mirror: copytree happens and DB is reset from readonly src."""
+        bundled = self._make_sample_set(tmp_path / "bundled", "backyard_birds",
+                                        db_text="pristine\n")
+        user_dir = tmp_path / "user_data"
+        monkeypatch.setattr("settings_utils._get_user_data_dir", lambda: str(user_dir))
+
+        debug: list = []
+        mirror = api._mirror_sample_set_to_user_dir(str(bundled), debug)
+
+        assert mirror is not None
+        mirror_path = Path(mirror)
+        assert mirror_path == user_dir / "sample_sets" / "backyard_birds"
+        assert (mirror_path / "photo.jpg").is_file()
+        # Live DB was reset from the readonly source (not the "stale" copy).
+        assert (mirror_path / ".kestrel" / "kestrel_database.csv").read_text() == "pristine\n"
+
+    def test_mirror_reuses_existing_then_refreshes_db(self, api, tmp_path, monkeypatch):
+        """Second call: tree is not re-copied, but the DB is reset each session."""
+        bundled = self._make_sample_set(tmp_path / "bundled", "backyard_birds",
+                                        db_text="pristine\n")
+        user_dir = tmp_path / "user_data"
+        monkeypatch.setattr("settings_utils._get_user_data_dir", lambda: str(user_dir))
+
+        # First call lays down the mirror.
+        api._mirror_sample_set_to_user_dir(str(bundled), [])
+        mirror_db = user_dir / "sample_sets" / "backyard_birds" / ".kestrel" / "kestrel_database.csv"
+        # Simulate the user "dirtying" the live DB during a tutorial session.
+        mirror_db.write_text("dirty\n")
+
+        debug: list = []
+        api._mirror_sample_set_to_user_dir(str(bundled), debug)
+
+        # Per-session reset: DB returns to the readonly state.
+        assert mirror_db.read_text() == "pristine\n"
+        # And we did reuse the existing tree rather than re-copy it.
+        assert any("reusing existing mirror" in line for line in debug)
+
+    def test_mirror_returns_none_on_copytree_failure(self, api, tmp_path, monkeypatch):
+        """If shutil.copytree raises (e.g. source missing), return None and log."""
+        monkeypatch.setattr("settings_utils._get_user_data_dir",
+                            lambda: str(tmp_path / "user_data"))
+        debug: list = []
+        # Source does not exist → copytree raises FileNotFoundError.
+        result = api._mirror_sample_set_to_user_dir(str(tmp_path / "missing_set"), debug)
+        assert result is None
+        assert any("failed to mirror" in line for line in debug)

--- a/analyzer/tests/unit/test_api_bridge_pure.py
+++ b/analyzer/tests/unit/test_api_bridge_pure.py
@@ -495,10 +495,10 @@ class TestCCAnalysisSettingsSnapshot:
 
 
 class TestSampleSetMirror:
-    """Tests for ``_mirror_sample_set_to_user_dir`` — the read-only-install
-    fallback that lets sample sets work when bundled under
-    ``Program Files\\WindowsApps`` (MSIX) or any other location the user
-    cannot write to."""
+    """Tests for ``_mirror_sample_set_to_temp`` — the platform-agnostic
+    per-session mirror that copies bundled sample sets into a writable temp
+    dir so the tutorial starts from a clean slate every run and read-only
+    installs (MSIX / ``WindowsApps``, macOS App Translocation) just work."""
 
     def _make_sample_set(self, root, name, db_text="header\nrow\n"):
         """Build a minimal sample-set fixture: <root>/<name>/.kestrel/{db,readonly_db}."""
@@ -510,50 +510,94 @@ class TestSampleSetMirror:
         (set_dir / "photo.jpg").write_bytes(b"\xff\xd8\xff\xe0")  # JPEG header
         return set_dir
 
+    def _pin_temp_root(self, monkeypatch, root):
+        """Point the temp-mirror root at a tmp_path-backed dir (no real OS temp)."""
+        monkeypatch.setattr(
+            api_bridge.Api, "_sample_sets_temp_root",
+            staticmethod(lambda: str(root)),
+        )
+
     def test_mirror_copies_tree_and_restores_db(self, api, tmp_path, monkeypatch):
         """First-use mirror: copytree happens and DB is reset from readonly src."""
         bundled = self._make_sample_set(tmp_path / "bundled", "backyard_birds",
                                         db_text="pristine\n")
-        user_dir = tmp_path / "user_data"
-        monkeypatch.setattr("settings_utils._get_user_data_dir", lambda: str(user_dir))
+        temp_root = tmp_path / "temp_mirror"
+        self._pin_temp_root(monkeypatch, temp_root)
 
         debug: list = []
-        mirror = api._mirror_sample_set_to_user_dir(str(bundled), debug)
+        mirror = api._mirror_sample_set_to_temp(str(bundled), debug)
 
         assert mirror is not None
         mirror_path = Path(mirror)
-        assert mirror_path == user_dir / "sample_sets" / "backyard_birds"
+        assert mirror_path == temp_root / "backyard_birds"
         assert (mirror_path / "photo.jpg").is_file()
         # Live DB was reset from the readonly source (not the "stale" copy).
         assert (mirror_path / ".kestrel" / "kestrel_database.csv").read_text() == "pristine\n"
 
-    def test_mirror_reuses_existing_then_refreshes_db(self, api, tmp_path, monkeypatch):
-        """Second call: tree is not re-copied, but the DB is reset each session."""
+    def test_mirror_wipes_prior_session_then_refreshes_db(self, api, tmp_path, monkeypatch):
+        """Wipe-on-load: a second call discards last session's edits AND any
+        files that no longer exist in the bundle, then resets the DB."""
         bundled = self._make_sample_set(tmp_path / "bundled", "backyard_birds",
                                         db_text="pristine\n")
-        user_dir = tmp_path / "user_data"
-        monkeypatch.setattr("settings_utils._get_user_data_dir", lambda: str(user_dir))
+        temp_root = tmp_path / "temp_mirror"
+        self._pin_temp_root(monkeypatch, temp_root)
 
         # First call lays down the mirror.
-        api._mirror_sample_set_to_user_dir(str(bundled), [])
-        mirror_db = user_dir / "sample_sets" / "backyard_birds" / ".kestrel" / "kestrel_database.csv"
-        # Simulate the user "dirtying" the live DB during a tutorial session.
+        api._mirror_sample_set_to_temp(str(bundled), [])
+        mirror_dir = temp_root / "backyard_birds"
+        mirror_db = mirror_dir / ".kestrel" / "kestrel_database.csv"
+        # Simulate a prior tutorial session: dirty the DB and drop a stray file.
         mirror_db.write_text("dirty\n")
+        stray = mirror_dir / "user_added.txt"
+        stray.write_text("leftover\n")
 
         debug: list = []
-        api._mirror_sample_set_to_user_dir(str(bundled), debug)
+        api._mirror_sample_set_to_temp(str(bundled), debug)
 
-        # Per-session reset: DB returns to the readonly state.
+        # Clean slate: DB reset to readonly state and the stray file is gone.
         assert mirror_db.read_text() == "pristine\n"
-        # And we did reuse the existing tree rather than re-copy it.
-        assert any("reusing existing mirror" in line for line in debug)
+        assert not stray.exists()
+        assert any("copied" in line for line in debug)
+
+    def test_mirror_auto_refreshes_when_bundle_changes(self, api, tmp_path, monkeypatch):
+        """If the bundled set changes between sessions, the mirror picks it up."""
+        bundled = self._make_sample_set(tmp_path / "bundled", "backyard_birds",
+                                        db_text="v1\n")
+        temp_root = tmp_path / "temp_mirror"
+        self._pin_temp_root(monkeypatch, temp_root)
+
+        api._mirror_sample_set_to_temp(str(bundled), [])
+        # Ship a new bundled version (e.g. an app update changes the readonly DB).
+        (bundled / ".kestrel" / "kestrel_database_readonly.csv").write_text("v2\n")
+        (bundled / "new_photo.jpg").write_bytes(b"\xff\xd8\xff\xe0")
+
+        mirror = Path(api._mirror_sample_set_to_temp(str(bundled), []))
+        assert (mirror / ".kestrel" / "kestrel_database.csv").read_text() == "v2\n"
+        assert (mirror / "new_photo.jpg").is_file()
 
     def test_mirror_returns_none_on_copytree_failure(self, api, tmp_path, monkeypatch):
         """If shutil.copytree raises (e.g. source missing), return None and log."""
-        monkeypatch.setattr("settings_utils._get_user_data_dir",
-                            lambda: str(tmp_path / "user_data"))
+        self._pin_temp_root(monkeypatch, tmp_path / "temp_mirror")
         debug: list = []
         # Source does not exist → copytree raises FileNotFoundError.
-        result = api._mirror_sample_set_to_user_dir(str(tmp_path / "missing_set"), debug)
+        result = api._mirror_sample_set_to_temp(str(tmp_path / "missing_set"), debug)
         assert result is None
         assert any("failed to mirror" in line for line in debug)
+
+    def test_cleanup_removes_temp_root(self, api, tmp_path, monkeypatch):
+        """cleanup_sample_set_mirrors removes the whole temp mirror tree."""
+        bundled = self._make_sample_set(tmp_path / "bundled", "backyard_birds")
+        temp_root = tmp_path / "temp_mirror"
+        self._pin_temp_root(monkeypatch, temp_root)
+
+        api._mirror_sample_set_to_temp(str(bundled), [])
+        assert temp_root.is_dir()
+
+        api.cleanup_sample_set_mirrors()
+        assert not temp_root.exists()
+
+    def test_cleanup_is_noop_when_absent(self, api, tmp_path, monkeypatch):
+        """cleanup is safe to call when no mirror was ever created."""
+        self._pin_temp_root(monkeypatch, tmp_path / "never_created")
+        # Must not raise.
+        api.cleanup_sample_set_mirrors()

--- a/analyzer/visualizer.py
+++ b/analyzer/visualizer.py
@@ -1051,6 +1051,14 @@ def main():
                 api.cleanup_tracked_culling_caches()
         except Exception as e:
             warn('Cache cleanup during shutdown failed:', e)
+        # Best-effort removal of this session's temp sample-set mirrors. Skipping
+        # it (e.g. on crash) is harmless — the next launch wipes and rebuilds the
+        # mirror before use.
+        try:
+            if api is not None and hasattr(api, 'cleanup_sample_set_mirrors'):
+                api.cleanup_sample_set_mirrors()
+        except Exception as e:
+            warn('Sample-set mirror cleanup during shutdown failed:', e)
         try:
             server.shutdown()
             server.server_close()


### PR DESCRIPTION
## Summary
`get_sample_sets_paths` handed back paths inside the bundled `_internal/sample_sets/` tree, and `write_kestrel_csv` (plus the per-session readonly→live DB reset) then wrote back into that same tree. On a writable install this is fine; on a read-only install it fails — MSIX / Microsoft Store puts the runtime under `Program Files\WindowsApps\…` (`PermissionError`, errno 13), and macOS Gatekeeper App Translocation relocates the `.app` to a read-only quarantine path (`OSError` EROFS, errno 30).

This PR makes the loader **mirror each bundled sample set into a writable per-session temp dir on every platform, by default**, and hand the UI that copy:

- Mirror lives at `<os-temp>/ProjectKestrel/sample_sets/<set>`; the mirror's live DB is reset from `kestrel_database_readonly.csv` so it's a clean sample set for the run.
- **Wipe-on-load:** the mirror is removed and re-copied from the bundle on each load, so every tutorial run starts from a predictable clean slate and the demo set auto-refreshes if the bundled copy ever changes.
- **Read-only installs just work** without special-casing the errno — the writable copy is the default path, not an exception handler. This is what closes both the MSIX (errno 13) and macOS App Translocation (errno 30 / EROFS) cases.
- **Fallback preserved:** if mirroring fails for any reason, the loader uses the bundled set directly and restores its DB in place, exactly as before — letting any residual `OSError` surface in the debug trace for future triage rather than swallowing it.
- **Cleanup:** a best-effort `rmtree` of the temp mirror root runs on clean shutdown (`visualizer.py`). Non-critical by design — wipe-on-load already guarantees a clean slate even when shutdown cleanup is skipped (e.g. on a crash).

## Reports surfaced by this work
- Windows Microsoft Store install: recovery dialogs with a runtime tail full of `[ERROR] [API] write_kestrel_csv(...sample_sets\backyard_birds) error: [Errno 13] Permission denied`. The tutorial auto-loads `backyard_birds` on Welcome, and after the failed restore each UI mutation triggered another denied write until the user force-closed.
- macOS App Translocation: the same `write_kestrel_csv(...sample_sets/backyard_birds)` storm but with errno **30 (EROFS)** instead of 13.

Both now route through the writable temp mirror.

## Test plan
- [x] `python -m pytest analyzer/tests/unit/test_api_bridge_pure.py` — 54 pass. New `TestSampleSetMirror` covers: temp mirror (copy + DB reset), wipe-on-load discarding a prior session's edits and stray files, auto-refresh when the bundle changes, graceful `None` on copy failure, and the shutdown-cleanup helper (removes tree / no-op when absent).
- [x] Smoke-tested `get_sample_sets_paths` against the real bundled sets: both `backyard_birds` and `forest_trail` resolve into the temp dir with a live DB; a dirtied DB is reset on the next load; `cleanup_sample_set_mirrors` removes the tree.
- [ ] On a Microsoft Store / WindowsApps install: open Welcome, start the tutorial, confirm `backyard_birds` loads with no `[ERROR] [API] write_kestrel_csv` entries and edits persist between dialogs.
- [ ] On a macOS App-Translocated `.app` (run from the DMG without moving to /Applications): same check, confirm no `[Errno 30]` storm.
- [ ] On a writable install (Inno / dev): confirm the tutorial still loads and the temp mirror is cleaned up on close.