### PR TITLE
Match reject companions case-insensitively

### DIFF
--- a/analyzer/api_bridge.py
+++ b/analyzer/api_bridge.py
@@ -6227,38 +6227,78 @@ class Api:
             print(f"[API] sign_out() -> Error: {e}", flush=True)
             return {"success": False, "error": str(e)}
 
-    def _find_sidecar_file(self, root_path: str, filename: str, ext: str = '.xmp'):
+    def _build_dir_index(self, root_path: str) -> dict:
+        """Map lowercased entry name -> real on-disk name for one directory.
+
+        Companion lookup has to be case-insensitive: cameras write
+        ``IMG_2265.JPG`` while ``_culling_companion_extensions`` is normalized
+        to lowercase (``_normalize_extensions`` lowercases unconditionally). A
+        literal ``os.path.exists(base + '.jpg')`` therefore misses the real
+        file on a case-sensitive filesystem, and the JPG silently stays behind
+        when its RAW is rejected. Windows and macOS mask this because their
+        filesystems fold case for us; Linux does not.
+
+        This mirrors the convention `select_camera_images`
+        (kestrel_analyzer/config.py) already applies when it decides a
+        same-stem JPG belongs to a RAW.
+
+        Returns {} if the directory is unreadable, so callers degrade to
+        "no companions found" rather than raising.
+        """
+        try:
+            return {entry.lower(): entry for entry in os.listdir(root_path)}
+        except OSError:
+            return {}
+
+    def _find_sidecar_file(self, root_path: str, filename: str, ext: str = '.xmp',
+                           dir_index: dict | None = None):
         """Find sidecar file with given extension for an image file.
-        
+
         Checks multiple naming conventions:
         - filename + ext (e.g., IMG_001.CR3.xmp)
         - name_without_ext + ext (e.g., IMG_001.xmp for IMG_001.CR3)
-        
+
+        Matching is case-insensitive; the returned name is the real on-disk
+        spelling, so callers can join it to a path directly.
+
+        ``dir_index`` is an optional pre-built listing from
+        ``_build_dir_index``. Pass it when resolving many files in one
+        directory to avoid re-listing per file; omit it and one is built here.
+
         Returns the filename (not path) if found, None otherwise.
         Searches in the same directory as the image.
         """
-        # Check primary naming: filename + ext (e.g., IMG_001.CR3.xmp)
-        sidecar_path = os.path.join(root_path, filename + ext)
-        if os.path.exists(sidecar_path):
-            return filename + ext
-        
-        # Check secondary naming: name_without_ext + ext (e.g., IMG_001.xmp)
+        index = self._build_dir_index(root_path) if dir_index is None else dir_index
+
+        # Primary naming: filename + ext (e.g., IMG_001.CR3.xmp)
+        hit = index.get((filename + ext).lower())
+        if hit:
+            return hit
+
+        # Secondary naming: name_without_ext + ext (e.g., IMG_001.xmp)
         if '.' in filename:
             base_name = filename.rsplit('.', 1)[0]
-            alt_sidecar_path = os.path.join(root_path, base_name + ext)
-            if os.path.exists(alt_sidecar_path):
-                return base_name + ext
-        
+            hit = index.get((base_name + ext).lower())
+            if hit:
+                return hit
+
         return None
 
-    def _find_companion_files(self, root_path: str, filename: str) -> list[str]:
-        """Find configured companion files (XMP + JPEG variants) for an image."""
+    def _find_companion_files(self, root_path: str, filename: str,
+                              dir_index: dict | None = None) -> list[str]:
+        """Find configured companion files (XMP + JPEG variants) for an image.
+
+        ``dir_index`` is an optional pre-built listing from
+        ``_build_dir_index``. Without it this lists the directory once per
+        call; batch callers should build the index once and pass it in.
+        """
         companions: list[str] = []
         seen: set[str] = set()
         filename_key = str(filename or '').lower()
+        index = self._build_dir_index(root_path) if dir_index is None else dir_index
 
         for ext in self._culling_companion_extensions:
-            companion = self._find_sidecar_file(root_path, filename, ext)
+            companion = self._find_sidecar_file(root_path, filename, ext, dir_index=index)
             if not companion:
                 continue
             key = companion.lower()
@@ -6269,9 +6309,15 @@ class Api:
 
         return companions
 
-    def _move_file_with_sidecars(self, root_path: str, filename: str, reject_dir: str):
+    def _move_file_with_sidecars(self, root_path: str, filename: str, reject_dir: str,
+                                 dir_index: dict | None = None):
         """Move a file and its configured companion files to reject directory.
-        
+
+        ``dir_index`` is an optional pre-built listing of ``root_path`` shared
+        across a batch. It can go stale as files move out during the batch, but
+        every move below is already guarded by ``os.path.exists``, so a stale
+        entry degrades to a logged warning rather than an error.
+
         Returns (success: bool, moved_files: list[str])
         """
         moved_files = []
@@ -6288,7 +6334,7 @@ class Api:
         except Exception:
             return False, moved_files
 
-        companion_files = self._find_companion_files(root_path, filename)
+        companion_files = self._find_companion_files(root_path, filename, dir_index=dir_index)
         if companion_files:
             for companion in companion_files:
                 companion_src = os.path.join(root_path, companion)
@@ -6340,8 +6386,14 @@ class Api:
                 else:
                     errors.append(f'{raw}: invalid filename')
 
+            # One listing for the whole batch: every file here lives in
+            # root_real, so re-listing per file (x6 companion extensions)
+            # would be O(files x dirsize) on a folder that can hold thousands.
+            dir_index = self._build_dir_index(root_real)
             for fn in sanitized_filenames:
-                success, moved_files = self._move_file_with_sidecars(root_real, fn, reject_dir)
+                success, moved_files = self._move_file_with_sidecars(
+                    root_real, fn, reject_dir, dir_index=dir_index
+                )
                 if success:
                     moved.extend(moved_files)
                 else:
@@ -6379,8 +6431,12 @@ class Api:
             fields=fields if isinstance(fields, dict) else None,
         )
 
-    def _restore_file_with_sidecars(self, reject_dir: str, root_path: str, filename: str):
+    def _restore_file_with_sidecars(self, reject_dir: str, root_path: str, filename: str,
+                                    dir_index: dict | None = None):
         """Restore a file and its configured companion files from reject directory.
+
+        ``dir_index`` is an optional pre-built listing of ``reject_dir`` shared
+        across a batch; see ``_move_file_with_sidecars`` on staleness.
 
         Returns (success: bool, restored_files: list[str])
         """
@@ -6398,7 +6454,7 @@ class Api:
         except Exception:
             return False, restored_files
 
-        companion_files = self._find_companion_files(reject_dir, filename)
+        companion_files = self._find_companion_files(reject_dir, filename, dir_index=dir_index)
         if companion_files:
             for companion in companion_files:
                 companion_src = os.path.join(reject_dir, companion)
@@ -6449,8 +6505,13 @@ class Api:
                 else:
                     errors.append(f'{raw}: invalid filename')
 
+            # One listing for the whole batch — same reasoning as the reject
+            # path, over the rejects folder instead of the shoot folder.
+            restore_index = self._build_dir_index(reject_dir)
             for fn in sanitized_filenames:
-                success, restored_files = self._restore_file_with_sidecars(reject_dir, root_real, fn)
+                success, restored_files = self._restore_file_with_sidecars(
+                    reject_dir, root_real, fn, dir_index=restore_index
+                )
                 if success:
                     restored.extend(restored_files)
                 else:
@@ -6505,12 +6566,14 @@ class Api:
 
             reject_filenames = []
             excluded = set()
+            # Read-only scan, so one listing is safe and strictly correct here.
+            scan_index = self._build_dir_index(reject_dir)
             for name in candidates:
                 key = name.lower()
                 if key in excluded:
                     continue
                 reject_filenames.append(name)
-                companions = self._find_companion_files(reject_dir, name)
+                companions = self._find_companion_files(reject_dir, name, dir_index=scan_index)
                 for comp in companions:
                     excluded.add(comp.lower())
 

--- a/analyzer/tests/unit/test_reject_move.py
+++ b/analyzer/tests/unit/test_reject_move.py
@@ -3,6 +3,7 @@
 Uses set_e_raw_jpg_mix fixtures for RAW+JPG companion file testing.
 """
 
+import os
 import pytest
 import shutil
 from pathlib import Path
@@ -205,3 +206,110 @@ class TestRawJpgMixFixtures:
         # Originals gone
         assert not (workdir / raw_file.name).exists()
         assert not (workdir / jpg_companion.name).exists()
+
+
+class TestCompanionCaseInsensitivity:
+    """Companion lookup must not depend on filesystem case-folding.
+
+    Companion extensions are normalized to lowercase by
+    `_normalize_extensions`, but cameras write `IMG_2265.JPG`. The lookup used
+    to probe the literal lowercase path, which Windows and macOS resolve for
+    us and Linux does not — so on a case-sensitive filesystem the JPG stayed
+    behind while the reject reported success with zero errors. There is no
+    Linux job in CI, so nothing caught it.
+    """
+
+    @pytest.fixture
+    def api(self):
+        return api_bridge.Api()
+
+    def _shoot(self, tmp_path, raw_name, companion_name):
+        workdir = tmp_path / "workdir"
+        workdir.mkdir()
+        (workdir / raw_name).write_bytes(b"\x00" * 64)
+        (workdir / companion_name).write_bytes(b"\xff" * 64)
+        return workdir
+
+    @pytest.mark.parametrize("companion_name", [
+        "IMG_9001.JPG",   # as the camera writes it
+        "IMG_9001.jpg",   # already lowercase
+        "IMG_9001.JpG",   # mixed, e.g. renamed by another tool
+    ])
+    def test_jpg_companion_moves_regardless_of_extension_case(
+        self, api, tmp_path, companion_name
+    ):
+        workdir = self._shoot(tmp_path, "IMG_9001.CR2", companion_name)
+
+        result = api.move_rejects_to_folder(str(workdir), ["IMG_9001.CR2"])
+        assert result["success"] is True
+        assert result["errors"] == []
+
+        reject_dir = workdir / "_KESTREL_Rejects"
+        assert (reject_dir / "IMG_9001.CR2").exists()
+        # Moved under its real on-disk spelling, not a case-folded guess.
+        assert (reject_dir / companion_name).exists()
+        assert not (workdir / companion_name).exists()
+
+    def test_xmp_sidecar_moves_regardless_of_extension_case(self, api, tmp_path):
+        """The XMP path had the identical flaw, not just the JPEG one."""
+        workdir = self._shoot(tmp_path, "IMG_9002.CR2", "IMG_9002.XMP")
+
+        result = api.move_rejects_to_folder(str(workdir), ["IMG_9002.CR2"])
+        assert result["success"] is True
+
+        reject_dir = workdir / "_KESTREL_Rejects"
+        assert (reject_dir / "IMG_9002.XMP").exists()
+        assert not (workdir / "IMG_9002.XMP").exists()
+
+    def test_undo_restores_uppercase_companion(self, api, tmp_path):
+        """Restore uses the same lookup, so it must round-trip."""
+        workdir = self._shoot(tmp_path, "IMG_9003.CR2", "IMG_9003.JPG")
+        reject_dir = workdir / "_KESTREL_Rejects"
+
+        api.move_rejects_to_folder(str(workdir), ["IMG_9003.CR2"])
+        # Assert the midpoint explicitly. Without it this test passes even when
+        # the companion was never moved: the JPG would still be sitting in
+        # workdir and the post-undo assertions would hold vacuously.
+        assert (reject_dir / "IMG_9003.JPG").exists()
+        assert not (workdir / "IMG_9003.JPG").exists()
+
+        result = api.undo_reject_move(str(workdir), ["IMG_9003.CR2"])
+        assert result["success"] is True
+
+        assert (workdir / "IMG_9003.CR2").exists()
+        assert (workdir / "IMG_9003.JPG").exists()
+        assert not (reject_dir / "IMG_9003.JPG").exists()
+
+    def test_batch_lists_each_directory_once(self, api, tmp_path, monkeypatch):
+        """The batch shares one directory listing across all rejected files.
+
+        Guards the O(files x extensions x dirsize) regression: without the
+        shared index this listed the folder 6x per file.
+        """
+        workdir = tmp_path / "workdir"
+        workdir.mkdir()
+        names = []
+        for i in range(10):
+            raw = f"IMG_8{i:03d}.CR2"
+            (workdir / raw).write_bytes(b"\x00" * 16)
+            (workdir / f"IMG_8{i:03d}.JPG").write_bytes(b"\xff" * 16)
+            names.append(raw)
+
+        real_listdir = os.listdir
+        calls = []
+
+        def counting_listdir(path):
+            calls.append(str(path))
+            return real_listdir(path)
+
+        monkeypatch.setattr(api_bridge.os, "listdir", counting_listdir)
+        result = api.move_rejects_to_folder(str(workdir), names)
+        assert result["success"] is True
+
+        listings_of_workdir = [c for c in calls if os.path.realpath(c) == os.path.realpath(str(workdir))]
+        assert len(listings_of_workdir) == 1, (
+            f"expected 1 listing of the shoot folder, got {len(listings_of_workdir)}"
+        )
+        reject_dir = workdir / "_KESTREL_Rejects"
+        for i in range(10):
+            assert (reject_dir / f"IMG_8{i:03d}.JPG").exists()


### PR DESCRIPTION
Fixes the pre-existing `test_reject_move.py::TestRawJpgMixFixtures::test_move_raw_with_real_jpg_companion` failure. Two files.

## The bug

`_normalize_extensions` lowercases every extension unconditionally, so `_culling_companion_extensions` only ever contains `.jpg`. `_find_sidecar_file` then probed the literal path:

```python
alt_sidecar_path = os.path.join(root_path, base_name + ext)   # "IMG_2265" + ".jpg"
if os.path.exists(alt_sidecar_path):
```

Cameras write `IMG_2265.JPG`. On a case-sensitive filesystem that probe returns `False`, `_find_companion_files` returns `[]`, and only the RAW moves — while the operation reports `success: True` with `errors: []`.

The same flaw affected the `.xmp` sidecar path and the restore direction, since both go through the same helper.

## Why it survived this long

Windows (NTFS) and macOS (APFS) are case-insensitive by default, so `os.path.exists("IMG_2265.jpg")` transparently matches the on-disk `IMG_2265.JPG` and the lookup works by filesystem accident.

All four workflows that run pytest are `windows-latest` or `macos-latest` — there is no Linux job. So this could not fail in CI or on a normal dev machine, only on a case-sensitive filesystem. The test has been failing there since it was added; `git log -S"_find_sidecar_file"` shows the helper and its test landed in the same commit and neither has changed since.

**User impact is limited but real:** you ship `.dmg` and Microsoft Store bundles, so nobody on a distributed build can hit this. It's reachable by someone running from source on Linux, or on a case-sensitive-formatted APFS volume. They'd reject a RAW+JPG pair, get a success message, and silently keep an orphaned JPG — with no undo, since `undo_reject_move` can't restore what never moved.

## The fix

Resolve companions against a lowercased directory listing and return the **real on-disk spelling**, so callers can join it to a path directly:

```python
def _build_dir_index(self, root_path: str) -> dict:
    try:
        return {entry.lower(): entry for entry in os.listdir(root_path)}
    except OSError:
        return {}
```

This mirrors the convention `select_camera_images` (`kestrel_analyzer/config.py`) already applies when it decides a same-stem JPG belongs to a RAW — the two places are supposed to agree on what counts as the same capture, and now do.

I chose a folded listing over "probe `.jpg`, `.JPG`, `.Jpg`…" because the latter doesn't generalize to arbitrary casing and would need repeating for every extension.

### Batching the listing

The naive version calls `os.listdir` inside `_find_sidecar_file`, which runs twice per extension across six companion extensions — 12 listings per rejected file. Rejecting a few hundred images from a folder holding thousands makes that O(files × dirsize).

So `dir_index` is threaded as an optional parameter through `_find_sidecar_file` → `_find_companion_files` → `_move_file_with_sidecars` / `_restore_file_with_sidecars`, and built **once per batch** at the three call sites that loop:

| Call site | Directory indexed | Notes |
|---|---|---|
| `move_rejects_to_folder` | `root_real` | every file in the batch is in this one folder |
| `undo_reject_move` | `reject_dir` | same shape, other direction |
| restore-candidates scan | `reject_dir` | read-only loop, previously the worst offender |

When `dir_index` is omitted the helper builds its own, so any call site I didn't wire — and any future one — is still correct, just without the batching win.

**On staleness:** the shared index can list files that have already moved out mid-batch. Every move is already guarded by `os.path.exists` before `shutil.move`, so a stale entry degrades to the existing "companion detected but not found" warning rather than an error. The candidates scan is read-only, so no staleness is possible there.

## Tests

Added `TestCompanionCaseInsensitivity` (6 cases):

- JPG companion moves regardless of extension case — parametrized over `.JPG`, `.jpg`, `.JpG`.
- XMP sidecar likewise, since that path had the identical flaw.
- Undo round-trips an uppercase companion. This one asserts the **midpoint** explicitly (that the JPG reached the rejects folder) — without that it passes vacuously against the unfixed code, because the JPG would still be sitting in the working folder and the post-undo assertions would hold trivially.
- `test_batch_lists_each_directory_once` monkeypatches `os.listdir` and asserts exactly one listing of the shoot folder across a 10-file batch, guarding the O(files × extensions × dirsize) regression.

I verified these discriminate: against unmodified `dev`, 5 of the 6 fail (the sixth is the already-lowercase `.jpg` case, which passes either way and is there for coverage of the non-regressing path).

**Full unit suite: 527 passed, 2 skipped, 0 failed** — green for the first time, since this was the only failure. 4 modules skipped for a missing `cv2` in this environment, unrelated.

## Note on CI

Nothing here adds a Linux job, so this class of bug remains invisible to CI. If you ever want a cheap guard, a `ubuntu-latest` job running only `pytest analyzer/tests/unit` would catch case-sensitivity mistakes without needing the packaging toolchain. Happy to open that separately — not doing it here to keep this focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NUDXm9YojWoTQKjSLWJEuq)_