### PR TITLE
Fix UnboundLocalError in custom-editor launch path

### DIFF
--- a/analyzer/editor_launch.py
+++ b/analyzer/editor_launch.py
@@ -303,16 +303,16 @@ def launch(path: str, editor: str):
         },
     }
 
-    info = _EDITOR_REGISTRY.get(editor)
+    entry = _EDITOR_REGISTRY.get(editor)
 
     # Windows
     if sys.platform.startswith('win'):
-        if info:
+        if entry:
             # Special finder for darktable
-            if 'win_find' in info:
-                candidates = info['win_find']()
+            if 'win_find' in entry:
+                candidates = entry['win_find']()
             else:
-                candidates = info.get('win_candidates', [])
+                candidates = entry.get('win_candidates', [])
             for exe in candidates:
                 if exe and os.path.exists(exe):
                     try:
@@ -325,11 +325,11 @@ def launch(path: str, editor: str):
 
     # macOS
     if sys.platform == 'darwin':
-        if info:
+        if entry:
             apps_to_try = []
-            if info.get('mac_app'):
-                apps_to_try.append(info['mac_app'])
-            apps_to_try.extend(info.get('mac_app_fallbacks', []))
+            if entry.get('mac_app'):
+                apps_to_try.append(entry['mac_app'])
+            apps_to_try.extend(entry.get('mac_app_fallbacks', []))
             # Sandbox: locate the .app by display name and open via NSWorkspace
             # (LaunchServices-brokered); subprocess 'open -a' is unavailable.
             if _sandboxed():
@@ -398,8 +398,8 @@ def launch(path: str, editor: str):
         return
 
     # Linux / other
-    if info:
-        for cmd_args in info.get('linux', []):
+    if entry:
+        for cmd_args in entry.get('linux', []):
             try:
                 subprocess.Popen(cmd_args + [path]); return
             except FileNotFoundError:

--- a/analyzer/tests/unit/test_editor_launch_custom.py
+++ b/analyzer/tests/unit/test_editor_launch_custom.py
@@ -1,0 +1,78 @@
+"""Regression tests for editor_launch.launch() with a custom editor.
+
+The custom-editor branch used to reference an ``info`` name that had
+been shadowed later in the same function by a local assignment
+(``info = _EDITOR_REGISTRY.get(editor)``), which made the earlier
+``info(f'...')`` call fail with ``UnboundLocalError`` — surfaced as
+"cannot access local variable 'info' where it is not associated with
+a value" in the ``[API] open_in_editor error:`` log.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+import editor_launch
+
+
+pytestmark = pytest.mark.unit
+
+
+def test_launch_custom_editor_does_not_raise_unbound_local(monkeypatch, tmp_path):
+    """The custom-editor path must not shadow the ``info`` logger."""
+    target = tmp_path / "photo.jpg"
+    target.write_bytes(b"")
+
+    custom_exe = tmp_path / "fake_editor"
+    custom_exe.write_bytes(b"")
+
+    launched: list[list[str]] = []
+
+    monkeypatch.setattr(
+        editor_launch,
+        "load_persisted_settings",
+        lambda: {"customEditorPath": str(custom_exe)},
+    )
+    monkeypatch.setattr(
+        editor_launch,
+        "_validate_custom_editor_path",
+        lambda raw: str(custom_exe),
+    )
+    monkeypatch.setattr(
+        editor_launch.subprocess,
+        "Popen",
+        lambda argv, *a, **kw: launched.append(list(argv)) or None,
+    )
+
+    editor_launch.launch(str(target), "custom")
+
+    assert launched, "custom editor Popen was not invoked"
+    assert launched[0][0] == str(custom_exe)
+    assert launched[0][-1] == str(target)
+
+
+def test_launch_named_editor_still_uses_registry(monkeypatch, tmp_path):
+    """Renaming the local variable must not break the registry lookup."""
+    target = tmp_path / "photo.jpg"
+    target.write_bytes(b"")
+
+    launched: list[list[str]] = []
+    monkeypatch.setattr(
+        editor_launch.subprocess,
+        "Popen",
+        lambda argv, *a, **kw: launched.append(list(argv)) or None,
+    )
+    # Force the Linux branch so the test is portable and hits the
+    # ``if entry:`` path deterministically.
+    monkeypatch.setattr(editor_launch.sys, "platform", "linux")
+
+    editor_launch.launch(str(target), "gimp")
+
+    assert launched, "no editor launch attempted"
+    # The registry lists ``flatpak run org.gimp.GIMP`` first; either
+    # that or plain ``gimp`` is acceptable, as long as the target is
+    # the last argv element.
+    assert launched[0][-1] == str(target)


### PR DESCRIPTION
## Summary

`editor_launch.launch()` imports `settings_utils.info` as a logger at module scope, then later assigns `info = _EDITOR_REGISTRY.get(editor)` inside the same function. Python treats `info` as local across the entire function body, so the earlier `info(f'[editor] launching custom editor: ...')` call in the custom-editor branch raised `UnboundLocalError` before the per-platform registry lookup ran.

The failure surfaced in production as repeated log lines of the form:

```
[serve][ERROR] [API] open_in_editor error: cannot access local variable 'info' where it is not associated with a value
```

Every attempt to open a photo with a custom editor from the culling view failed silently (the API returns `{'success': False, 'error': ...}` but the editor never launches). Reported on macOS (Rock Wren build).

## Fix

Rename the local variable to `entry` so the earlier `info(...)` call resolves to the module-level logger import. No behavioral change beyond making the custom-editor branch actually reachable.

## Test plan

- [x] New unit test `tests/unit/test_editor_launch_custom.py::test_launch_custom_editor_does_not_raise_unbound_local` reproduces the exact `UnboundLocalError` on the pre-fix code and passes after the rename.
- [x] `test_launch_named_editor_still_uses_registry` guards against a copy-paste regression on the registry lookup path (Linux branch, deterministic on the runner).
- [x] `pytest analyzer/tests/unit/test_editor_launch_custom.py` — 2 passed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01T2vZxpER4cvBcDbUXHWUVx)_