### PR TITLE
fix(raw-preview): Raw Zoom fallback to embedded JPEG for Nikon Z8 HE / HE* NEFs

### DIFF
--- a/analyzer/api_bridge.py
+++ b/analyzer/api_bridge.py
@@ -6597,42 +6597,80 @@ class Api:
                 f'[raw-preview] Processing RAW file {filename} '
                 f'(exp={exp_correction:+.3f}, mode={render_mode}, cache={use_cache})'
             )
-            with rawpy.imread(full_path) as raw:
-                try:
-                    sizes = raw.sizes
-                    raw_sizes = {
-                        'width': int(getattr(sizes, 'width', 0) or 0),
-                        'height': int(getattr(sizes, 'height', 0) or 0),
-                        'raw_width': int(getattr(sizes, 'raw_width', 0) or 0),
-                        'raw_height': int(getattr(sizes, 'raw_height', 0) or 0),
-                        'iwidth': int(getattr(sizes, 'iwidth', 0) or 0),
-                        'iheight': int(getattr(sizes, 'iheight', 0) or 0),
-                        'flip': int(getattr(sizes, 'flip', 0) or 0),
-                    }
-                except Exception:
-                    raw_sizes = {}
+            rgb = None
+            raw_sizes = {}
+            used_embedded_fallback = False
+            embedded_fallback_reason = None
+            embedded_jpeg_bytes = None
+            embedded_jpeg_dims = None
+            try:
+                with rawpy.imread(full_path) as raw:
+                    try:
+                        sizes = raw.sizes
+                        raw_sizes = {
+                            'width': int(getattr(sizes, 'width', 0) or 0),
+                            'height': int(getattr(sizes, 'height', 0) or 0),
+                            'raw_width': int(getattr(sizes, 'raw_width', 0) or 0),
+                            'raw_height': int(getattr(sizes, 'raw_height', 0) or 0),
+                            'iwidth': int(getattr(sizes, 'iwidth', 0) or 0),
+                            'iheight': int(getattr(sizes, 'iheight', 0) or 0),
+                            'flip': int(getattr(sizes, 'flip', 0) or 0),
+                        }
+                    except Exception:
+                        raw_sizes = {}
 
-                linear_scale = float(max(0.25, min(8.0, 2.0 ** exp_correction)))
-                if use_no_auto_bright:
-                    rgb = raw.postprocess(
-                        no_auto_bright=True,
-                        exp_shift=linear_scale,
-                        exp_preserve_highlights=_preserve_highlights_for_stops(exp_correction),
-                    )
-                else:
-                    if exp_correction != 0.0:
+                    linear_scale = float(max(0.25, min(8.0, 2.0 ** exp_correction)))
+                    if use_no_auto_bright:
                         rgb = raw.postprocess(
+                            no_auto_bright=True,
                             exp_shift=linear_scale,
                             exp_preserve_highlights=_preserve_highlights_for_stops(exp_correction),
                         )
                     else:
-                        rgb = raw.postprocess()
+                        if exp_correction != 0.0:
+                            rgb = raw.postprocess(
+                                exp_shift=linear_scale,
+                                exp_preserve_highlights=_preserve_highlights_for_stops(exp_correction),
+                            )
+                        else:
+                            rgb = raw.postprocess()
+            except rawpy.LibRawFileUnsupportedError as raw_err:
+                # LibRaw parsed the container but couldn't decompress the
+                # sensor data. Most common trigger: Nikon Z8 / Z9 High-
+                # Efficiency (HE / HE*) NEFs, which use intoPIX's
+                # proprietary TicoRAW codec that neither LibRaw nor rawpy
+                # can decode. The full-resolution embedded JPEG preview
+                # is still extractable and matches the sensor pixel
+                # count to within crop margins — good enough to serve as
+                # the RAW zoom instead of falling all the way back to
+                # the low-resolution thumbnail stub on the JS side.
+                # Exposure correction is not available on this path
+                # (the embedded JPEG is a fixed in-camera render).
+                embedded_jpeg_bytes, embedded_jpeg_dims = (
+                    self._extract_full_res_embedded_jpeg(full_path)
+                )
+                if embedded_jpeg_bytes is None:
+                    # No embedded preview either — propagate the original
+                    # LibRaw error to the outer handler for logging.
+                    raise
+                used_embedded_fallback = True
+                embedded_fallback_reason = str(raw_err)
+                debug(
+                    f'[raw-preview] RAW decode unsupported for {filename}; '
+                    f'served embedded {embedded_jpeg_dims[0]}x{embedded_jpeg_dims[1]} '
+                    f'JPEG preview instead ({raw_err})'
+                )
 
-            img = Image.fromarray(rgb)
+            if used_embedded_fallback:
+                jpg_bytes = embedded_jpeg_bytes
+                img_width, img_height = embedded_jpeg_dims
+            else:
+                img = Image.fromarray(rgb)
+                buf = BytesIO()
+                img.save(buf, format='JPEG', quality=90, subsampling=0, optimize=False, progressive=False)
+                jpg_bytes = buf.getvalue()
+                img_width, img_height = img.width, img.height
 
-            buf = BytesIO()
-            img.save(buf, format='JPEG', quality=90, subsampling=0, optimize=False, progressive=False)
-            jpg_bytes = buf.getvalue()
             wrote_cache = False
             if use_cache:
                 os.makedirs(cache_dir, exist_ok=True)
@@ -6655,22 +6693,84 @@ class Api:
                 'cache_written': bool(wrote_cache),
                 'storage_preview_path': storage_preview_path,
                 'raw_sizes': raw_sizes,
-                'postprocess_rgb_shape': list(rgb.shape) if hasattr(rgb, 'shape') else [],
-                'postprocess_rgb_dtype': str(getattr(rgb, 'dtype', '')),
                 'jpeg_bytes': int(len(jpg_bytes)),
                 'jpeg_kb': round(len(jpg_bytes) / 1024.0, 2),
-                'jpeg_dimensions': {'width': int(img.width), 'height': int(img.height)},
+                'jpeg_dimensions': {'width': int(img_width), 'height': int(img_height)},
             })
+            if used_embedded_fallback:
+                debug_meta['fallback'] = 'embedded_jpeg_preview'
+                debug_meta['fallback_reason'] = embedded_fallback_reason
+            else:
+                debug_meta['postprocess_rgb_shape'] = list(rgb.shape) if hasattr(rgb, 'shape') else []
+                debug_meta['postprocess_rgb_dtype'] = str(getattr(rgb, 'dtype', ''))
             if debug_logging_enabled:
                 debug(f'[raw-preview] debug: {json.dumps(debug_meta, sort_keys=True)}')
-            if use_cache:
-                debug(f'[raw-preview] Done, {len(jpg_bytes)//1024}KB JPEG ({img.width}x{img.height}), cached as {cache_name}')
+            if used_embedded_fallback:
+                debug(
+                    f'[raw-preview] Done (embedded fallback), '
+                    f'{len(jpg_bytes)//1024}KB JPEG ({img_width}x{img_height})'
+                    + (f', cached as {cache_name}' if wrote_cache else ', cache disabled')
+                )
+            elif use_cache:
+                debug(f'[raw-preview] Done, {len(jpg_bytes)//1024}KB JPEG ({img_width}x{img_height}), cached as {cache_name}')
             else:
-                debug(f'[raw-preview] Done, {len(jpg_bytes)//1024}KB JPEG ({img.width}x{img.height}), cache disabled')
-            return {'success': True, 'data': b64, 'mime': 'image/jpeg', 'debug': debug_meta}
+                debug(f'[raw-preview] Done, {len(jpg_bytes)//1024}KB JPEG ({img_width}x{img_height}), cache disabled')
+            response = {'success': True, 'data': b64, 'mime': 'image/jpeg', 'debug': debug_meta}
+            if used_embedded_fallback:
+                response['fallback'] = 'embedded_jpeg_preview'
+                response['fallback_reason'] = embedded_fallback_reason
+            return response
         except Exception as e:
             error(f'[API] read_raw_full error: {e} (filename={filename}, root_path={root_path_real if "root_path_real" in locals() else root_path})')
             return {'success': False, 'error': str(e)}
+
+    def _extract_full_res_embedded_jpeg(self, full_path: str):
+        """Reopen a RAW container and pull out the largest embedded JPEG
+        preview as (bytes, (width, height)), or (None, None) if none is
+        recoverable. A fresh rawpy.imread handle is required because a
+        prior failed postprocess() leaves the previous handle in an
+        out-of-order state.
+
+        Applies the JPEG's own EXIF Orientation tag so the returned
+        bytes are already upright. When the JPEG needs no rotation (the
+        common Z8 case for a landscape shot), the original in-camera
+        JPEG bytes are returned untouched to preserve full quality —
+        Pillow only re-encodes when it also has to rotate.
+
+        Used by read_raw_full() as the fallback path when LibRaw can
+        parse the container but not decode the sensor data (Nikon Z8/Z9
+        HE / HE* NEFs, the most common real-world trigger).
+        """
+        import rawpy
+        from io import BytesIO
+        from PIL import Image, ImageOps
+        try:
+            with rawpy.imread(full_path) as raw:
+                thumb = raw.extract_thumb()
+        except (rawpy.LibRawNoThumbnailError,
+                rawpy.LibRawUnsupportedThumbnailError,
+                rawpy.LibRawFileUnsupportedError,
+                rawpy.LibRawIOError):
+            return None, None
+        except Exception:
+            return None, None
+        if thumb is None or not getattr(thumb, 'data', None):
+            return None, None
+        if thumb.format != rawpy.ThumbFormat.JPEG:
+            return None, None
+        try:
+            with Image.open(BytesIO(thumb.data)) as prev_img:
+                exif_orient = prev_img.getexif().get(0x0112, 1)
+                if exif_orient in (None, 1):
+                    return thumb.data, (int(prev_img.width), int(prev_img.height))
+                oriented = ImageOps.exif_transpose(prev_img)
+                if oriented.mode != 'RGB':
+                    oriented = oriented.convert('RGB')
+                obuf = BytesIO()
+                oriented.save(obuf, format='JPEG', quality=95, subsampling=0)
+                return obuf.getvalue(), (int(oriented.width), int(oriented.height))
+        except Exception:
+            return None, None
 
     def cleanup_culling_cache(self, root_path: str):
         """Remove the .kestrel/culling_TMP folder to free up space."""

--- a/analyzer/js/scene-zoom.js
+++ b/analyzer/js/scene-zoom.js
@@ -405,7 +405,16 @@
                   applySceneZoomTransform(curImg, sceneZoomThumbEl, zoomLastX, zoomLastY, sceneZoomScale);
                 }
               };
-              if (box) box.dataset.rawLabel = `RAW (${formatExposureEv(expCorrEffective)} EV)`;
+              // When the Python side fell back to the embedded full-res
+              // JPEG preview (LibRaw can't decode HE/HE* Z8 NEFs), the
+              // exposure-correction EV is not applied — label it that
+              // way so the user isn't misled by an EV number that had
+              // no effect. Otherwise show the actual applied EV.
+              if (box) {
+                box.dataset.rawLabel = (res && res.fallback === 'embedded_jpeg_preview')
+                  ? 'RAW (embedded preview)'
+                  : `RAW (${formatExposureEv(expCorrEffective)} EV)`;
+              }
               box.classList.add('raw-loaded');
               if (sceneZoomThumbEl) {
                 applySceneZoomTransform(curImg, sceneZoomThumbEl, zoomLastX, zoomLastY, sceneZoomScale);

--- a/analyzer/tests/unit/test_read_raw_full_he_fallback.py
+++ b/analyzer/tests/unit/test_read_raw_full_he_fallback.py
@@ -1,0 +1,289 @@
+"""Unit tests for Api.read_raw_full()'s embedded-JPEG fallback for RAW
+files whose sensor data can't be decoded by LibRaw (Nikon Z8/Z9 HE / HE*
+NEFs are the canonical trigger — intoPIX TicoRAW ships in neither
+LibRaw nor rawpy).
+
+Uses mocked rawpy handles so the tests are fast and CI-friendly. A
+smoke check against the real Z8 samples on raw.pixls.us was verified
+manually during development.
+"""
+
+from __future__ import annotations
+
+import io
+import os
+from pathlib import Path
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+from PIL import Image
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+import rawpy
+import api_bridge
+
+
+pytestmark = pytest.mark.unit
+
+
+def _make_jpeg_bytes(size=(8256, 5504), color=(100, 140, 200)) -> bytes:
+    """Return raw JPEG bytes at the requested size. Used to fake the
+    full-resolution embedded preview extracted by extract_thumb()."""
+    img = Image.new("RGB", size, color=color)
+    buf = io.BytesIO()
+    img.save(buf, format="JPEG", quality=90)
+    return buf.getvalue()
+
+
+def _make_rotated_jpeg_bytes(size=(200, 100)) -> bytes:
+    """Return JPEG bytes carrying an EXIF Orientation=6 (rotate 90° CW).
+    Used to verify the fallback applies orientation."""
+    img = Image.new("RGB", size, color=(50, 200, 90))
+    exif = img.getexif()
+    exif[0x0112] = 6  # rotate 90° CW
+    buf = io.BytesIO()
+    img.save(buf, format="JPEG", quality=90, exif=exif)
+    return buf.getvalue()
+
+
+def _mock_raw_thumb(*, thumb_format=None, thumb_data=None, raise_on_thumb=None):
+    """Build a context-manager mock that mimics rawpy.imread() returning
+    a handle whose extract_thumb() behaves as specified."""
+    raw = MagicMock()
+    if raise_on_thumb is not None:
+        raw.extract_thumb.side_effect = raise_on_thumb
+    else:
+        thumb = MagicMock()
+        thumb.format = thumb_format
+        thumb.data = thumb_data
+        raw.extract_thumb.return_value = thumb
+    raw.__enter__.return_value = raw
+    raw.__exit__.return_value = False
+    return raw
+
+
+class TestExtractFullResEmbeddedJpeg:
+    """Direct tests of the Api._extract_full_res_embedded_jpeg helper.
+
+    Bootstrapping a full Api() instance for a helper test is heavy, so
+    each test calls the unbound method with a lightweight object as
+    self — the helper doesn't touch instance state."""
+
+    def _call(self, path):
+        return api_bridge.Api._extract_full_res_embedded_jpeg(
+            MagicMock(spec=object), str(path)
+        )
+
+    def test_returns_original_jpeg_when_no_orientation_needed(self, tmp_path):
+        jpeg_bytes = _make_jpeg_bytes((320, 200))
+        path = tmp_path / "z8_he.NEF"
+        path.write_bytes(b"\x00")
+        with patch.object(
+            rawpy, "imread",
+            return_value=_mock_raw_thumb(
+                thumb_format=rawpy.ThumbFormat.JPEG,
+                thumb_data=jpeg_bytes,
+            ),
+        ):
+            data, dims = self._call(path)
+        # No rotation → helper hands back the in-camera JPEG bytes byte-for-byte.
+        assert data == jpeg_bytes
+        assert dims == (320, 200)
+
+    def test_applies_exif_orientation_and_reencodes(self, tmp_path):
+        rotated = _make_rotated_jpeg_bytes(size=(200, 100))
+        path = tmp_path / "z8_he_portrait.NEF"
+        path.write_bytes(b"\x00")
+        with patch.object(
+            rawpy, "imread",
+            return_value=_mock_raw_thumb(
+                thumb_format=rawpy.ThumbFormat.JPEG,
+                thumb_data=rotated,
+            ),
+        ):
+            data, dims = self._call(path)
+        # Orientation 6 = 90° CW → dims should be swapped (200x100 -> 100x200).
+        assert dims == (100, 200)
+        # And the returned bytes are a fresh JPEG (not the original).
+        assert data != rotated
+        with Image.open(io.BytesIO(data)) as reopened:
+            assert reopened.format == "JPEG"
+            assert (reopened.width, reopened.height) == (100, 200)
+
+    def test_libraw_file_unsupported_from_imread_returns_none(self, tmp_path):
+        """Some containers can't even be opened for thumbnail extraction —
+        distinct from HE where imread + extract_thumb both work."""
+        path = tmp_path / "unopenable.NEF"
+        path.write_bytes(b"\x00")
+        with patch.object(
+            rawpy, "imread",
+            side_effect=rawpy.LibRawFileUnsupportedError("nope"),
+        ):
+            data, dims = self._call(path)
+        assert data is None
+        assert dims is None
+
+    def test_no_thumbnail_returns_none(self, tmp_path):
+        path = tmp_path / "no_thumb.NEF"
+        path.write_bytes(b"\x00")
+        with patch.object(
+            rawpy, "imread",
+            return_value=_mock_raw_thumb(
+                raise_on_thumb=rawpy.LibRawNoThumbnailError("no thumb"),
+            ),
+        ):
+            data, dims = self._call(path)
+        assert data is None
+        assert dims is None
+
+    def test_bitmap_thumb_returns_none(self, tmp_path):
+        """Some cameras store an uncompressed bitmap thumb rather than a
+        JPEG — currently unhandled; the helper should say so, not lie."""
+        path = tmp_path / "bitmap_thumb.NEF"
+        path.write_bytes(b"\x00")
+        with patch.object(
+            rawpy, "imread",
+            return_value=_mock_raw_thumb(
+                thumb_format=rawpy.ThumbFormat.BITMAP,
+                thumb_data=b"\x00" * 4096,
+            ),
+        ):
+            data, dims = self._call(path)
+        assert data is None
+        assert dims is None
+
+    def test_corrupt_jpeg_returns_none(self, tmp_path):
+        path = tmp_path / "corrupt.NEF"
+        path.write_bytes(b"\x00")
+        with patch.object(
+            rawpy, "imread",
+            return_value=_mock_raw_thumb(
+                thumb_format=rawpy.ThumbFormat.JPEG,
+                thumb_data=b"not a real jpeg at all",
+            ),
+        ):
+            data, dims = self._call(path)
+        assert data is None
+        assert dims is None
+
+
+class TestReadRawFullHeFallback:
+    """Higher-level tests: read_raw_full() must route to the embedded
+    JPEG when postprocess() raises LibRawFileUnsupportedError (Z8 HE)."""
+
+    @pytest.fixture
+    def he_scene(self, tmp_path):
+        """Build a tmp root with a fake .NEF and a raw handle whose
+        postprocess() raises LibRawFileUnsupportedError."""
+        root = tmp_path / "shoot"
+        root.mkdir()
+        nef = root / "DSC_7191.NEF"
+        nef.write_bytes(b"\x00")
+
+        unsupported = MagicMock()
+        unsupported.sizes = MagicMock(
+            width=8280, height=5520, raw_width=8280, raw_height=5520,
+            iwidth=8280, iheight=5520, flip=0,
+        )
+        unsupported.postprocess.side_effect = rawpy.LibRawFileUnsupportedError(
+            b"Unsupported file format or not RAW file"
+        )
+        unsupported.__enter__.return_value = unsupported
+        unsupported.__exit__.return_value = False
+
+        embedded_bytes = _make_jpeg_bytes((8256, 5504))
+        preview_raw = _mock_raw_thumb(
+            thumb_format=rawpy.ThumbFormat.JPEG,
+            thumb_data=embedded_bytes,
+        )
+        return {
+            "root": root,
+            "nef": nef,
+            "unsupported_raw": unsupported,
+            "preview_raw": preview_raw,
+            "embedded_bytes": embedded_bytes,
+        }
+
+    def test_he_falls_back_to_embedded_jpeg(self, he_scene):
+        api = api_bridge.Api()
+        # First imread returns the handle whose postprocess raises;
+        # second imread (inside the helper) returns the preview handle
+        # from which extract_thumb succeeds.
+        with patch.object(
+            rawpy, "imread",
+            side_effect=[he_scene["unsupported_raw"], he_scene["preview_raw"]],
+        ):
+            result = api.read_raw_full(he_scene["nef"].name, str(he_scene["root"]))
+        assert result["success"] is True
+        assert result.get("fallback") == "embedded_jpeg_preview"
+        assert result.get("fallback_reason")
+        assert result["mime"] == "image/jpeg"
+        # Data is base64-encoded JPEG bytes. Decode and verify shape.
+        import base64
+        decoded = base64.b64decode(result["data"])
+        assert decoded == he_scene["embedded_bytes"]
+        # Debug metadata carries the fallback marker.
+        assert result["debug"].get("fallback") == "embedded_jpeg_preview"
+        assert result["debug"]["jpeg_dimensions"] == {"width": 8256, "height": 5504}
+
+    def test_he_writes_cache_entry_by_default(self, he_scene):
+        api = api_bridge.Api()
+        with patch.object(
+            rawpy, "imread",
+            side_effect=[he_scene["unsupported_raw"], he_scene["preview_raw"]],
+        ):
+            result = api.read_raw_full(he_scene["nef"].name, str(he_scene["root"]))
+        assert result["success"] is True
+        # A JPEG must have landed in the culling_TMP cache alongside the
+        # image. Same file → subsequent calls hit that cache instead of
+        # re-running the failing rawpy.postprocess.
+        cache_dir = he_scene["root"] / ".kestrel" / "culling_TMP"
+        jpegs = list(cache_dir.glob("*_preview.jpg"))
+        assert len(jpegs) == 1
+        assert jpegs[0].read_bytes() == he_scene["embedded_bytes"]
+
+    def test_he_with_no_embedded_preview_reports_original_error(self, he_scene):
+        """If both the RAW decode AND the embedded preview extraction
+        fail, the caller must see the LibRaw error, not silent success."""
+        api = api_bridge.Api()
+        no_thumb_raw = _mock_raw_thumb(
+            raise_on_thumb=rawpy.LibRawNoThumbnailError("no thumb"),
+        )
+        with patch.object(
+            rawpy, "imread",
+            side_effect=[he_scene["unsupported_raw"], no_thumb_raw],
+        ):
+            result = api.read_raw_full(he_scene["nef"].name, str(he_scene["root"]))
+        assert result["success"] is False
+        assert "Unsupported file format" in result["error"]
+
+    def test_supported_raw_bypasses_fallback(self, tmp_path):
+        """When postprocess() returns normally the fallback branch must
+        not fire — otherwise every raw would be silently downgraded."""
+        import numpy as np
+        root = tmp_path / "shoot"
+        root.mkdir()
+        nef = root / "DSC_0001.NEF"
+        nef.write_bytes(b"\x00")
+
+        rgb = np.zeros((64, 96, 3), dtype=np.uint8)
+        rgb[:, :, 0] = 128
+        ok_raw = MagicMock()
+        ok_raw.sizes = MagicMock(
+            width=96, height=64, raw_width=96, raw_height=64,
+            iwidth=96, iheight=64, flip=0,
+        )
+        ok_raw.postprocess.return_value = rgb
+        ok_raw.__enter__.return_value = ok_raw
+        ok_raw.__exit__.return_value = False
+
+        api = api_bridge.Api()
+        with patch.object(rawpy, "imread", return_value=ok_raw):
+            result = api.read_raw_full(nef.name, str(root))
+
+        assert result["success"] is True
+        assert "fallback" not in result
+        assert result["debug"].get("fallback") is None
+        assert "postprocess_rgb_shape" in result["debug"]


### PR DESCRIPTION
## Summary

User-reported via in-app feedback (Rock-Wren, macOS): **"Raw Zoom" shows a pixelated image** for Nikon Z8 `.NEF` files even though the bird crop looks fine. Log tail on the reporting session confirmed `rawpy.imread` was reporting `'Unsupported file format or not RAW file'` for a specific set of NEF frames from a Z8.

Verified locally against the three raw.pixls.us Z8 samples (lossless, HE, HE*):

| File | rawpy.imread | raw.postprocess | raw.extract_thumb |
|---|---|---|---|
| `Nikon_Z8_raw_14_bit_lossless_compression.NEF` | ✅ | ✅ | ✅ (5667 KB) |
| `Nikon_Z8_high_efficiency_low.NEF` (HE) | ✅ | ❌ `LibRawFileUnsupportedError` | ✅ (5743 KB) |
| `Nikon_Z8_raw_high_efficiency_hight.NEF` (HE*) | ✅ | ❌ `LibRawFileUnsupportedError` | ✅ (5689 KB) |

## Root cause

Nikon's HE / HE* NEFs use **intoPIX TicoRAW**, a proprietary licensed codec. LibRaw's Z8 support (0.22 onwards) reads the container metadata but explicitly rejects HE/HE* at the decode step — and rawpy's bundled LibRaw is not built with the intoPIX SDK on any platform. rawpy 0.27.0 (current pin) is already the latest; upstream is not going to add HE decoding.

`api_bridge.read_raw_full()` had no fallback for this: postprocess raised, the outer `except Exception` caught it, `{success: False, error: '…'}` came back, and `scene-zoom.js` silently kept the low-res thumbnail stub visible. That's exactly what the user was seeing as "pixelated."

## Fix

Every NEF, including HE / HE*, carries a **full-sensor-resolution embedded JPEG** in a SubIFD, and `rawpy.extract_thumb()` reads it via LibRaw's metadata path (which does not depend on decoding the sensor data). This PR:

1. **`api_bridge._extract_full_res_embedded_jpeg()`** — new helper. Opens a fresh `rawpy.imread` handle (the failed-postprocess handle is left in an out-of-order state and would raise `LibRawOutOfOrderCallError`), calls `extract_thumb()`, applies EXIF Orientation via Pillow. When no rotation is needed the in-camera JPEG bytes pass through untouched — no re-encode, full quality preserved.

2. **`api_bridge.read_raw_full()`** — catches `LibRawFileUnsupportedError` inside the rawpy block and routes to the helper. When it succeeds the response carries `fallback: 'embedded_jpeg_preview'` and `debug.fallback = 'embedded_jpeg_preview'`. When the embedded JPEG is also unavailable, the original LibRaw error is re-raised so the outer handler logs it exactly as before.

3. **`scene-zoom.js`** — switches the RAW label from `"RAW (+X.XX EV)"` to `"RAW (embedded preview)"` when the response carries the fallback flag, so users aren't misled by an EV number that had no effect on the fixed in-camera render.

The analysis pipeline path was already correct — `pipeline.py:189` calls `decode_embedded_preview` when `build_metered_detection_image` fails on HE files, and `image_utils.decode_embedded_preview` uses the same `imread + extract_thumb` sequence. No pipeline changes are required for HE analysis coverage.

## End-to-end verification

Standing up `api_bridge.Api()` locally and calling `read_raw_full` on the three Z8 samples:

```
lossless.NEF: success=True  fallback=None                     JPEG=8280x5520  (normal postprocess path)
he_low.NEF:   success=True  fallback=embedded_jpeg_preview    JPEG=8256x5504  (embedded fallback)
he_high.NEF:  success=True  fallback=embedded_jpeg_preview    JPEG=8256x5504  (embedded fallback)
```

Both HE variants now render at full sensor resolution (8256×5504 vs. the raw sensor 8280×5520 — the 24/16 px delta is the standard crop margin; no thumbnail-scale downgrade).

## Tests

New `tests/unit/test_read_raw_full_he_fallback.py` — 10 unit tests, all mocked rawpy handles following the existing `test_image_utils.py` pattern:

- `TestExtractFullResEmbeddedJpeg` — helper-level: original bytes preserved when no rotation, orientation applied and re-encoded when needed, `(None, None)` on unopenable container / no-thumb / bitmap-thumb / corrupt JPEG.
- `TestReadRawFullHeFallback` — end-to-end via `Api()`: HE path returns fallback JPEG bytes with the `fallback` flag; cache entry lands in `.kestrel/culling_TMP`; helper-fails path surfaces the original LibRaw error (not silent success); supported RAW bypasses the fallback entirely (no silent quality downgrade for working files).

Full pre-touch regression sweep passes: `test_api_bridge_pure.py` + `test_image_utils.py` + `test_raw_exif.py` + new file = 90 passed.

## Test plan

- [ ] Open a folder of Z8 HE / HE* NEFs on macOS + Windows, hover-zoom on a scene — expect a full-res image with the "RAW (embedded preview)" label.
- [ ] Same folder with a mix of lossless and HE frames — lossless frames should still show the "RAW (+X.XX EV)" label and respond to exposure correction.
- [ ] Confirm `culling_TMP/*_preview.jpg` files land in the folder for HE frames after the first zoom.
- [ ] Verify a completely broken RAW (truncated, wrong extension, non-Nikon) still returns `success: false` — the fallback should not mask true failures.

---
_Generated by [Claude Code](https://claude.ai/code/session_01V9UEUtN85UHw8osDYGKb3i)_