### PR TITLE
Instrument the clean/unclean shutdown tracker

### DIFF
--- a/analyzer/api_bridge.py
+++ b/analyzer/api_bridge.py
@@ -2647,9 +2647,24 @@ class Api:
             settings = load_persisted_settings()
             queue_state = _queue_manager.get_persisted_recovery_state()
             unclean_utc = str(settings.get('last_unclean_shutdown_utc', '') or '').strip()
-            exit_reason = str(settings.get('last_exit_reason', '') or '').strip().lower()
+            raw_reason = str(settings.get('last_exit_reason', '') or '').strip().lower()
+            exit_reason = raw_reason
+            coerced = False
             if exit_reason not in ('clean', 'os_shutdown', 'crash', 'unknown'):
                 exit_reason = 'unknown' if unclean_utc else 'clean'
+                coerced = True
+            # The frontend shows the recovery dialog when unclean_shutdown is
+            # true and exit_reason is 'crash'/'unknown'/''. Log what we hand
+            # it so a crash-report log tail records the decision inputs, not
+            # just the outcome. See visualizer._log_shutdown_state.
+            will_prompt = bool(unclean_utc) and exit_reason in ('crash', 'unknown')
+            info(
+                f'[shutdown] recovery_status: raw_last_exit_reason={raw_reason!r} '
+                f'resolved={exit_reason} coerced={coerced} '
+                f'unclean_utc={unclean_utc or "none"} will_prompt={will_prompt} '
+                f'session_started={str(settings.get("app_session_started_utc", "") or "none")} '
+                f'last_closed={str(settings.get("last_session_closed_utc", "") or "none")}'
+            )
             return {
                 'success': True,
                 'unclean_shutdown': bool(unclean_utc),
@@ -2658,6 +2673,7 @@ class Api:
                 'queue_recovery': queue_state,
             }
         except Exception as e:
+            error(f'[shutdown] recovery_status: failed to read recovery state: {e}')
             return {'success': False, 'error': str(e)}
 
     # Phase 3: restore_analysis_queue removed — feature replaced by the
@@ -2667,12 +2683,18 @@ class Api:
         """Clear persisted unclean-shutdown flag and optionally queue recovery snapshot."""
         try:
             settings = load_persisted_settings()
+            had_flag = str(settings.get('last_unclean_shutdown_utc', '') or '').strip()
             settings.pop('last_unclean_shutdown_utc', None)
             if bool(clear_queue_state):
                 settings.pop('queue_recovery_state', None)
             save_persisted_settings(settings)
+            info(
+                f'[shutdown] recovery_cleared: unclean_utc={had_flag or "none"} '
+                f'queue_state_cleared={bool(clear_queue_state)}'
+            )
             return {'success': True}
         except Exception as e:
+            error(f'[shutdown] recovery_cleared: failed: {e}')
             return {'success': False, 'error': str(e)}
 
     def send_recovery_crash_report(self):

--- a/analyzer/tests/unit/test_shutdown_tracker_logging.py
+++ b/analyzer/tests/unit/test_shutdown_tracker_logging.py
@@ -1,0 +1,252 @@
+"""Unit tests for the clean/unclean shutdown tracker's instrumentation.
+
+The recovery dialog fires on the *next* launch, so when it fires wrongly the
+only evidence is whatever the previous session wrote to its log. These tests
+pin the behaviour of that instrumentation: every state transition is logged
+with its old and new value plus the writer that caused it, every write is
+read back, and a lost write is reported loudly rather than silently.
+
+They also pin the invariant that the logging is observability only — adding
+it must not change what the tracker persists.
+"""
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+try:
+    import visualizer
+    from visualizer import (
+        EXIT_REASON_KEY,
+        _log_shutdown_state,
+        _mark_session_clean_exit,
+        _mark_session_exit_reason,
+        _pid_is_alive,
+        _settings_file_hint,
+        _verify_exit_reason_persisted,
+    )
+except Exception as e:  # pragma: no cover - environment-dependent
+    pytest.skip(f'visualizer module not importable in this env: {e}', allow_module_level=True)
+
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def fake_settings(monkeypatch):
+    """Back load/save_persisted_settings with an in-memory dict."""
+    store = {'data': {}}
+
+    def _load():
+        return dict(store['data'])
+
+    def _save(payload):
+        store['data'] = dict(payload)
+
+    monkeypatch.setattr(visualizer, 'load_persisted_settings', _load)
+    monkeypatch.setattr(visualizer, 'save_persisted_settings', _save)
+    return store
+
+
+@pytest.fixture
+def shutdown_log(capsys):
+    """Collect the [shutdown] lines emitted during a test."""
+    def _read():
+        err = capsys.readouterr().err
+        return [ln for ln in err.splitlines() if '[shutdown]' in ln]
+    return _read
+
+
+class TestPidLiveness:
+    """``_pid_is_alive`` is how we detect a second instance clobbering the
+    first one's bookkeeping — the leading hypothesis for the false
+    positives. It must never raise, whatever it is handed."""
+
+    def test_current_process_is_alive(self):
+        assert _pid_is_alive(os.getpid()) is True
+
+    def test_zero_and_negative_are_undeterminable(self):
+        assert _pid_is_alive(0) is None
+        assert _pid_is_alive(-1) is None
+
+    def test_unclaimed_pid_reports_not_alive_or_unknown(self):
+        # Never assert False outright: a recycled pid could legitimately be
+        # live on a busy machine. The contract is only "returns a tri-state
+        # without raising".
+        assert _pid_is_alive(2_000_000_000) in (True, False, None)
+
+    def test_garbage_input_does_not_raise(self):
+        assert _pid_is_alive(None) is None
+
+
+class TestLogHelpers:
+    def test_log_shutdown_state_emits_tagged_line(self, shutdown_log):
+        _log_shutdown_state('unit_test', alpha='one', beta=2)
+        lines = shutdown_log()
+        assert len(lines) == 1
+        assert 'unit_test' in lines[0]
+        assert 'alpha=one' in lines[0]
+        assert 'beta=2' in lines[0]
+
+    def test_log_shutdown_state_omits_none_fields(self, shutdown_log):
+        _log_shutdown_state('unit_test', present='yes', absent=None)
+        line = shutdown_log()[0]
+        assert 'present=yes' in line
+        assert 'absent' not in line
+
+    def test_log_shutdown_state_never_raises(self):
+        class Exploding:
+            def __repr__(self):
+                raise RuntimeError('boom')
+        # Must be swallowed — this runs on shutdown paths.
+        _log_shutdown_state('unit_test', bad=Exploding())
+
+    def test_settings_file_hint_leaks_no_home_directory(self):
+        hint = _settings_file_hint()
+        if hint is None:
+            pytest.skip('settings path unavailable in this env')
+        # One parent dir + filename only; never an absolute path, which on
+        # Windows/macOS embeds the username and would land in crash reports.
+        assert not os.path.isabs(hint)
+        assert hint.count(os.sep) <= 1
+
+
+class TestWriteVerification:
+    def test_matching_value_logs_persisted(self, fake_settings, shutdown_log):
+        fake_settings['data'] = {EXIT_REASON_KEY: 'clean'}
+        _verify_exit_reason_persisted('unit', 'clean')
+        assert any('persisted' in ln for ln in shutdown_log())
+
+    def test_lost_write_is_reported_loudly(self, fake_settings, shutdown_log):
+        fake_settings['data'] = {EXIT_REASON_KEY: 'unknown'}
+        _verify_exit_reason_persisted('unit', 'clean')
+        lines = shutdown_log()
+        assert any('WRITE DID NOT STICK' in ln for ln in lines)
+        assert any("expected='clean'" in ln and "on_disk='unknown'" in ln for ln in lines)
+
+    def test_read_failure_is_reported_not_raised(self, monkeypatch, shutdown_log):
+        def _boom():
+            raise OSError('disk gone')
+        monkeypatch.setattr(visualizer, 'load_persisted_settings', _boom)
+        _verify_exit_reason_persisted('unit', 'clean')
+        assert any('verification read failed' in ln for ln in shutdown_log())
+
+
+class TestExitReasonTransitions:
+    def test_transition_logs_old_and_new_and_source(self, fake_settings, shutdown_log):
+        fake_settings['data'] = {EXIT_REASON_KEY: 'unknown'}
+        _mark_session_exit_reason('crash', source='unit-test')
+        line = next(ln for ln in shutdown_log() if 'transition' in ln)
+        assert "previous='unknown'" in line
+        assert 'new=crash' in line
+        assert 'source=unit-test' in line
+
+    def test_transition_persists_the_value(self, fake_settings):
+        fake_settings['data'] = {EXIT_REASON_KEY: 'unknown'}
+        _mark_session_exit_reason('os_shutdown', source='unit-test')
+        assert fake_settings['data'][EXIT_REASON_KEY] == 'os_shutdown'
+
+    def test_clean_reason_clears_the_unclean_flag(self, fake_settings):
+        fake_settings['data'] = {
+            EXIT_REASON_KEY: 'unknown',
+            'last_unclean_shutdown_utc': '2026-07-01T00:00:00Z',
+        }
+        _mark_session_exit_reason('clean', source='unit-test')
+        assert 'last_unclean_shutdown_utc' not in fake_settings['data']
+        assert fake_settings['data']['app_session_closed_cleanly'] is True
+
+    def test_invalid_reason_is_rejected_and_logged(self, fake_settings, shutdown_log):
+        fake_settings['data'] = {EXIT_REASON_KEY: 'unknown'}
+        _mark_session_exit_reason('bogus', source='unit-test')
+        assert any('REJECTED' in ln for ln in shutdown_log())
+        # State untouched.
+        assert fake_settings['data'][EXIT_REASON_KEY] == 'unknown'
+
+    def test_save_failure_is_logged_not_swallowed(self, monkeypatch, fake_settings, shutdown_log):
+        def _boom(_payload):
+            raise OSError('read-only filesystem')
+        monkeypatch.setattr(visualizer, 'save_persisted_settings', _boom)
+        _mark_session_exit_reason('crash', source='unit-test')
+        assert any('FAILED to record' in ln for ln in shutdown_log())
+
+    def test_default_source_is_recorded(self, fake_settings, shutdown_log):
+        fake_settings['data'] = {EXIT_REASON_KEY: 'unknown'}
+        _mark_session_exit_reason('crash')
+        assert any('source=unspecified' in ln for ln in shutdown_log())
+
+
+class TestCleanExit:
+    def test_marks_clean_and_logs_entry_with_source(self, fake_settings, shutdown_log):
+        fake_settings['data'] = {EXIT_REASON_KEY: 'unknown'}
+        _mark_session_clean_exit(source='main:finally')
+        lines = shutdown_log()
+        assert any('clean_exit: entered' in ln and 'source=main:finally' in ln for ln in lines)
+        assert any('marking clean' in ln for ln in lines)
+        assert fake_settings['data'][EXIT_REASON_KEY] == 'clean'
+
+    @pytest.mark.parametrize('preserved', ['crash', 'os_shutdown'])
+    def test_does_not_downgrade_an_earlier_verdict(self, fake_settings, shutdown_log, preserved):
+        fake_settings['data'] = {EXIT_REASON_KEY: preserved}
+        _mark_session_clean_exit(source='main:finally')
+        assert fake_settings['data'][EXIT_REASON_KEY] == preserved
+        assert any(f'preserved={preserved}' in ln for ln in shutdown_log())
+
+    def test_clears_stale_unclean_flag(self, fake_settings):
+        fake_settings['data'] = {
+            EXIT_REASON_KEY: 'unknown',
+            'last_unclean_shutdown_utc': '2026-07-01T00:00:00Z',
+        }
+        _mark_session_clean_exit(source='unit-test')
+        assert 'last_unclean_shutdown_utc' not in fake_settings['data']
+
+    def test_entry_is_logged_even_when_the_write_fails(
+        self, monkeypatch, fake_settings, shutdown_log
+    ):
+        """The whole point: distinguish 'never ran' from 'ran and lost'."""
+        def _boom(_payload):
+            raise OSError('disk full')
+        monkeypatch.setattr(visualizer, 'save_persisted_settings', _boom)
+        _mark_session_clean_exit(source='main:finally')
+        lines = shutdown_log()
+        assert any('clean_exit: entered' in ln for ln in lines)
+        assert any('FAILED to mark clean exit' in ln for ln in lines)
+
+
+class TestSessionStartLogging:
+    def test_logs_classification_inputs_and_flags_unclean(self, fake_settings, shutdown_log):
+        fake_settings['data'] = {
+            EXIT_REASON_KEY: 'unknown',
+            'app_session_started_utc': '2026-07-01T00:00:00Z',
+            'app_session_pid': 4242,
+        }
+        visualizer._mark_session_start()
+        lines = shutdown_log()
+        assert any('classifying prior session' in ln for ln in lines)
+        assert any('FLAGGING prior session unclean' in ln for ln in lines)
+        assert any('prev_pid=4242' in ln for ln in lines)
+        assert fake_settings['data']['last_unclean_shutdown_utc'] == '2026-07-01T00:00:00Z'
+
+    def test_clean_prior_session_is_not_flagged(self, fake_settings, shutdown_log):
+        fake_settings['data'] = {
+            EXIT_REASON_KEY: 'clean',
+            'app_session_started_utc': '2026-07-01T00:00:00Z',
+        }
+        visualizer._mark_session_start()
+        lines = shutdown_log()
+        assert any('prior session OK' in ln for ln in lines)
+        assert 'last_unclean_shutdown_utc' not in fake_settings['data']
+
+    def test_opens_new_session_as_unknown(self, fake_settings, shutdown_log):
+        fake_settings['data'] = {EXIT_REASON_KEY: 'clean'}
+        visualizer._mark_session_start()
+        assert fake_settings['data'][EXIT_REASON_KEY] == 'unknown'
+        assert fake_settings['data']['app_session_pid'] == os.getpid()
+        assert any('opening new session' in ln for ln in shutdown_log())
+
+
+if __name__ == '__main__':
+    pytest.main([__file__, '-v'])

--- a/analyzer/visualizer.py
+++ b/analyzer/visualizer.py
@@ -194,6 +194,111 @@ def _utc_now_iso() -> str:
 EXIT_REASON_KEY = 'app_session_exit_reason'
 EXIT_REASON_MIGRATION_KEY = 'exit_reason_migrated_v1'
 
+# ── Shutdown-tracker instrumentation ──────────────────────────────────────
+# A large share of incoming crash reports are recovery-dialog false
+# positives: the log tail shows a session that ended normally, yet the next
+# launch classified it 'unknown' and prompted for a crash report. The state
+# machine has three writers (_mark_session_start, _mark_session_clean_exit,
+# _mark_session_exit_reason), every one of which swallows its exceptions,
+# so today a failed write is indistinguishable from a write that never
+# happened.
+#
+# Everything below is observability only — no control flow depends on it.
+# Each transition logs old → new plus the writer that caused it, and each
+# write is read back to confirm it actually landed on disk. Together with
+# the prior session's pid liveness (see _pid_is_alive) these lines should
+# identify which path is failing to run, or whether a second concurrently
+# running instance is clobbering the first one's state.
+_SHUTDOWN_TAG = '[shutdown]'
+
+
+def _pid_is_alive(pid: int) -> Optional[bool]:
+    """Best-effort liveness check for a pid. None when undeterminable.
+
+    Used to log whether the *previous* session's process is somehow still
+    running when a new one starts — the signature of a second instance
+    overwriting the first's exit-reason bookkeeping, which would present
+    exactly as a false unclean-shutdown on the next launch.
+    """
+    if not pid or pid <= 0:
+        return None
+    try:
+        if sys.platform.startswith('win'):
+            import ctypes
+            PROCESS_QUERY_LIMITED_INFORMATION = 0x1000
+            STILL_ACTIVE = 259
+            kernel32 = ctypes.WinDLL('kernel32', use_last_error=True)
+            handle = kernel32.OpenProcess(
+                PROCESS_QUERY_LIMITED_INFORMATION, False, int(pid)
+            )
+            if not handle:
+                return False
+            try:
+                code = ctypes.c_ulong()
+                if not kernel32.GetExitCodeProcess(handle, ctypes.byref(code)):
+                    return None
+                return code.value == STILL_ACTIVE
+            finally:
+                kernel32.CloseHandle(handle)
+        os.kill(int(pid), 0)
+        return True
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        # Process exists but is owned by someone else.
+        return True
+    except Exception:
+        return None
+
+
+def _settings_file_hint() -> Optional[str]:
+    """Basename + parent of the settings file, for the session-start line.
+
+    Full paths are not logged — a home directory leaks the username into
+    crash reports. Two instances disagreeing on this value (e.g. a sandboxed
+    App Store build vs a direct build) would explain state that never
+    appears to persist.
+    """
+    try:
+        from settings_utils import _get_settings_path
+        path = _get_settings_path()
+        return os.path.join(os.path.basename(os.path.dirname(path)), os.path.basename(path))
+    except Exception:
+        return None
+
+
+def _log_shutdown_state(event: str, **fields) -> None:
+    """Emit one structured ``[shutdown]`` line. Never raises."""
+    try:
+        parts = ' '.join(f'{k}={v}' for k, v in fields.items() if v is not None)
+        info(f'{_SHUTDOWN_TAG} {event}{(" " + parts) if parts else ""}')
+    except Exception:
+        pass
+
+
+def _verify_exit_reason_persisted(event: str, expected: str) -> None:
+    """Re-read settings and warn if ``EXIT_REASON_KEY`` didn't stick.
+
+    This is the single most useful datum for the false-positive
+    investigation: it separates "the writer never ran" from "the writer ran
+    and the value did not survive the write" (corrupt settings.json, a
+    refused save, or a racing writer overwriting it).
+    """
+    try:
+        on_disk = str(
+            load_persisted_settings().get(EXIT_REASON_KEY, '') or ''
+        ).strip().lower()
+        if on_disk == expected:
+            _log_shutdown_state(f'{event}: persisted', exit_reason=on_disk)
+        else:
+            warn(
+                f'{_SHUTDOWN_TAG} {event}: WRITE DID NOT STICK — '
+                f'expected={expected!r} on_disk={on_disk!r}. Next launch will '
+                f'likely report a false unclean shutdown.'
+            )
+    except Exception as exc:
+        warn(f'{_SHUTDOWN_TAG} {event}: verification read failed: {exc}')
+
 
 def _classify_prior_session(settings: dict) -> str:
     """Return the previous session's exit reason, applying legacy migration.
@@ -221,19 +326,56 @@ def _mark_session_start() -> None:
         settings = load_persisted_settings()
         prev_reason = _classify_prior_session(settings)
         prev_started = str(settings.get('app_session_started_utc', '') or '').strip()
+        prev_pid = int(settings.get('app_session_pid', 0) or 0)
+
+        # Full classification inputs, so a crash-report log tail shows exactly
+        # what the detector saw rather than just its verdict.
+        _log_shutdown_state(
+            'session_start: classifying prior session',
+            raw_exit_reason=repr(str(settings.get(EXIT_REASON_KEY, '') or '')),
+            classified=prev_reason,
+            prev_started=prev_started or "''",
+            prev_pid=prev_pid or None,
+            # True here means the previous session's process is somehow still
+            # running — i.e. a second instance is about to overwrite its
+            # bookkeeping. Prime suspect for the false positives.
+            prev_pid_alive=_pid_is_alive(prev_pid),
+            legacy_closed_cleanly=settings.get('app_session_closed_cleanly'),
+            already_migrated=bool(settings.get(EXIT_REASON_MIGRATION_KEY)),
+            last_closed=str(settings.get('last_session_closed_utc', '') or '') or None,
+        )
+
         # Only 'crash' and 'unknown' get surfaced as recoverable unclean
         # shutdowns. 'os_shutdown' is intentionally suppressed so PC reboots
         # don't generate false crash dialogs.
         if prev_reason in ('crash', 'unknown') and prev_started:
             settings['last_unclean_shutdown_utc'] = prev_started
+            _log_shutdown_state(
+                'session_start: FLAGGING prior session unclean',
+                reason=prev_reason,
+                unclean_utc=prev_started,
+            )
         else:
+            had_flag = bool(str(settings.get('last_unclean_shutdown_utc', '') or '').strip())
             settings.pop('last_unclean_shutdown_utc', None)
+            _log_shutdown_state(
+                'session_start: prior session OK',
+                reason=prev_reason,
+                cleared_stale_flag=had_flag or None,
+            )
         settings['last_exit_reason'] = prev_reason
         settings[EXIT_REASON_MIGRATION_KEY] = True
         settings['app_session_started_utc'] = _utc_now_iso()
         settings['app_session_closed_cleanly'] = False  # legacy, kept one release
         settings[EXIT_REASON_KEY] = 'unknown'
         settings['app_session_pid'] = int(os.getpid())
+        _log_shutdown_state(
+            'session_start: opening new session',
+            exit_reason="'unknown' (until exit)",
+            pid=os.getpid(),
+            started=settings['app_session_started_utc'],
+            settings_file=_settings_file_hint(),
+        )
 
         try:
             today_utc = datetime.utcnow().strftime('%Y-%m-%d')
@@ -252,11 +394,14 @@ def _mark_session_start() -> None:
             pass
 
         save_persisted_settings(settings)
-    except Exception:
-        pass
+        _verify_exit_reason_persisted('session_start', 'unknown')
+    except Exception as exc:
+        # Previously silent. A failure here means the new session was never
+        # registered, so the *next* launch reads stale state.
+        warn(f'{_SHUTDOWN_TAG} session_start: FAILED to record session start: {exc}')
 
 
-def _mark_session_clean_exit() -> None:
+def _mark_session_clean_exit(source: str = 'unspecified') -> None:
     """Mark this session closed cleanly and clear stale unclean-shutdown recovery.
 
     Preserves a previously-recorded 'os_shutdown' or 'crash' reason — the
@@ -265,17 +410,38 @@ def _mark_session_clean_exit() -> None:
     window during reboot/logoff. In the latter case shutdown_watch has
     already recorded 'os_shutdown' and we must not overwrite it.
     """
+    _log_shutdown_state('clean_exit: entered', source=source, pid=os.getpid())
     try:
         settings = load_persisted_settings()
         settings['app_session_closed_cleanly'] = True
         existing_reason = str(settings.get(EXIT_REASON_KEY, '') or '').strip().lower()
         if existing_reason not in ('os_shutdown', 'crash'):
             settings[EXIT_REASON_KEY] = 'clean'
+            _log_shutdown_state(
+                'clean_exit: marking clean',
+                previous=repr(existing_reason),
+                pid=os.getpid(),
+            )
+        else:
+            # Not an error: shutdown_watch or the crash handler already
+            # classified this exit and that verdict outranks 'clean'.
+            _log_shutdown_state(
+                'clean_exit: preserving earlier reason',
+                preserved=existing_reason,
+                pid=os.getpid(),
+            )
         settings['last_session_closed_utc'] = _utc_now_iso()
         settings.pop('last_unclean_shutdown_utc', None)
         save_persisted_settings(settings)
-    except Exception:
-        pass
+        _verify_exit_reason_persisted(
+            'clean_exit',
+            'clean' if existing_reason not in ('os_shutdown', 'crash') else existing_reason,
+        )
+    except Exception as exc:
+        # Previously silent. This is the highest-value failure to know about:
+        # if this write is lost, the next launch sees 'unknown' and shows the
+        # recovery dialog for a session that in fact exited normally.
+        warn(f'{_SHUTDOWN_TAG} clean_exit: FAILED to mark clean exit: {exc}')
 
 
 def _is_pywebview_orphan_callback(exc_type, exc_value) -> bool:
@@ -297,25 +463,43 @@ def _is_pywebview_orphan_callback(exc_type, exc_value) -> bool:
     return '_returnValuesCallbacks' in msg and 'is not a function' in msg
 
 
-def _mark_session_exit_reason(reason: str) -> None:
+def _mark_session_exit_reason(reason: str, source: str = 'unspecified') -> None:
     """Atomically record the cause of an in-progress shutdown.
 
     Called from the OS-shutdown watcher (``shutdown_watch``) and from the
     top-level crash handler so the next launch can distinguish a true
     application crash from a system reboot or logoff. Failsafe: any I/O
     error is swallowed because this runs at the worst possible moment.
+
+    ``source`` names the caller and appears in the ``[shutdown]`` log line;
+    it exists purely so a crash-report log tail shows which writer fired.
     """
     if reason not in ('clean', 'os_shutdown', 'crash', 'unknown'):
+        warn(f'{_SHUTDOWN_TAG} exit_reason: REJECTED invalid reason={reason!r} source={source}')
         return
     try:
         settings = load_persisted_settings()
+        previous = str(settings.get(EXIT_REASON_KEY, '') or '').strip().lower()
         settings[EXIT_REASON_KEY] = reason
         if reason == 'clean':
             settings['app_session_closed_cleanly'] = True
             settings.pop('last_unclean_shutdown_utc', None)
+        _log_shutdown_state(
+            'exit_reason: transition',
+            previous=repr(previous),
+            new=reason,
+            source=source,
+            pid=os.getpid(),
+        )
         save_persisted_settings(settings)
-    except Exception:
-        pass
+        _verify_exit_reason_persisted('exit_reason', reason)
+    except Exception as exc:
+        # Runs during OS shutdown or from the crash handler, so it must not
+        # raise — but it should no longer vanish without a trace either.
+        warn(
+            f'{_SHUTDOWN_TAG} exit_reason: FAILED to record reason={reason!r} '
+            f'source={source}: {exc}'
+        )
 
 
 def _apply_legal_upgrade_self_heal(settings: dict, prev_version: str, current_version: str) -> bool:
@@ -864,9 +1048,19 @@ def main():
     # suppress the false unclean-shutdown dialog. Best-effort and failsafe.
     try:
         import shutdown_watch
-        shutdown_watch.install(lambda: _mark_session_exit_reason('os_shutdown'))
+        _watch_installed = shutdown_watch.install(
+            lambda: _mark_session_exit_reason('os_shutdown', source='shutdown_watch')
+        )
+        # If no listener installed, an OS reboot/logoff cannot be
+        # distinguished from a crash and *will* raise a false unclean
+        # shutdown on the next launch. Worth knowing per-platform.
+        _log_shutdown_state(
+            'watch_install',
+            installed=bool(_watch_installed),
+            platform=sys.platform,
+        )
     except Exception as _e:
-        warn('shutdown_watch install failed:', _e)
+        warn(f'{_SHUTDOWN_TAG} watch_install: shutdown_watch install failed: {_e}')
 
     # ── Crash hardening ───────────────────────────────────────────────────────
     # faulthandler dumps a Python traceback to stderr (which is tee-streamed to
@@ -900,7 +1094,7 @@ def main():
             tb_str = ''.join(_tb.format_exception(args.exc_type, args.exc_value, args.exc_traceback))
             error(f'[Thread {thread_name!r}] Uncaught exception: {args.exc_type.__name__}: {args.exc_value}')
             error(f'[Thread {thread_name!r}] Traceback:\n{tb_str}')
-            _mark_session_exit_reason('crash')
+            _mark_session_exit_reason('crash', source=f'thread_excepthook:{thread_name}')
             if _telemetry is not None:
                 try:
                     _crash_settings = load_persisted_settings()
@@ -1175,17 +1369,22 @@ def main():
         log('Server stopped.')
         # Mark clean exit here (inside finally) so it runs even if server
         # shutdown raises, preventing a false "unclean shutdown" on next launch.
-        _mark_session_clean_exit()
+        # NOTE: in the recovery-dialog false-positive reports, 'Server stopped.'
+        # is very often the final line of the captured log. The [shutdown]
+        # lines emitted below are what distinguish "this call never returned"
+        # from "it ran and the write was lost".
+        _mark_session_clean_exit(source='main:finally')
+        _log_shutdown_state('main: exit path complete', pid=os.getpid())
 
 
 if __name__ == '__main__':
     try:
         main()
     except KeyboardInterrupt:
-        _mark_session_clean_exit()
+        _mark_session_clean_exit(source='KeyboardInterrupt')
     except Exception as _main_exc:
         # Top-level crash handler — send crash report before re-raising
-        _mark_session_exit_reason('crash')
+        _mark_session_exit_reason('crash', source='main:toplevel')
         try:
             import traceback as _tb
             if _telemetry is not None:


### PR DESCRIPTION
## Why

Recovery-dialog false positives are the single largest category in triage — 20 of the 22 crashes in the 2026-07-26 run. The log tail shows a session that ended normally, yet the next launch classified it `unknown` and prompted for a crash report.

The tracker has three writers — `_mark_session_start`, `_mark_session_clean_exit`, `_mark_session_exit_reason` — and every one of them swallowed its exceptions. So today a failed write looks exactly like a write that never happened. In most of these reports `Server stopped.` is the final captured line, which is precisely the point where that ambiguity bites: `_mark_session_clean_exit()` is the next statement, and it emitted nothing either way.

This is instrumentation only — no control flow depends on any of it, and no persisted value changes.

## What gets logged

All lines are tagged `[shutdown]` so they're greppable in a crash-report log tail.

**Transitions** — old → new, the writer responsible (new `source` argument on both exit writers), and the pid:

```
[shutdown] exit_reason: transition previous='unknown' new=os_shutdown source=shutdown_watch pid=19280
[shutdown] clean_exit: entered source=main:finally pid=19280
[shutdown] clean_exit: preserving earlier reason preserved=os_shutdown pid=19280
```

**Write verification** — every write is read back. This is the datum that separates "the writer never ran" from "it ran and the value did not survive":

```
[shutdown] clean_exit: persisted exit_reason=clean
[shutdown] clean_exit: WRITE DID NOT STICK — expected='clean' on_disk='unknown'. Next launch will likely report a false unclean shutdown.
```

**Classification inputs at startup**, not just the verdict:

```
[shutdown] session_start: classifying prior session raw_exit_reason='unknown' classified=unknown prev_started=2026-07-26T21:38:01Z prev_pid=19280 prev_pid_alive=True legacy_closed_cleanly=False already_migrated=True last_closed=2026-07-26T21:37:44Z
[shutdown] session_start: FLAGGING prior session unclean reason=unknown unclean_utc=2026-07-26T21:38:01Z
```

`prev_pid_alive` is the one I'd watch first. `app_session_pid` has been recorded for a while but is never read by anything. If the previous session's process is still running when a new one starts, a second instance is overwriting the first's bookkeeping — which would present as exactly this false positive. That hypothesis is currently untestable from the data we collect; after this it is a single grep.

**Watch install result**, per platform — when no listener installs, an OS reboot can't be told apart from a crash and *always* raises a false positive on the next launch:

```
[shutdown] watch_install installed=True platform=win32
```

**The read side** — `get_recovery_status` logs the inputs to the dialog decision and whether it will prompt; `clear_recovery_state` logs what it cleared.

Finally, the previously silent `except Exception: pass` blocks in all three writers now `warn` with the exception.

## Privacy

No new PII. The only path logged is `_settings_file_hint()`, which reduces the settings path to the app-data folder name plus filename (`ProjectKestrel/settings.json`). That parent directory is a fixed app name on all three platforms — verified in `settings_utils._get_user_data_dir` — so no username can reach a report. A test asserts the hint is never an absolute path.

## Test plan

- [x] New `analyzer/tests/unit/test_shutdown_tracker_logging.py` — 25 tests covering pid liveness tri-state, log-helper safety (including a field whose `__repr__` raises), write verification on match/mismatch/read-failure, all four transition paths, invalid-reason rejection, save-failure logging, `clean_exit` not downgrading an earlier `crash`/`os_shutdown` verdict, and the session-start flag/no-flag branches.
- [x] Existing `test_session_lifecycle.py` still passes unchanged — 12 tests. 37 total.
- [x] Simulated four full launch/exit lifecycles (fresh install, clean quit, killed process, OS reboot) and confirmed the emitted lines read correctly end to end, including the false-positive path.
- [x] No regressions in the rest of the unit suite: 473 passed. The 6 failures and 12 collection errors present are all missing `numpy`/`pandas`/`cv2` in the container and reproduce identically on unmodified `dev`.

## Follow-up

No fix here by design — the goal is a few weeks of data. Once reports carry these lines, the failing path should be identifiable directly from the tail, and I'll pick it up in a future triage run.

---
_Generated by [Claude Code](https://claude.ai/code/session_01T2vZxpER4cvBcDbUXHWUVx)_