### PR TITLE
fix(scene-grid): keep Folder Actions menu on top of later folder rows

### DIFF
--- a/analyzer/css/grid.css
+++ b/analyzer/css/grid.css
@@ -952,6 +952,16 @@
   font-size: 13px;
 }
 
+/* Each .folder-group-header is position:sticky with z-index:10, which
+   creates a per-header stacking context. Sibling headers therefore paint
+   in DOM order, so a later folder row can obscure an earlier row's open
+   Folder Actions menu even though the menu is z-index:1000 within its own
+   header. Raise the owning header above other headers only while its menu
+   is present. */
+.folder-group-header:has(.folder-group-actions-menu) {
+  z-index: 1001;
+}
+
 .folder-group-actions-item {
   padding: 8px 14px;
   cursor: pointer;


### PR DESCRIPTION
## Summary

User-reported bug via in-app feedback against Rock-Wren: opening the **Folder Actions** dropdown on the 1st or 2nd folder in the scene grid draws the menu **behind** the 3rd folder's header row.

## Root cause

`.folder-group-header` is `position: sticky` with `z-index: 10`, which creates a stacking context per header. The Folder Actions menu is `position: absolute` with `z-index: 1000` inside `.folder-group-actions-wrap` (`position: relative`, no z-index), so the menu's 1000 is contained within its owning header's stacking context. Sibling headers all share `z-index: 10` at their parent's level, and equal z-indexes paint in DOM order — so a later folder-group's header paints on top of an earlier folder's open menu.

## Fix

Single-file CSS change: raise the owning header's z-index above other sticky headers only when the menu is currently mounted inside it, via `:has()`. `:has()` is already used elsewhere in the codebase and is supported by every WebView2/WKWebView shipped with recent Kestrel builds.

```css
.folder-group-header:has(.folder-group-actions-menu) {
  z-index: 1001;
}
```

Chosen `1001` because it needs to sit above sibling headers (10) but well below dialog/tutorial/tooltip layers (9000+). No companion JS change required — the menu element is only in the DOM while open, so the selector self-toggles.

Reproduces on `origin/dev` (Rock-Wren tag matches `dev` for the touched files); the fix applies cleanly to `dev`.

## Test plan

- [ ] Load a folder set with ≥ 3 folder groups, all collapsed or with short bodies.
- [ ] Open Folder Actions on folder #1 → menu paints above folder #2/#3 headers.
- [ ] Open Folder Actions on folder #2 → menu paints above folder #3 header.
- [ ] Verify that closing the menu (Escape, outside click, re-click, item click) restores the header to its normal z-index.
- [ ] Verify that dialogs opened from menu items (Adjust Capture Time, Clear Kestrel Data, etc.) still layer above the header.

---
_Generated by [Claude Code](https://claude.ai/code/session_01V9UEUtN85UHw8osDYGKb3i)_