### PR TITLE
docs: Intel (x86_64) Mac build instructions

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -174,6 +174,62 @@ packaging/build_app_headless.sh
 
 Targets `analyzer/ProjectKestrel-macos.spec`.
 
+#### Building on Intel (x86_64) Macs
+
+The spec builds for the host architecture (`target_arch=None`), so a native
+Intel build needs no code changes — just an x86_64 environment. Verified on
+macOS 26 / Intel with Python 3.12:
+
+1. Make sure Git LFS is installed and the model weights are pulled **before**
+   building:
+
+   ```bash
+   brew install git-lfs
+   git lfs install
+   git lfs pull
+   ```
+
+   Without this, the ONNX files under `analyzer/models/` are tiny pointer
+   stubs (e.g. `quality.onnx` at ~130 bytes instead of ~1.1 MB) and the
+   build "succeeds" but the app fails at model load.
+
+2. Create the venv the build script expects, using an **x86_64** Python 3.12:
+
+   ```bash
+   python3.12 -m venv .venv2
+   .venv2/bin/pip install -r requirements-macos.txt
+   ```
+
+   All pinned packages ship x86_64 macOS wheels except `rawpy`, which pip
+   builds from source automatically (takes a few minutes).
+
+3. Run `packaging/build_app_headless.sh`. Output lands in
+   `analyzer/dist/Project Kestrel.app`. Confirm the architecture with:
+
+   ```bash
+   lipo -archs "analyzer/dist/Project Kestrel.app/Contents/MacOS/ProjectKestrel"
+   ```
+
+To produce a DMG locally, mirror the CI packaging step
+(`.github/workflows/build-macos.yml`):
+
+```bash
+brew install create-dmg
+create-dmg \
+  --volname "Project Kestrel" \
+  --window-size 540 380 \
+  --icon-size 128 \
+  --icon "Project Kestrel.app" 140 190 \
+  --app-drop-link 400 190 \
+  --hide-extension "Project Kestrel.app" \
+  "artifact/ProjectKestrel.dmg" \
+  "analyzer/dist/Project Kestrel.app"
+```
+
+Note that local builds are neither Developer ID-signed nor notarized
+(`codesign_identity=None` in the spec), so Gatekeeper will warn on other
+machines. Signing and notarization happen in CI.
+
 Both spec files use `analyzer/visualizer.py` as the entry point.
 
 ## Code Organization


### PR DESCRIPTION
## Summary

Adds a short subsection to the macOS build docs in `DEVELOPMENT.md` covering native builds on Intel Macs, verified end-to-end on an Intel machine (macOS 26, Python 3.12 x86_64):

- No code changes are needed — `ProjectKestrel-macos.spec` uses `target_arch=None`, so the build follows the host architecture.
- Documents the Git LFS prerequisite (without `git lfs pull`, the ONNX models are pointer stubs and the built app fails at model load — easy to miss since the build itself succeeds).
- Notes that all pinned deps have x86_64 wheels except `rawpy`, which pip compiles from source automatically.
- Includes the local DMG packaging command mirroring `.github/workflows/build-macos.yml`, with a note that local builds are unsigned/un-notarized.

The resulting Intel app and DMG were built and launch-tested successfully. Feel free to tweak or drop anything that doesn't fit the docs style.

## Test plan
- [x] Followed the documented steps verbatim on an Intel Mac: LFS pull → `.venv2` with x86_64 Python 3.12 → `packaging/build_app_headless.sh`
- [x] Verified `lipo -archs` reports `x86_64` and the app launches
- [x] Built the DMG with the documented `create-dmg` invocation; `hdiutil verify` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)