### PR TITLE
Surface the unsupported-RAW fallback in a dismissible banner

### DIFF
--- a/analyzer/css/raw-warn-banner.css
+++ b/analyzer/css/raw-warn-banner.css
@@ -1,0 +1,119 @@
+/* ── Unsupported-RAW Warning Banner ─────────────────────────────────
+   Same top-of-window treatment as the legal consent banner
+   (css/legal-banner.css), in a warning red instead of the legal blue.
+   Shown when a loaded folder contains RAW files whose sensor data
+   LibRaw could not decompress, so the pipeline analysed the embedded
+   JPEG preview instead. Dismissible per-session via the × button, or
+   permanently via "Don't Show Again".                                */
+.raw-warn-banner {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  background: #a82323;
+  color: #fff;
+  padding: 10px 44px 10px 20px;
+  z-index: 100000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 20px;
+  flex-wrap: wrap;
+  font-size: 13px;
+  font-weight: 500;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.5);
+}
+
+.raw-warn-banner.hidden {
+  display: none;
+}
+
+/* When the legal banner is also visible it owns the top strip; stack this
+   one directly beneath it so neither is covered. The offset is measured
+   from the legal banner at render time (it wraps to two lines on narrow
+   windows) and written to --raw-warn-offset by refreshRawWarnBanner(). */
+.raw-warn-banner.stacked {
+  top: var(--raw-warn-offset, 40px);
+}
+
+.raw-warn-msg {
+  max-width: 760px;
+  line-height: 1.4;
+}
+
+.raw-warn-actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.raw-warn-banner a,
+.raw-warn-link {
+  color: #fff;
+  text-decoration: underline;
+  font-weight: 700;
+}
+
+.raw-warn-link {
+  padding: 4px 10px;
+  border: 1px solid rgba(255, 255, 255, 0.6);
+  border-radius: 6px;
+  text-decoration: none;
+  font-size: 12px;
+  transition: background 0.15s, border-color 0.15s;
+}
+
+.raw-warn-link:hover {
+  background: rgba(255, 255, 255, 0.12);
+  border-color: #fff;
+}
+
+.raw-warn-btn {
+  background: #fff;
+  color: #a82323;
+  border: none;
+  padding: 4px 12px;
+  border-radius: 6px;
+  font-weight: 700;
+  cursor: pointer;
+  font-size: 12px;
+  transition: opacity 0.2s;
+}
+
+.raw-warn-btn:hover {
+  opacity: 0.9;
+}
+
+/* Dismiss (×) — pinned to the right edge, vertically centred. */
+.raw-warn-close {
+  position: absolute;
+  top: 50%;
+  right: 12px;
+  transform: translateY(-50%);
+  background: transparent;
+  color: #fff;
+  border: none;
+  border-radius: 6px;
+  width: 24px;
+  height: 24px;
+  line-height: 1;
+  font-size: 18px;
+  font-weight: 700;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background 0.15s;
+}
+
+.raw-warn-close:hover {
+  background: rgba(255, 255, 255, 0.18);
+}
+
+.raw-warn-close:focus-visible,
+.raw-warn-btn:focus-visible,
+.raw-warn-link:focus-visible {
+  outline: 2px solid #fff;
+  outline-offset: 2px;
+}

--- a/analyzer/js/csv-init.js
+++ b/analyzer/js/csv-init.js
@@ -308,6 +308,7 @@
           rows = [];
           header = [];
           if (typeof renderScenes === 'function') renderScenes();
+          hideRawWarnBanner();
         } catch (e) { console.warn('[clear] renderScenes error', e); }
         setStatus('Idle');
       });

--- a/analyzer/js/event-wiring.js
+++ b/analyzer/js/event-wiring.js
@@ -305,6 +305,9 @@
             // UI-driven settings writes include the persisted legal flags.
             await hydrateSettingsFromServer();
             document.getElementById('legalNotice').classList.add('hidden');
+            // The RAW warning stacks beneath the legal banner; with that gone
+            // it should move back up to the top strip.
+            try { refreshRawWarnBanner(); } catch (_) { }
             showToast('Terms accepted. Welcome to Project Kestrel!', 4000);
           }
         } catch (e) {

--- a/analyzer/js/multi-folder.js
+++ b/analyzer/js/multi-folder.js
@@ -14,6 +14,7 @@
         sceneGrid.innerHTML = '';
         // Re-render so scene-grid.js can flip the welcome panel back on.
         try { if (typeof renderScenes === 'function') renderScenes(); } catch (_) { }
+        try { hideRawWarnBanner(); } catch (_) { }
         setStatus('No folders selected — check folders in the tree to load scenes');
       }
     }, 400);
@@ -144,6 +145,7 @@
       treeActivePath = paths.length === 1 ? paths[0] : null;
       renderFolderTree();
       await renderScenes();
+      try { refreshRawWarnBanner(); } catch (_) { }
       showProgress('Done', 100);
       await sleep(400);
       hideProgress();
@@ -202,6 +204,7 @@
 
         // Now render with rootPath set
         await renderScenes();
+        try { refreshRawWarnBanner(); } catch (_) { }
 
         // Also save in settings for file opening (use rootHint for consistency)
         const settings = loadSettings();

--- a/analyzer/js/queue.js
+++ b/analyzer/js/queue.js
@@ -1017,6 +1017,9 @@
           ensureSceneNameColumn();
           ensureRatingColumns();
           await renderScenes();
+          // Freshly-analysed rows may be the first to carry the
+          // embedded-preview fallback marker for this folder.
+          try { refreshRawWarnBanner(); } catch (_) { }
           // If a scene dialog is open, its filmstrip is stale after renderScenes
           // rebuilt the scenes array with fresh row objects — re-render it now.
           if (_currentScene) {

--- a/analyzer/js/raw-warn.js
+++ b/analyzer/js/raw-warn.js
@@ -1,0 +1,133 @@
+    // ── Unsupported-RAW Warning Banner ──────────────────────────────────────
+    // The analysis pipeline falls back to a file's embedded JPEG preview when
+    // LibRaw can open the RAW container but cannot decompress the sensor data
+    // — most commonly Nikon's High Efficiency (HE / HE*) NEFs, which use the
+    // proprietary TicoRAW codec. That fallback is recorded per row as
+    // exposure_pipeline == 'embedded_preview_jpeg' and, until now, was only
+    // visible as a transient line in the Live Analysis status area and a
+    // warning in the run log. Users who analysed a whole shoot of HE NEFs got
+    // materially worse results with no durable signal as to why.
+    //
+    // This surfaces it with the same top-of-window banner treatment as the
+    // legal consent notice, in a warning red. Dismissible for the session via
+    // the × button, or permanently via "Don't Show Again".
+
+    const RAW_WARN_LEARN_MORE_URL = 'https://www.projectkestrel.org/notes/nikon-unsupported-raws';
+    const RAW_WARN_SUPPRESS_KEY = 'raw_unsupported_warn_suppressed';
+    const RAW_WARN_FALLBACK_PIPELINE = 'embedded_preview_jpeg';
+
+    // Extension → the wording used when that brand's RAWs hit the fallback.
+    // Only Nikon ships a compression mode common enough to warrant calling
+    // out by name; add entries here if another vendor's codec starts showing
+    // up in the wild.
+    const RAW_WARN_MESSAGES = {
+      '.nef': 'Your Nikon .NEF RAW files are encoded using an unsupported '
+        + 'compression type and will lead to poor results. Consider changing '
+        + 'your compression type.',
+    };
+
+    // Suppressed for this session only (× button). Cleared on next launch.
+    let _rawWarnDismissedThisSession = false;
+
+    function _rawWarnExtOf(name) {
+      const s = String(name || '');
+      const dot = s.lastIndexOf('.');
+      return dot === -1 ? '' : s.slice(dot).toLowerCase();
+    }
+
+    /** Return the extension whose warning should show, or '' if none. */
+    function detectUnsupportedRawExt(rowList) {
+      if (!Array.isArray(rowList)) return '';
+      for (const r of rowList) {
+        if (!r) continue;
+        if (String(r.exposure_pipeline || '') !== RAW_WARN_FALLBACK_PIPELINE) continue;
+        const ext = _rawWarnExtOf(r.filename);
+        if (ext in RAW_WARN_MESSAGES) return ext;
+      }
+      return '';
+    }
+
+    function _rawWarnIsSuppressed() {
+      try { return getSetting(RAW_WARN_SUPPRESS_KEY, false) === true; } catch { return false; }
+    }
+
+    function _rawWarnSuppressForever() {
+      const settings = { ...loadSettings(), [RAW_WARN_SUPPRESS_KEY]: true };
+      saveSettings(settings);
+      // Mirror to settings.json so the choice survives a localStorage reset.
+      if (hasPywebviewApi && window.pywebview?.api?.save_settings_data) {
+        try { window.pywebview.api.save_settings_data(settings); } catch (_) { }
+      }
+    }
+
+    function hideRawWarnBanner() {
+      document.getElementById('rawWarnNotice')?.classList.add('hidden');
+    }
+
+    /**
+     * Show or hide the banner based on the currently loaded rows.
+     * Safe to call repeatedly — every folder load re-evaluates.
+     */
+    function refreshRawWarnBanner() {
+      const banner = document.getElementById('rawWarnNotice');
+      const msgEl = document.getElementById('rawWarnMsg');
+      if (!banner || !msgEl) return;
+
+      if (_rawWarnDismissedThisSession || _rawWarnIsSuppressed()) {
+        banner.classList.add('hidden');
+        return;
+      }
+
+      const ext = detectUnsupportedRawExt(rows);
+      if (!ext) {
+        banner.classList.add('hidden');
+        return;
+      }
+
+      msgEl.textContent = RAW_WARN_MESSAGES[ext];
+      // The legal banner owns the top strip when it is up; stack beneath it.
+      // Measure rather than assume a height — it wraps to two lines on a
+      // narrow window.
+      const legal = document.getElementById('legalNotice');
+      const legalVisible = !!legal && !legal.classList.contains('hidden');
+      if (legalVisible) {
+        banner.style.setProperty('--raw-warn-offset', `${legal.offsetHeight}px`);
+      } else {
+        banner.style.removeProperty('--raw-warn-offset');
+      }
+      banner.classList.toggle('stacked', legalVisible);
+      banner.classList.remove('hidden');
+    }
+
+    (function wireRawWarnBanner() {
+      const closeBtn = document.getElementById('rawWarnCloseBtn');
+      if (closeBtn) {
+        closeBtn.addEventListener('click', () => {
+          _rawWarnDismissedThisSession = true;
+          hideRawWarnBanner();
+        });
+      }
+
+      const dontShowBtn = document.getElementById('rawWarnDontShowBtn');
+      if (dontShowBtn) {
+        dontShowBtn.addEventListener('click', () => {
+          _rawWarnDismissedThisSession = true;
+          try { _rawWarnSuppressForever(); } catch (e) {
+            console.error('Failed to persist RAW warning suppression', e);
+          }
+          hideRawWarnBanner();
+        });
+      }
+
+      // pywebview has no real browser context, so target="_blank" opens a
+      // dead window. Route through open_url like every other external link.
+      const learnMore = document.getElementById('rawWarnLearnMore');
+      if (learnMore) {
+        learnMore.addEventListener('click', ev => {
+          if (hasPywebviewApi && window.pywebview?.api?.open_url) {
+            ev.preventDefault();
+            try { window.pywebview.api.open_url(RAW_WARN_LEARN_MORE_URL); } catch (_) { }
+          }
+        });
+      }
+    })();

--- a/analyzer/tests/unit/test_raw_warn_banner.py
+++ b/analyzer/tests/unit/test_raw_warn_banner.py
@@ -1,0 +1,135 @@
+"""Static wiring tests for the unsupported-RAW warning banner.
+
+The banner is pure frontend (``js/raw-warn.js`` + ``css/raw-warn-banner.css``
++ markup in ``visualizer.html``), and the repo has no JS test runner, so
+these are source-level lints in the same spirit as
+``tests/test_security_visualizer_js_xss.py``. They catch the failure modes
+that would silently disable the banner: a renamed element id, a dropped
+stylesheet/script tag, a changed settings key, or a broken Learn More URL.
+
+Behavioural coverage (detector output, dismissal, persistence, stacking
+under the legal banner) was verified in a headless Chromium harness when
+the feature landed; see the PR description.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import unittest
+
+_THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+_ANALYZER_DIR = os.path.dirname(os.path.dirname(_THIS_DIR))
+
+LEARN_MORE_URL = "https://www.projectkestrel.org/notes/nikon-unsupported-raws"
+SUPPRESS_KEY = "raw_unsupported_warn_suppressed"
+FALLBACK_MARKER = "embedded_preview_jpeg"
+
+# Element ids the JS looks up; all must exist in the markup.
+ELEMENT_IDS = (
+    "rawWarnNotice",
+    "rawWarnMsg",
+    "rawWarnLearnMore",
+    "rawWarnDontShowBtn",
+    "rawWarnCloseBtn",
+)
+
+
+def _read(*parts: str) -> str:
+    with open(os.path.join(_ANALYZER_DIR, *parts), "r", encoding="utf-8") as f:
+        return f.read()
+
+
+class TestRawWarnBannerWiring(unittest.TestCase):
+    def setUp(self) -> None:
+        self.html = _read("visualizer.html")
+        self.js = _read("js", "raw-warn.js")
+        self.css = _read("css", "raw-warn-banner.css")
+
+    def test_markup_defines_every_element_the_js_queries(self) -> None:
+        for el_id in ELEMENT_IDS:
+            with self.subTest(element=el_id):
+                self.assertIn(
+                    f'id="{el_id}"', self.html,
+                    f"visualizer.html is missing #{el_id}",
+                )
+                self.assertIn(
+                    f"'{el_id}'", self.js,
+                    f"raw-warn.js never references #{el_id}",
+                )
+
+    def test_stylesheet_and_script_are_loaded(self) -> None:
+        self.assertIn('href="css/raw-warn-banner.css"', self.html)
+        self.assertIn('src="js/raw-warn.js"', self.html)
+
+    def test_script_loads_before_its_callers(self) -> None:
+        """raw-warn.js must be parsed before the modules that call into it."""
+        pos = self.html.index('src="js/raw-warn.js"')
+        for caller in ("js/multi-folder.js", "js/csv-init.js", "js/event-wiring.js"):
+            with self.subTest(caller=caller):
+                self.assertLess(
+                    pos, self.html.index(f'src="{caller}"'),
+                    f"raw-warn.js must be loaded before {caller}",
+                )
+
+    def test_banner_starts_hidden(self) -> None:
+        banner = re.search(r'<div id="rawWarnNotice"[^>]*>', self.html)
+        self.assertIsNotNone(banner, "rawWarnNotice div not found")
+        self.assertIn("hidden", banner.group(0))
+
+    def test_learn_more_points_at_the_published_note(self) -> None:
+        self.assertIn(LEARN_MORE_URL, self.html)
+        self.assertIn(LEARN_MORE_URL, self.js)
+
+    def test_detector_keys_off_the_pipeline_fallback_marker(self) -> None:
+        """The marker must match what pipeline.py writes to the CSV."""
+        self.assertIn(FALLBACK_MARKER, self.js)
+        pipeline = _read("kestrel_analyzer", "pipeline.py")
+        self.assertIn(
+            f'"{FALLBACK_MARKER}"', pipeline,
+            "pipeline.py no longer emits the exposure_pipeline value the "
+            "banner detects; the banner would never fire",
+        )
+
+    def test_suppression_key_is_persisted_to_the_backend(self) -> None:
+        self.assertIn(SUPPRESS_KEY, self.js)
+        self.assertIn("save_settings_data", self.js)
+
+    def test_close_button_is_labelled_for_screen_readers(self) -> None:
+        close = re.search(r'<button id="rawWarnCloseBtn"[^>]*>', self.html, re.S)
+        self.assertIsNotNone(close)
+        self.assertIn("aria-label", close.group(0))
+
+    def test_css_defines_the_classes_the_markup_uses(self) -> None:
+        for cls in (
+            "raw-warn-banner", "raw-warn-msg", "raw-warn-actions",
+            "raw-warn-link", "raw-warn-btn", "raw-warn-close",
+        ):
+            with self.subTest(cls=cls):
+                self.assertIn(f".{cls}", self.css)
+                self.assertIn(cls, self.html)
+
+    def test_banner_has_a_hidden_rule(self) -> None:
+        self.assertRegex(self.css, r"\.raw-warn-banner\.hidden\s*\{[^}]*display:\s*none")
+
+    def test_stacked_offset_is_driven_by_the_measured_variable(self) -> None:
+        """CSS must consume the custom property the JS sets, or the banner
+        overlaps the legal notice when that one wraps to two lines."""
+        self.assertIn("--raw-warn-offset", self.css)
+        self.assertIn("--raw-warn-offset", self.js)
+
+    def test_learn_more_routes_through_open_url(self) -> None:
+        """target=_blank alone opens a dead window under pywebview."""
+        self.assertIn("open_url", self.js)
+
+    def test_callers_refresh_the_banner_after_loading_rows(self) -> None:
+        for module in ("multi-folder.js", "queue.js"):
+            with self.subTest(module=module):
+                self.assertIn(
+                    "refreshRawWarnBanner", _read("js", module),
+                    f"{module} loads rows but never refreshes the banner",
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/analyzer/visualizer.html
+++ b/analyzer/visualizer.html
@@ -25,6 +25,7 @@
   <link rel="stylesheet" href="css/welcome.css" />
   <link rel="stylesheet" href="css/timeline.css" />
   <link rel="stylesheet" href="css/legal-banner.css" />
+  <link rel="stylesheet" href="css/raw-warn-banner.css" />
   <link rel="stylesheet" href="css/dialogs/base.css" />
   <link rel="stylesheet" href="css/dialogs/kdlg.css" />
   <link rel="stylesheet" href="css/dialogs/scene.css" />
@@ -51,6 +52,16 @@
         rel="noopener" class="legal-notice-link">View Privacy Policy</a>
       <button id="legalAgreeBtn" class="legal-notice-btn">Agree &amp; Dismiss</button>
     </div>
+  </div>
+  <div id="rawWarnNotice" class="raw-warn-banner hidden" role="alert">
+    <span id="rawWarnMsg" class="raw-warn-msg"></span>
+    <div class="raw-warn-actions">
+      <a id="rawWarnLearnMore" href="https://www.projectkestrel.org/notes/nikon-unsupported-raws"
+        target="_blank" rel="noopener" class="raw-warn-link">Learn More</a>
+      <button id="rawWarnDontShowBtn" class="raw-warn-btn">Don&rsquo;t Show Again</button>
+    </div>
+    <button id="rawWarnCloseBtn" class="raw-warn-close" type="button"
+      aria-label="Dismiss this warning">&times;</button>
   </div>
   <div class="app-body">
   <header>
@@ -1566,6 +1577,7 @@
   <script src="js/folder-tree.js"></script>
   <script src="js/analyze-dialog.js"></script>
   <script src="js/queue.js"></script>
+  <script src="js/raw-warn.js"></script>
   <script src="js/multi-folder.js"></script>
   <script src="js/csv-init.js"></script>
   <script src="js/event-wiring.js"></script>


### PR DESCRIPTION
## Context

When LibRaw can open a RAW container but can't decompress the sensor data, the pipeline falls back to the file's embedded JPEG preview and records `exposure_pipeline='embedded_preview_jpeg'` on the row. Nikon's High Efficiency (HE / HE\*) NEFs are the common trigger — they use the proprietary TicoRAW codec from intoPIX.

Until now that fallback was only visible as a transient line in the Live Analysis status area and a warning in the run log. A user could analyse a whole shoot of HE NEFs, get materially worse results, and never learn why.

## What this adds

A top-of-window banner using the same treatment as the legal consent notice, in a warning red:

> Your Nikon .NEF RAW files are encoded using an unsupported compression type and will lead to poor results. Consider changing your compression type.  `[Learn More]` `[Don't Show Again]`  `×`

- **Learn More** → `https://www.projectkestrel.org/notes/nikon-unsupported-raws`, routed through `open_url` because `target="_blank"` opens a dead window under pywebview.
- **Don't Show Again** → persists `raw_unsupported_warn_suppressed` to `settings.json` as well as localStorage, so the choice survives a localStorage reset.
- **×** → dismisses for the current session only.

Detection is client-side over the loaded rows, so it fires for folders analysed before this change as well as fresh runs, and re-evaluates on every folder load and post-analysis auto-refresh. Only `.nef` is wired to a message today; `RAW_WARN_MESSAGES` in `js/raw-warn.js` is the single place to add another vendor if one starts showing up.

When the legal banner is also up, the warning stacks beneath it using an offset measured from the legal banner at render time — a fixed height would overlap once that banner wraps to two lines on a narrow window.

## Note before merging to main

The Learn More target (`/notes/nikon-unsupported-raws`) is not published yet — you mentioned it lands before this reaches main. The link is a plain constant in `js/raw-warn.js` if the path changes.

## Files

| File | Change |
|---|---|
| `analyzer/js/raw-warn.js` | new — detector, render/hide, button wiring |
| `analyzer/css/raw-warn-banner.css` | new — red variant of the legal-banner treatment |
| `analyzer/visualizer.html` | banner markup + stylesheet/script tags |
| `analyzer/js/multi-folder.js` | refresh after both folder-load paths; hide on clear |
| `analyzer/js/queue.js` | refresh after post-analysis auto-refresh |
| `analyzer/js/csv-init.js` | hide when the tree is cleared |
| `analyzer/js/event-wiring.js` | un-stack once the legal banner is accepted |
| `analyzer/tests/unit/test_raw_warn_banner.py` | new — 13 wiring lints |

## Test plan

Behaviour verified in a headless Chromium harness against the real `visualizer.html`:

- [x] Detector returns `.nef` for a folder mixing fallback NEFs with normally-decoded CR3s; banner renders with the correct copy and href.
- [x] Negative cases stay hidden: cleanly-decoded NEFs, a CR3 that hit the fallback, an empty folder.
- [x] Lower-case `.nef` matches (extension compare is case-insensitive).
- [x] `×` hides the banner and it stays hidden across a subsequent folder load.
- [x] **Don't Show Again** writes the setting and the banner stays hidden after a full page reload.
- [x] Stacked under the legal banner at 1400px and at 720px, where the legal banner wraps to 94px — measured `warnTop == legalBottom == 94`, no overlap.
- [x] No new page errors in the console.

Static lints: `pytest analyzer/tests/unit/test_raw_warn_banner.py` — 13 passed, 16 subtests passed.

Screenshots were captured during review and shared with @SanjaySoniLV directly.

---
_Generated by [Claude Code](https://claude.ai/code/session_01T2vZxpER4cvBcDbUXHWUVx)_