### PR TITLE
Filter pywebview orphan-callback exceptions from crash reports

### DIFF
--- a/analyzer/tests/unit/test_pywebview_orphan_callback_filter.py
+++ b/analyzer/tests/unit/test_pywebview_orphan_callback_filter.py
@@ -1,0 +1,67 @@
+"""Unit tests for the pywebview orphan-callback filter in the crash handler.
+
+When pywebview's JS-side promise callback is gone (because the page reloaded
+or navigated between the API call and Python's return), it raises
+``JavascriptException`` with a "_returnValuesCallbacks.<fn>.<id> is not a
+function" message on its background dispatch thread. Kestrel's
+``threading.excepthook`` must treat this as a no-op rather than a crash.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+try:
+    from visualizer import _is_pywebview_orphan_callback
+except Exception as e:  # pragma: no cover - environment-dependent
+    pytest.skip(f'visualizer module not importable in this env: {e}', allow_module_level=True)
+
+
+pytestmark = pytest.mark.unit
+
+
+# Stand-in matching pywebview's ``webview.errors.JavascriptException`` by
+# name only — the filter uses ``exc_type.__name__`` for portability across
+# pywebview versions and avoids importing the GUI library at test time.
+JavascriptException = type('JavascriptException', (Exception,), {})
+
+
+class TestIsPywebviewOrphanCallback:
+    def test_matches_inspect_folders_orphan(self):
+        msg = (
+            "{'name': 'TypeError', "
+            "'stack': 'TypeError: window.pywebview._returnValuesCallbacks."
+            "inspect_folders.3212165498894174 is not a function\\n', "
+            "'message': 'window.pywebview._returnValuesCallbacks."
+            "inspect_folders.3212165498894174 is not a function'}"
+        )
+        exc = JavascriptException(msg)
+        assert _is_pywebview_orphan_callback(JavascriptException, exc) is True
+
+    def test_matches_any_api_function_orphan(self):
+        msg = (
+            "window.pywebview._returnValuesCallbacks.choose_directories."
+            "987654321 is not a function"
+        )
+        exc = JavascriptException(msg)
+        assert _is_pywebview_orphan_callback(JavascriptException, exc) is True
+
+    def test_rejects_other_js_exception(self):
+        exc = JavascriptException("ReferenceError: foo is not defined")
+        assert _is_pywebview_orphan_callback(JavascriptException, exc) is False
+
+    def test_rejects_non_js_exception(self):
+        exc = RuntimeError(
+            "window.pywebview._returnValuesCallbacks.x.1 is not a function"
+        )
+        assert _is_pywebview_orphan_callback(RuntimeError, exc) is False
+
+    def test_rejects_none(self):
+        assert _is_pywebview_orphan_callback(None, None) is False
+
+    def test_rejects_partial_message(self):
+        exc = JavascriptException("_returnValuesCallbacks is missing")
+        assert _is_pywebview_orphan_callback(JavascriptException, exc) is False

--- a/analyzer/visualizer.py
+++ b/analyzer/visualizer.py
@@ -278,6 +278,25 @@ def _mark_session_clean_exit() -> None:
         pass
 
 
+def _is_pywebview_orphan_callback(exc_type, exc_value) -> bool:
+    """Return True for the benign pywebview "orphan callback" JS exception.
+
+    pywebview resolves a Python API call by evaluating
+    ``window.pywebview._returnValuesCallbacks.<fn>.<id>(...)`` on its
+    background thread. If the JS-side context (window/page) navigated or
+    reloaded between the API call and Python's return, that callback no
+    longer exists and pywebview raises ``JavascriptException`` with a
+    ``"... is not a function"`` message. This is not a Kestrel defect — the
+    caller is gone — so the crash handler treats it as a no-op.
+    """
+    if exc_type is None or exc_value is None:
+        return False
+    if exc_type.__name__ != 'JavascriptException':
+        return False
+    msg = str(exc_value)
+    return '_returnValuesCallbacks' in msg and 'is not a function' in msg
+
+
 def _mark_session_exit_reason(reason: str) -> None:
     """Atomically record the cause of an in-progress shutdown.
 
@@ -821,6 +840,19 @@ def main():
         try:
             import traceback as _tb
             thread_name = getattr(args.thread, 'name', 'unknown')
+            # pywebview raises JavascriptException from its background dispatch
+            # thread when a Python API call returns but the JS-side promise
+            # callback is gone (page reloaded / navigated to another HTML file
+            # while the call was in flight). The "_returnValuesCallbacks.<fn>.
+            # <id> is not a function" message is the canonical signature. It is
+            # not a Kestrel defect — the caller went away — so log it once and
+            # don't mark the session as crashed or ship a crash report.
+            if _is_pywebview_orphan_callback(args.exc_type, args.exc_value):
+                warn(
+                    f'[Thread {thread_name!r}] pywebview orphan callback '
+                    f'(JS context navigated before Python returned); ignored.'
+                )
+                return
             tb_str = ''.join(_tb.format_exception(args.exc_type, args.exc_value, args.exc_traceback))
             error(f'[Thread {thread_name!r}] Uncaught exception: {args.exc_type.__name__}: {args.exc_value}')
             error(f'[Thread {thread_name!r}] Traceback:\n{tb_str}')


### PR DESCRIPTION
## Summary
Stops the crash reporter from shipping pywebview "orphan callback" `JavascriptException`s as Kestrel crashes. The Rufous-Hummingbird crash queue logged 148 of these in 24 hours from a single user with a slow Synology UNC share — every one a benign artifact of the user navigating between pages while a Python API call (e.g. `inspect_folders`) was in flight.

## Root cause
When JS calls `window.pywebview.api.<fn>(...)`, pywebview stores a Promise-resolver callback at `window.pywebview._returnValuesCallbacks.<fn>[<callId>]`. The Python method runs on a background dispatch thread; when it returns, pywebview's `evaluate_js` invokes that callback to resolve the JS-side Promise.

If the user reloads or navigates the window between the call and the return, `window` is wiped and the callback is gone. pywebview raises `JavascriptException: ... _returnValuesCallbacks.<fn>.<id> is not a function` from its dispatch thread; Kestrel's `threading.excepthook` (visualizer.py) captures every uncaught thread exception and ships it as a crash. One slow API call + a few clicks = a flood.

## Fix
`_thread_excepthook` now consults a small pure helper, `_is_pywebview_orphan_callback`, before deciding to report. If the exception type's name is `JavascriptException` and the message contains both `_returnValuesCallbacks` and `is not a function`, the handler logs a single `warn` line and returns — no `exit_reason=crash`, no telemetry upload.

The helper is matched on `exc_type.__name__` rather than an `isinstance` check so the test suite doesn't need to import `webview`/GUI deps.

## Test plan
- [x] New `analyzer/tests/unit/test_pywebview_orphan_callback_filter.py` — 6 cases covering the canonical inspect_folders message, a different API function, an unrelated JS exception, a same-message-but-wrong-type Python exception, `None`, and a partial-message false negative.
- [x] `python3 -m pytest analyzer/tests/unit/test_pywebview_orphan_callback_filter.py analyzer/tests/unit/test_session_lifecycle.py -v` → 18 passed.
- [ ] Real-world: next inspect_folders crash from the affected user should now produce a single `[Thread ...] pywebview orphan callback ... ignored.` warn in the runtime log and no entry in the `/api/crash` queue.

## Notes
- Scope is intentionally narrow: only the precise `_returnValuesCallbacks` + `is not a function` signature is suppressed. Other JavaScript exceptions (a real `ReferenceError`, a Kestrel-side JS bug surfaced through `evaluate_js`) still flow through to the crash reporter.
- No JS changes. The underlying behaviour (in-flight API calls outliving their page) is a pywebview design constraint; the right place to handle it is at the crash reporter's filter boundary, not by adding a version-counter to every `inspect_folders` call site.

---
_Generated by [Claude Code](https://claude.ai/code/session_019a46SmEjuqSUp1EiERNZpV)_