### PR TITLE
Model the Cloud Compute time estimate on the real pipeline

### DIFF
--- a/analyzer/api_bridge.py
+++ b/analyzer/api_bridge.py
@@ -4498,9 +4498,15 @@ class Api:
         """Run a real-image upload-throughput probe against the staging bucket.
 
         Returns ``{ok, mbps, samples_uploaded, total_bytes, elapsed_ms,
-        errors}``. Errors surface as ``{ok: False, error}``; the Worker's
-        ``file_too_large`` rejection is propagated verbatim so the dialog can
-        explain the 200 MB cap.
+        errors, pipeline}``. Errors surface as ``{ok: False, error}``; the
+        Worker's ``file_too_large`` rejection is propagated verbatim so the
+        dialog can explain the 200 MB cap.
+
+        ``pipeline`` carries the Worker's own dispatch/scale-out constants
+        (thresholds, container cap, spawn cooldown, cold start, per-container
+        throughput) so the analyze dialog's job-time estimate models the
+        deployed pipeline rather than a hardcoded copy that goes stale when a
+        threshold moves. ``None`` against an older Worker.
         """
         root_real, err = self._validate_root_dir(
             folder_path, context="cloud_compute_upload_test", require_exists=True

--- a/analyzer/cloud_compute_client.py
+++ b/analyzer/cloud_compute_client.py
@@ -702,8 +702,14 @@ class CloudComputeClient:
         test... N/10``.
 
         Returns ``{mbps, samples_uploaded, total_bytes, elapsed_ms,
-        bytes_per_sample, errors}``. Raises :class:`CloudComputeError` if the
-        Worker rejects the request (e.g. a 200 MB file size cap is hit).
+        bytes_per_sample, errors, pipeline}``. Raises :class:`CloudComputeError`
+        if the Worker rejects the request (e.g. a 200 MB file size cap is hit).
+
+        ``pipeline`` is the Worker's dispatch/scale-out descriptor (thresholds,
+        container cap, cold start, per-container throughput) used by the
+        analyze dialog's job-time estimate. It is passed through verbatim and
+        is ``None`` against a Worker too old to serve it — the estimate falls
+        back to its own built-in values, so this is advisory, never fatal.
         """
         folder = Path(folder).resolve()
         if not folder.is_dir():
@@ -787,6 +793,7 @@ class CloudComputeClient:
         ok_results = [r for r in results if 200 <= r[0] < 300]
         total_bytes = sum(r[1] for r in ok_results)
         mbps = (total_bytes / 1_048_576) / elapsed_total if elapsed_total > 0 else 0.0
+        pipeline = resp.get("pipeline")
         return {
             "mbps": mbps,
             "samples_uploaded": len(ok_results),
@@ -795,6 +802,7 @@ class CloudComputeClient:
             "elapsed_ms": int(elapsed_total * 1000),
             "bytes_per_sample": sizes,
             "errors": errors,
+            "pipeline": pipeline if isinstance(pipeline, dict) else None,
         }
 
     # ─── End-to-end orchestrator ─────────────────────────────────────────

--- a/analyzer/css/dialogs/analyze.css
+++ b/analyzer/css/dialogs/analyze.css
@@ -1123,3 +1123,20 @@
   color: #cfe2ff;
   border-color: #7eb8e0;
 }
+
+/* Pre-flight bottleneck chip under the cloud est. time stat. Tells the user
+   whether the quoted number is bounded by their connection or by Cloud
+   Compute, so a slow estimate points at something actionable. */
+.adlg-cloud-regime {
+  display: block;
+  margin-top: 3px;
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+  color: var(--muted, #8a93a5);
+  cursor: help;
+}
+.adlg-cloud-regime--upload   { color: #7eb8e0; }
+.adlg-cloud-regime--compute  { color: #e0b070; }
+.adlg-cloud-regime--balanced { color: #7fc98a; }

--- a/analyzer/css/dialogs/cloud-compute.css
+++ b/analyzer/css/dialogs/cloud-compute.css
@@ -899,3 +899,21 @@ dialog.kdlg.signin-chooser-dlg {
   color: var(--muted, #778);
   text-align: center;
 }
+
+/* Live bottleneck read-out — sits alongside the two phase pills and names
+   which half of the pipeline is currently the constraint. Deliberately
+   lower-contrast than the phase pills: it's context, not status. */
+.cloud-bottleneck-pill {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  padding: 1px 7px;
+  border-radius: var(--radius-sm);
+  border: 1px solid transparent;
+  background: transparent;
+  color: var(--muted, #888);
+  cursor: help;
+}
+.cloud-bottleneck-pill.upload   { color: #9bb8ff; border-color: #35406040; }
+.cloud-bottleneck-pill.compute  { color: #ffc060; border-color: #4a3a2040; }
+.cloud-bottleneck-pill.balanced { color: #6bcf6b; border-color: #24401f40; }

--- a/analyzer/js/analyze-dialog.js
+++ b/analyzer/js/analyze-dialog.js
@@ -57,39 +57,192 @@
       return el;
     }
 
-    // Cloud destination est. time:
-    //   max(upload_seconds, analysis_floor_seconds)
-    // where analysis_floor = images × 0.5s (sustained 2 imgs/sec on Modal),
-    // and upload_seconds is computed from the speed-test result if present.
-    // Returns null when destination=cloud and no speed test has run yet.
-    const _CLOUD_ANALYSIS_FLOOR_SECS_PER_IMG = 0.5; // 2 imgs/sec sustained
+    // ── Cloud destination est. time ────────────────────────────────────────────
+    //
+    // The old model was `max(upload_seconds, images × 0.5s)`. The 0.5 s/img
+    // analysis floor assumed 2 img/sec sustained, but a job that scales out to
+    // its full container allowance sustains ~3 img/sec — so the floor carried a
+    // permanent ~50% pessimism that dominated the estimate on fast connections.
+    //
+    // The model below simulates the actual worker pipeline instead:
+    //   1. Nothing is analyzed until CLOUDCOMPUTE_DISPATCH_THRESHOLD images
+    //      (or the whole job, if smaller) have landed in R2 staging.
+    //   2. One Modal container starts, after a cold-start delay.
+    //   3. Whenever the un-analyzed uploaded backlog reaches SCALE_THRESHOLD,
+    //      the worker splits the range and spawns another container — up to
+    //      maxContainersPerJob, subject to a spawn cooldown.
+    //   4. Each container sustains ~1 img/sec.
+    // Analysis can never run ahead of the bytes, so the two phases interleave;
+    // simulating them together is what makes the estimate track reality on both
+    // slow and fast connections.
+    //
+    // The pipeline parameters are SERVED BY THE WORKER, in the `pipeline` block
+    // of the POST /api/upload-test response — the same speed test that gives us
+    // the transfer rate. They are read from the module the scheduler itself
+    // reads, so they cannot drift the way a hardcoded copy does (the deployed
+    // thresholds moved 250→100 and 500→200 at one point, which a mirrored copy
+    // would have silently missed).
+    //
+    // The values below are FALLBACKS ONLY, for an older Worker that doesn't
+    // serve the block, or a malformed response. They match the deployed values
+    // as of 2026-08; if they're ever what's actually in use, the estimate is
+    // still reasonable — just not authoritative.
+    const _CLOUD_FALLBACK_PIPELINE = {
+      containerImagesPerSec:   1.0,   // one Modal container, sustained
+      maxContainers:           3,     // limits.maxContainersPerJob
+      dispatchThreshold:       100,   // CLOUDCOMPUTE_DISPATCH_THRESHOLD
+      scaleThreshold:          200,   // SCALE_THRESHOLD (backlog to split)
+      spawnCooldownSeconds:    20,    // SPAWN_COOLDOWN_SEC
+      containerStartupSeconds: 22,    // measured Modal cold start
+    };
+    // Was effectively +50% (via the 0.5 s/img floor). The simulation models the
+    // ramp explicitly, so the residual margin only needs to cover jitter.
+    const _CLOUD_EST_MARGIN = 1.05;
 
+    // Merge the served descriptor over the fallbacks, field by field, so a
+    // Worker that grows/drops one key doesn't invalidate the rest. Every value
+    // must be a finite positive number to be taken.
+    function _cloudPipelineParams() {
+      const served = (typeof _cloudSpeedTestResult !== 'undefined' && _cloudSpeedTestResult)
+        ? _cloudSpeedTestResult.pipeline
+        : null;
+      const out = Object.assign({}, _CLOUD_FALLBACK_PIPELINE);
+      if (served && typeof served === 'object') {
+        for (const key of Object.keys(_CLOUD_FALLBACK_PIPELINE)) {
+          const v = Number(served[key]);
+          if (isFinite(v) && v > 0) out[key] = v;
+        }
+      }
+      return out;
+    }
+
+    // Simulate the upload/analysis pipeline. `uploadRate` is images/sec, or
+    // Infinity to model "bytes are already there" (used to isolate the
+    // compute-bound completion time). Returns seconds to the last analyzed image.
+    function _simulateCloudJob(totalImages, uploadRate, params) {
+      const p = params || _cloudPipelineParams();
+      const n = Math.max(0, Math.floor(totalImages));
+      if (n === 0) return 0;
+      const instant = !(uploadRate > 0) || !isFinite(uploadRate);
+      // Aim for ~2000 steps regardless of job size: fine enough to resolve the
+      // spawn cooldown on short jobs, coarse enough that a 20k-image job on a
+      // slow line doesn't stall the UI thread. This runs on every summary
+      // refresh and once per queued folder.
+      const horizon = instant
+        ? n / (p.maxContainers * p.containerImagesPerSec)
+        : n / uploadRate + n / p.containerImagesPerSec;
+      const dt = Math.min(60, Math.max(0.25, (horizon + p.containerStartupSeconds) / 2000));
+      const firstDispatchAt = Math.min(n, p.dispatchThreshold);
+
+      let t = 0;
+      let analyzed = 0;
+      let spawned = 0;          // containers spawned so far
+      let lastSpawnAt = -Infinity;
+      const readyAt = [];       // wall-clock time each container starts working
+      // Hard iteration bound: a stalled model must not spin the UI thread.
+      const maxSteps = 200000;
+
+      for (let step = 0; step < maxSteps && analyzed < n; step++) {
+        const uploaded = instant ? n : Math.min(n, uploadRate * t);
+        const backlog = uploaded - analyzed;
+
+        // Spawn decisions. The first container waits for the dispatch
+        // threshold; later ones wait for the backlog to justify a split.
+        const canSpawn = spawned < p.maxContainers
+          && (t - lastSpawnAt) >= p.spawnCooldownSeconds;
+        if (canSpawn) {
+          const trigger = spawned === 0
+            ? uploaded >= firstDispatchAt
+            : backlog >= p.scaleThreshold;
+          if (trigger) {
+            readyAt.push(t + p.containerStartupSeconds);
+            spawned++;
+            lastSpawnAt = t;
+          }
+        }
+
+        let active = 0;
+        for (let i = 0; i < readyAt.length; i++) if (readyAt[i] <= t) active++;
+        if (active > 0) {
+          // Analysis is clamped by what has actually been uploaded.
+          const capacity = active * p.containerImagesPerSec * dt;
+          analyzed = Math.min(n, analyzed + Math.min(capacity, Math.max(0, backlog)));
+        }
+        t += dt;
+      }
+      return t;
+    }
+
+    // Returns:
+    //   secs        — modelled wall-clock estimate (null before a speed test)
+    //   uploadSecs  — pure transfer time for the bytes
+    //   analysisSecs— pure compute time if the bytes were already staged
+    //   regime      — 'upload' | 'balanced' | 'compute' (null without a test)
     function _getCloudEstSeconds(totalImages) {
       const result = (typeof _cloudSpeedTestResult !== 'undefined') ? _cloudSpeedTestResult : null;
-      const analysisSecs = totalImages * _CLOUD_ANALYSIS_FLOOR_SECS_PER_IMG;
+      const p = _cloudPipelineParams();
+      const computeSecs = _simulateCloudJob(totalImages, Infinity, p);
       if (!result || !(result.mbps > 0) || !(result.samples_uploaded > 0)) {
-        return { secs: null, analysisSecs, uploadSecs: null, hasTest: false };
+        return { secs: null, analysisSecs: computeSecs, uploadSecs: null, regime: null, hasTest: false };
       }
       const avgBytes = Number(result.total_bytes || 0) / Number(result.samples_uploaded || 1);
-      if (!(avgBytes > 0)) return { secs: null, analysisSecs, uploadSecs: null, hasTest: true };
-      const totalMB = (totalImages * avgBytes) / 1_048_576;
-      const uploadSecs = totalMB / Number(result.mbps);
-      return {
-        secs: Math.max(analysisSecs, uploadSecs),
-        analysisSecs,
-        uploadSecs,
-        hasTest: true,
-      };
+      if (!(avgBytes > 0)) {
+        return { secs: null, analysisSecs: computeSecs, uploadSecs: null, regime: null, hasTest: true };
+      }
+      const avgMB = avgBytes / 1_048_576;
+      const uploadRate = Number(result.mbps) / avgMB;             // images/sec
+      const uploadSecs = totalImages / uploadRate;
+      const secs = _simulateCloudJob(totalImages, uploadRate, p) * _CLOUD_EST_MARGIN;
+
+      // Which side is the binding constraint? Both reference times come out of
+      // the same model, so the comparison is apples-to-apples. The dead band
+      // keeps the label from flickering when the two are within noise.
+      let regime = 'balanced';
+      if (computeSecs > 0) {
+        const ratio = uploadSecs / computeSecs;
+        if (ratio > 1.15) regime = 'upload';
+        else if (ratio < 0.87) regime = 'compute';
+      }
+      return { secs, analysisSecs: computeSecs, uploadSecs, regime, hasTest: true };
+    }
+
+    const _CLOUD_REGIME_TEXT = {
+      upload:   { label: 'Limited by your upload speed',  cls: 'upload' },
+      balanced: { label: 'Balanced',                      cls: 'balanced' },
+      compute:  { label: 'Limited by Cloud Compute speed', cls: 'compute' },
+    };
+
+    function _buildCloudRegimeChip(regime, uploadSecs, computeSecs) {
+      const spec = _CLOUD_REGIME_TEXT[regime];
+      if (!spec) return null;
+      const el = document.createElement('span');
+      el.className = `adlg-cloud-regime adlg-cloud-regime--${spec.cls}`;
+      el.textContent = spec.label;
+      const tip = regime === 'upload'
+        ? `Your connection needs ~${_formatDuration(uploadSecs)} to send these images; `
+          + `Cloud Compute could analyze them in ~${_formatDuration(computeSecs)}. `
+          + 'A faster upload would finish sooner.'
+        : regime === 'compute'
+          ? `These images upload in ~${_formatDuration(uploadSecs)} but take `
+            + `~${_formatDuration(computeSecs)} to analyze — Cloud Compute is the bottleneck.`
+          : `Upload (~${_formatDuration(uploadSecs)}) and analysis `
+            + `(~${_formatDuration(computeSecs)}) take about the same time.`;
+      el.setAttribute('title', tip);
+      el.setAttribute('aria-label', tip);
+      return el;
     }
 
     // Always-on "?" badge for cloud est. time. Phrasing differs from the local
     // baseline badge — the cloud "?" stays permanent because the estimate is
     // beta and depends on transfer speed + Modal worker availability.
     function _buildCloudUncertainBadge() {
+      const p = _cloudPipelineParams();
       const tip =
-        'Cloud Compute is in beta. Estimates use the higher of (a) projected ' +
-        'upload time and (b) a 2-images-per-second analysis floor. Actual time ' +
-        'depends on transfer speed and Modal worker availability.';
+        'Cloud Compute is in beta. The estimate models your measured upload ' +
+        'speed against Cloud Compute analyzing roughly ' +
+        `${p.containerImagesPerSec} image/sec per worker, scaling up to ` +
+        `${p.maxContainers} workers as the backlog grows. Actual time ` +
+        'depends on transfer speed and worker availability.';
       const el = document.createElement('span');
       el.className = 'est-time-uncertain est-time-uncertain--cloud';
       el.setAttribute('title', tip);
@@ -832,15 +985,18 @@
         let timeDim = true;
         let timeBadgeKind = null; // null | 'local-baseline' | 'cloud'
         let timeBadgeSampledImgs = 0;
+        let cloudRegimeChip = null;
         const isCloud = _isCloudDestination();
         if (isCloud) {
           if (totalImagesToProcess >= _EST_MIN_IMAGES_TO_ESTIMATE) {
-            const { secs, hasTest } = _getCloudEstSeconds(totalImagesToProcess);
+            const { secs, hasTest, regime, uploadSecs, analysisSecs } =
+              _getCloudEstSeconds(totalImagesToProcess);
             if (secs != null) {
               timeValue = `~${_formatDuration(secs)}`;
               timeLabel = 'est. time (cloud · beta)';
               timeDim = false;
               timeBadgeKind = 'cloud';
+              cloudRegimeChip = _buildCloudRegimeChip(regime, uploadSecs, analysisSecs);
             } else {
               // Cloud destination, no speed test yet — show "?" prominently
               // and let the panel below host the Run Speed Test button.
@@ -881,6 +1037,12 @@
         } else if (timeBadgeKind === 'cloud') {
           const valueEl = headline.querySelector('#_analyzeDlgTimeStatValue');
           if (valueEl) valueEl.appendChild(_buildCloudUncertainBadge());
+        }
+        // Which side of the pipeline is the bottleneck — sits under the
+        // est. time stat so the number and its explanation read together.
+        if (cloudRegimeChip) {
+          const statEl = headline.querySelector('#_analyzeDlgTimeStatValue')?.parentElement;
+          if (statEl) statEl.appendChild(cloudRegimeChip);
         }
       }
 

--- a/analyzer/js/cloud-compute.js
+++ b/analyzer/js/cloud-compute.js
@@ -578,6 +578,51 @@
       })[phase] || phase;
     }
 
+    // ── Live bottleneck read-out ─────────────────────────────────────────────
+    //
+    // Mirrors the pre-flight regime chip in the analyze dialog, but derived from
+    // live counts instead of a model, so the user can see whether the number
+    // they were quoted is playing out. The signal is the un-analyzed backlog:
+    // the worker only spawns another Modal container once the backlog reaches
+    // SCALE_THRESHOLD, so a persistently large backlog means compute is
+    // saturated, while a backlog near zero during an active upload means the
+    // workers are idling on bytes.
+    //
+    // Unlike the analyze dialog's estimate — which uses the thresholds the
+    // Worker serves in the upload-test `pipeline` block — these stay local
+    // constants on purpose: a live job may have had no speed test in this
+    // session, so there's no served descriptor to read. They only pick which
+    // of three LABELS to show, never a number, so drift shifts a boundary
+    // slightly rather than producing a wrong estimate. Still worth keeping
+    // roughly in step with the worker's src/lib/constants.ts.
+    const _CC_SCALE_THRESHOLD = 200;     // backlog at which another container spawns
+    const _CC_DISPATCH_THRESHOLD = 100;  // backlog before the first dispatch
+
+    function _ccBottleneck(state, uploadPhase, analysisPhase) {
+      // Only meaningful while both halves are genuinely in flight.
+      if (analysisPhase !== 'analyzing') return null;
+      const uploaded = Number(state.uploadedCount || 0);
+      const analyzed = Number(state.analyzedCount || 0);
+      const backlog = Math.max(0, uploaded - analyzed);
+      if (uploadPhase !== 'uploading') {
+        // Bytes are all in; from here the only thing left is compute.
+        return { key: 'compute', label: 'Compute-limited',
+                 tip: 'All images are uploaded — the remaining time is analysis.' };
+      }
+      if (backlog >= _CC_SCALE_THRESHOLD) {
+        return { key: 'compute', label: 'Compute-limited',
+                 tip: `${backlog} uploaded images are waiting to be analyzed — `
+                    + 'Cloud Compute is the bottleneck.' };
+      }
+      if (backlog < _CC_DISPATCH_THRESHOLD) {
+        return { key: 'upload', label: 'Upload-limited',
+                 tip: 'Analysis is keeping up with your upload — the job is '
+                    + 'bounded by how fast images reach the cloud.' };
+      }
+      return { key: 'balanced', label: 'Balanced',
+               tip: 'Upload and analysis are advancing at roughly the same rate.' };
+    }
+
     // ── §3: terminal-reason → friendly explanation ───────────────────────
     //
     // Single source of truth mapping a job's terminal reason (worker
@@ -777,6 +822,7 @@
       const retrieved = rawRetrieved;
       const uploadPhase = _ccUploadPhase(state);
       const analysisPhase = _ccAnalysisPhase(state);
+      const bottleneck = _ccBottleneck(state, uploadPhase, analysisPhase);
       const uploadPct = total > 0 ? Math.min(100, Math.round((uploaded / total) * 100)) : 0;
       const analysisPct = total > 0 ? Math.min(100, Math.round((analyzed / total) * 100)) : 0;
       const retrievedPct = total > 0 ? Math.min(100, Math.round((retrieved / total) * 100)) : 0;
@@ -844,6 +890,7 @@
           <div class="cloud-phase-row">
             <span class="cloud-phase-pill upload ${uploadPhase}">↑ ${_ccUploadPhaseLabel(uploadPhase)}</span>
             <span class="cloud-phase-pill analysis ${analysisPhase}">⚙ ${_ccAnalysisPhaseLabel(analysisPhase)}</span>
+            ${bottleneck ? `<span class="cloud-bottleneck-pill ${bottleneck.key}" title="${escapeHtml(bottleneck.tip)}">${escapeHtml(bottleneck.label)}</span>` : ''}
           </div>
           <div class="cloud-bar-block">
             <div class="cloud-bar-label">${uploaded} / ${total} uploaded${anchor}</div>

--- a/analyzer/visualizer.html
+++ b/analyzer/visualizer.html
@@ -758,6 +758,15 @@
   <dialog id="settingsDlg" class="kdlg kdlg--md kdlg--tall kdlg--flex">
     <div class="settings-body">
       <h3 style="margin:0">Settings</h3>
+      <!-- Analysis options (species identification, non-bird wildlife detection,
+           detection confidence, GPU) live in the Analyze dialog's "Review
+           settings" column, not here — they are chosen per analysis run. Users
+           reasonably look for them in Settings first, so point the way. -->
+      <div class="muted" style="font-size:12px;margin:6px 0 0">
+        Looking for analysis options — species identification, non-bird wildlife
+        detection, detection confidence, or GPU use? Those are chosen per run in
+        the <b>Analyze</b> dialog, under &ldquo;Review settings&rdquo;.
+      </div>
 
       <h4 style="margin:12px 0 8px;padding-top:8px;border-top:1px solid #1d2230;color:#a0a8b8;font-size:13px;text-transform:uppercase;letter-spacing:0.5px">UI &amp; Editor</h4>
 


### PR DESCRIPTION
Rebuilt on current `dev` (post-#87) and narrowed to one concern. The RAW-preview fallback that used to be item 1 here is gone — #87 covers it, and the one improvement worth carrying over is now #97. **No RAW-preview code in this branch.**

---

## The estimate was structurally pessimistic

**Report:** the Cloud Compute estimate is "pretty inaccurate and conservative"; asked for a tighter margin plus a read-out of which side is the bottleneck.

**Root cause.** The model was `max(upload_seconds, images × 0.5s)`. That `0.5 s/img` analysis floor assumes **2 img/sec** sustained — but a job that scales out to its full container allowance sustains **~3 img/sec**. That's a standing ~50% pessimism, and on a fast connection the floor is what `max()` picks, so it dominated the quote entirely.

(Worth noting: there was never an explicit "+50% margin" in the code. The pessimism was hiding in the floor.)

**Fix.** Replace the floor with a discrete simulation of what the worker actually does (`_simulateCloudJob`, ~2000 steps regardless of job size):

1. Nothing is analyzed until the dispatch threshold's worth of images have landed in staging.
2. One container starts, after a cold start.
3. Each time the un-analyzed *uploaded* backlog reaches the scale threshold, another container splits off — up to the container cap, subject to the spawn cooldown.
4. Each container sustains ~1 img/sec, clamped to what has actually uploaded.

Residual margin **5%**.

## The pipeline parameters are served, not hardcoded

`POST /api/upload-test` now returns a `pipeline` block (SanjaySoniLV/kestrel-cloud-compute-cloudflare-worker#8) read from the same constants module the scheduler reads, with the container cap resolved from the caller's tier. It rides the speed test because that's the only moment the estimate is computed — no extra round-trip, no new route to authenticate.

The desktop keeps `_CLOUD_FALLBACK_PIPELINE` and merges the served block over it **field by field**, taking only finite positive numbers. An older worker, a partial block, or a dropped key degrades to built-in values rather than breaking. Nothing here is load-bearing: a missing descriptor costs estimate accuracy and nothing else.

This replaced a first pass that hardcoded the constants into the desktop. That mirror was the weak point — the deployed thresholds had already moved once (250→100, 500→200) in exactly the way a mirrored copy misses silently.

## Bottleneck read-out

Same model, comparing pure transfer time against the same simulation run with instant uploads. Ratio > 1.15 → upload-bound, < 0.87 → compute-bound, else balanced (dead band stops the label flickering).

- **Pre-flight** (analyze dialog): *Limited by your upload speed* / *Balanced* / *Limited by Cloud Compute speed*, tooltip giving both reference times.
- **Live** (cloud panel during a job): *Upload-limited* / *Balanced* / *Compute-limited*, from **live counts** rather than the model. These keep local thresholds on purpose — a running job may have had no speed test this session, and they only select a label, never a number.

**Worked examples** (25 MB RAWs, cold start 22 s):

| Scenario | old est | new est | regime |
|---|---|---|---|
| 2000 imgs @ 2 MB/s | 6.94h | 7.29h | Limited by upload |
| 2000 imgs @ 75 MB/s | 16.7m | 13.2m | Balanced |
| 2000 imgs @ 250 MB/s | 16.7m | 12.6m | Limited by Cloud Compute |
| 150 imgs @ 25 MB/s | 2.5m | 4.8m | Balanced |

More honest in **both** directions. The last row goes *up*: a job under the scale threshold never gets a second container, so 150 images genuinely run at ~1 img/sec plus a cold start, and the old 2 img/sec floor was over-promising there.

## Also: analysis options were undiscoverable in Settings

Separate report — "cant find wildlife mode in settings to turn it on". Not a bug: "Detect non-bird wildlife (experimental)" lives in the **Analyze dialog** under "Review settings", because it's a per-run choice. Settings holds only display/exposure/autosave/analytics, so a user looking there finds nothing and concludes the feature is missing. Added a pointer line naming the per-run options.

Kept in this PR rather than split out again — it's a three-line static hint with no shared code.

## Verification

- `node --check` clean on both modified JS files.
- Estimate model validated numerically against the table above.
- Touches no file #87 touched, apart from one unrelated docstring in `api_bridge.py`.

Docs: SanjaySoniLV/Perch-Docs#6 (that repo and the CC worker are `main`-only — no `dev` branch — so those PRs target `main` correctly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)