### PR TITLE
Keep the embedded-preview flag alive across a cache hit

### DIFF
--- a/analyzer/api_bridge.py
+++ b/analyzer/api_bridge.py
@@ -6750,6 +6750,17 @@ class Api:
             base = os.path.splitext(os.path.basename(filename))[0]
             cache_name = f'{base}_{cache_token}_preview.jpg'
             cache_path = os.path.join(cache_dir, cache_name)
+            # The embedded-JPEG fallback gets its OWN cache slot (same token, so
+            # it invalidates on the same inputs). Both paths return a JPEG, so
+            # the bytes are interchangeable — what is NOT interchangeable is the
+            # claim the response makes about them. A fallback preview is a fixed
+            # in-camera render with no exposure shift applied; if a cache hit
+            # can't tell the two apart it drops the `fallback` flag, and
+            # scene-zoom.js re-labels the image "RAW (+X.XX EV)" — telling the
+            # user an EV correction was applied that never was, and can't be.
+            # Splitting the filename is what makes the flag survive a cache hit.
+            embedded_cache_name = f'{base}_{cache_token}_preview_embedded.jpg'
+            embedded_cache_path = os.path.join(cache_dir, embedded_cache_name)
 
             debug_meta = {
                 'filename': filename,
@@ -6770,24 +6781,40 @@ class Api:
                 'cache_token': cache_token,
             }
 
-            if use_cache and os.path.exists(cache_path):
+            hit_path = None
+            hit_was_embedded = False
+            if use_cache:
+                if os.path.exists(cache_path):
+                    hit_path = cache_path
+                elif os.path.exists(embedded_cache_path):
+                    hit_path = embedded_cache_path
+                    hit_was_embedded = True
+            if hit_path:
                 debug(
                     f'[raw-preview] cache hit for {filename} '
-                    f'(exp={exp_correction:+.3f}, mode={render_mode})'
+                    f'(exp={exp_correction:+.3f}, mode={render_mode}'
+                    f'{", embedded fallback" if hit_was_embedded else ""})'
                 )
-                with open(cache_path, 'rb') as f:
+                with open(hit_path, 'rb') as f:
                     cache_bytes = f.read()
-                cache_stat = os.stat(cache_path)
+                cache_stat = os.stat(hit_path)
                 debug_meta.update({
                     'cache_hit': True,
                     'cache_file_bytes': int(len(cache_bytes)),
                     'cache_file_mtime_ns': int(cache_stat.st_mtime_ns),
-                    'storage_preview_path': cache_path,
+                    'storage_preview_path': hit_path,
                 })
+                if hit_was_embedded:
+                    debug_meta['fallback'] = 'embedded_jpeg_preview'
                 if debug_logging_enabled:
                     debug(f'[raw-preview] debug: {json.dumps(debug_meta, sort_keys=True)}')
                 b64 = base64.b64encode(cache_bytes).decode('ascii')
-                return {'success': True, 'data': b64, 'mime': 'image/jpeg', 'debug': debug_meta}
+                response = {'success': True, 'data': b64, 'mime': 'image/jpeg', 'debug': debug_meta}
+                if hit_was_embedded:
+                    # Same flag the fresh-decode path sets, so scene-zoom.js
+                    # labels a cached fallback identically to a fresh one.
+                    response['fallback'] = 'embedded_jpeg_preview'
+                return response
 
             import rawpy
             from PIL import Image
@@ -6870,14 +6897,18 @@ class Api:
                 jpg_bytes = buf.getvalue()
                 img_width, img_height = img.width, img.height
 
+            # Route the fallback to its own cache slot so the next hit can still
+            # report it as an embedded preview rather than an EV-corrected RAW.
+            write_cache_path = embedded_cache_path if used_embedded_fallback else cache_path
+            write_cache_name = embedded_cache_name if used_embedded_fallback else cache_name
             wrote_cache = False
             if use_cache:
                 os.makedirs(cache_dir, exist_ok=True)
-                with open(cache_path, 'wb') as f:
+                with open(write_cache_path, 'wb') as f:
                     f.write(jpg_bytes)
                 wrote_cache = True
 
-            storage_preview_path = cache_path
+            storage_preview_path = write_cache_path
             if not wrote_cache:
                 # Even when cache is disabled, persist one debug copy for inspection.
                 os.makedirs(cache_dir, exist_ok=True)
@@ -6908,10 +6939,10 @@ class Api:
                 debug(
                     f'[raw-preview] Done (embedded fallback), '
                     f'{len(jpg_bytes)//1024}KB JPEG ({img_width}x{img_height})'
-                    + (f', cached as {cache_name}' if wrote_cache else ', cache disabled')
+                    + (f', cached as {write_cache_name}' if wrote_cache else ', cache disabled')
                 )
             elif use_cache:
-                debug(f'[raw-preview] Done, {len(jpg_bytes)//1024}KB JPEG ({img_width}x{img_height}), cached as {cache_name}')
+                debug(f'[raw-preview] Done, {len(jpg_bytes)//1024}KB JPEG ({img_width}x{img_height}), cached as {write_cache_name}')
             else:
                 debug(f'[raw-preview] Done, {len(jpg_bytes)//1024}KB JPEG ({img_width}x{img_height}), cache disabled')
             response = {'success': True, 'data': b64, 'mime': 'image/jpeg', 'debug': debug_meta}

--- a/analyzer/tests/unit/test_read_raw_full_he_fallback.py
+++ b/analyzer/tests/unit/test_read_raw_full_he_fallback.py
@@ -239,10 +239,17 @@ class TestReadRawFullHeFallback:
         # A JPEG must have landed in the culling_TMP cache alongside the
         # image. Same file → subsequent calls hit that cache instead of
         # re-running the failing rawpy.postprocess.
+        #
+        # The fallback uses its OWN cache name (`..._preview_embedded.jpg`)
+        # rather than the normal `..._preview.jpg`, so a later cache hit can
+        # still tell the caller these bytes are an embedded preview and not an
+        # EV-corrected RAW render. See TestEmbeddedFallbackCacheSlot.
         cache_dir = he_scene["root"] / ".kestrel" / "culling_TMP"
-        jpegs = list(cache_dir.glob("*_preview.jpg"))
+        jpegs = list(cache_dir.glob("*_preview_embedded.jpg"))
         assert len(jpegs) == 1
         assert jpegs[0].read_bytes() == he_scene["embedded_bytes"]
+        # And it must NOT occupy the normal RAW-render slot.
+        assert list(cache_dir.glob("*_preview.jpg")) == []
 
     def test_he_with_no_embedded_preview_reports_original_error(self, he_scene):
         """If both the RAW decode AND the embedded preview extraction
@@ -287,3 +294,98 @@ class TestReadRawFullHeFallback:
         assert "fallback" not in result
         assert result["debug"].get("fallback") is None
         assert "postprocess_rgb_shape" in result["debug"]
+
+
+class TestEmbeddedFallbackCacheSlot:
+    """The `fallback` flag must survive a cache hit.
+
+    Both code paths return a JPEG, so the cached bytes are interchangeable —
+    what is not interchangeable is the claim the response makes about them.
+    A fallback preview is a fixed in-camera render with no exposure shift
+    applied. If a cache hit can't distinguish the two it drops the flag, and
+    scene-zoom.js re-labels the image "RAW (+X.XX EV)" — telling the user an
+    EV correction happened that never did and cannot.
+
+    Because the exposure value is part of the cache key, moving the EV slider
+    is a cache MISS and re-fires the fallback, so the flag looks correct there.
+    The regression only shows on re-viewing at an EV already viewed — i.e. the
+    ordinary zoom-in / zoom-out / zoom-in-again loop.
+    """
+
+    def test_cached_fallback_still_reports_the_flag(self, tmp_path):
+        root = tmp_path / "shoot"
+        root.mkdir()
+        nef = root / "DSC_7191.NEF"
+        nef.write_bytes(b"\x00")
+
+        unsupported = MagicMock()
+        unsupported.sizes = MagicMock(
+            width=8280, height=5520, raw_width=8280, raw_height=5520,
+            iwidth=8280, iheight=5520, flip=0,
+        )
+        unsupported.postprocess.side_effect = rawpy.LibRawFileUnsupportedError(
+            b"Unsupported file format or not RAW file"
+        )
+        unsupported.__enter__.return_value = unsupported
+        unsupported.__exit__.return_value = False
+
+        embedded_bytes = _make_jpeg_bytes((8256, 5504))
+        preview_raw = _mock_raw_thumb(
+            thumb_format=rawpy.ThumbFormat.JPEG, thumb_data=embedded_bytes,
+        )
+
+        api = api_bridge.Api()
+        with patch.object(
+            rawpy, "imread", side_effect=[unsupported, preview_raw],
+        ):
+            first = api.read_raw_full(nef.name, str(root))
+        assert first["success"] is True
+        assert first.get("fallback") == "embedded_jpeg_preview"
+
+        # Second view of the same file at the same EV: served from cache, so
+        # rawpy must not be touched at all — but the flag must still be there.
+        with patch.object(
+            rawpy, "imread", side_effect=AssertionError("should have hit cache"),
+        ):
+            second = api.read_raw_full(nef.name, str(root))
+
+        assert second["success"] is True
+        assert second["debug"]["cache_hit"] is True
+        assert second.get("fallback") == "embedded_jpeg_preview"
+        assert second["debug"].get("fallback") == "embedded_jpeg_preview"
+        import base64
+        assert base64.b64decode(second["data"]) == embedded_bytes
+
+    def test_cached_normal_render_does_not_claim_fallback(self, tmp_path):
+        """The inverse: a cached ordinary RAW render must NOT gain the flag."""
+        import numpy as np
+        root = tmp_path / "shoot"
+        root.mkdir()
+        nef = root / "DSC_0002.NEF"
+        nef.write_bytes(b"\x00")
+
+        rgb = np.zeros((64, 96, 3), dtype=np.uint8)
+        ok_raw = MagicMock()
+        ok_raw.sizes = MagicMock(
+            width=96, height=64, raw_width=96, raw_height=64,
+            iwidth=96, iheight=64, flip=0,
+        )
+        ok_raw.postprocess.return_value = rgb
+        ok_raw.__enter__.return_value = ok_raw
+        ok_raw.__exit__.return_value = False
+
+        api = api_bridge.Api()
+        with patch.object(rawpy, "imread", return_value=ok_raw):
+            first = api.read_raw_full(nef.name, str(root))
+        assert first["success"] is True
+        assert "fallback" not in first
+
+        with patch.object(
+            rawpy, "imread", side_effect=AssertionError("should have hit cache"),
+        ):
+            second = api.read_raw_full(nef.name, str(root))
+
+        assert second["success"] is True
+        assert second["debug"]["cache_hit"] is True
+        assert "fallback" not in second
+        assert second["debug"].get("fallback") is None


### PR DESCRIPTION
Small follow-up to #87, on top of it in `dev`. Two files, one behaviour change.

## The bug

`read_raw_full()` caches its rendered JPEG and serves it from an early return on the next view. #87 added the embedded-JPEG fallback to the **fresh-decode** path and set `fallback: 'embedded_jpeg_preview'` on that return — but both paths write to the same cache filename, and the cache-hit early return never sets the flag.

So the second view of an undecodable RAW returns the right bytes with the wrong claim attached, and `scene-zoom.js` falls through to the else branch and labels it **"RAW (+X.XX EV)"**.

```
first zoom  → fresh decode → fallback fires → flag set → "RAW (embedded preview)"  ✅
second zoom → cache hit    → early return   → no flag  → "RAW (+0.00 EV)"          ❌
```

## Why it's worth fixing

The label is a promise about the pixels. On the fallback path the bytes are a fixed in-camera JPEG that no exposure shift was applied to — and none *can* be. A user who reads "+0.00 EV" and reaches for the exposure slider gets nothing back, with no indication why. The label is the only signal that exposure correction is inert for this file, so it's exactly the wrong thing to get wrong.

One subtlety that makes it easy to miss in testing: EV is part of the cache key, so **moving the slider is a cache miss**, which re-decodes, re-fires the fallback, and shows the correct label again. The regression only surfaces when re-viewing at an EV you've already viewed — i.e. the ordinary zoom-in / zoom-out / zoom-in-again loop. Which is the common interaction.

## The fix

Give the fallback its own cache slot — `{base}_{token}_preview_embedded.jpg` — using the **same cache token**, so it invalidates on exactly the same inputs (path, mtime, size, EV, render mode). Check both filenames on the way in; if the embedded one is what's present, set the flag on the response.

Costs one extra `os.path.exists` on the cache-hit path. No change to the fresh-decode path, the extraction helper, or the response shape.

I deliberately kept #87's `fallback: 'embedded_jpeg_preview'` field name rather than renaming anything, so `scene-zoom.js` needs no change at all.

## Tests

Extended `test_read_raw_full_he_fallback.py` rather than adding a second file:

- `test_he_writes_cache_entry_by_default` — updated for the new filename, and now also asserts the fallback does **not** occupy the normal RAW-render slot.
- `TestEmbeddedFallbackCacheSlot::test_cached_fallback_still_reports_the_flag` — full round trip. Second call patches `rawpy.imread` to raise `AssertionError`, so the test fails loudly if it isn't actually served from cache; asserts `cache_hit`, the flag on both the response and `debug`, and byte-identical data.
- `TestEmbeddedFallbackCacheSlot::test_cached_normal_render_does_not_claim_fallback` — the inverse, so a future change can't make everything look like a fallback.

12 passed in that file. Full unit suite: **522 passed, 2 skipped**. The one failure (`test_reject_move.py::test_move_raw_with_real_jpg_companion`) also fails on a clean `dev` — pre-existing, unrelated. 4 modules skipped for a missing `cv2` in this environment.

---

Split out of #96, which now carries only the Cloud Compute estimate work and has no RAW-preview code in it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NUDXm9YojWoTQKjSLWJEuq)_