### PR TITLE
ci: Add manual-trigger workflow for signed/notarized Intel Mac DMG builds

### DIFF
--- a/.github/workflows/build-macos-intel.yml
+++ b/.github/workflows/build-macos-intel.yml
@@ -1,0 +1,372 @@
+﻿name: Build macOS Artifacts (Intel)
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build-macos-intel:
+    runs-on: macos-15-intel
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          lfs: true
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+
+      - name: Create venv and install dependencies
+        shell: bash
+        run: |
+          python -m venv .venv2
+          source .venv2/bin/activate
+          python -m pip install --upgrade pip
+          pip install -r requirements-macos.txt
+          pip install pyinstaller
+
+      - name: Smoke test CLI from source (repo root, first 2 test images)
+        shell: bash
+        run: |
+          set -euo pipefail
+          SMOKE_DIR="${RUNNER_TEMP}/kestrel-smoke-source-input"
+          rm -rf "${SMOKE_DIR}"
+          mkdir -p "${SMOKE_DIR}"
+
+          smoke_imgs=()
+          while IFS= read -r img; do
+            smoke_imgs+=("${img}")
+          done < <(find test_imgs -maxdepth 1 -type f | sort | head -n 2)
+          if [ "${#smoke_imgs[@]}" -lt 2 ]; then
+            echo "Expected at least 2 images in test_imgs/ for source smoke test"
+            exit 1
+          fi
+
+          for img in "${smoke_imgs[@]}"; do
+            cp "${img}" "${SMOKE_DIR}/"
+          done
+
+          .venv2/bin/python analyzer/cli.py "${SMOKE_DIR}" --no-gpu --parallel-prefetch 1
+
+          META_PATH="${SMOKE_DIR}/.kestrel/kestrel_database.csv"
+          if [ ! -f "${META_PATH}" ]; then
+            echo "Source CLI smoke test did not produce kestrel_database.csv"
+            exit 1
+          fi
+          PROCESSED_ROWS=$(( $(wc -l < "${META_PATH}") - 1 ))
+          if [ "${PROCESSED_ROWS}" -lt 2 ]; then
+            echo "Source CLI smoke test processed fewer than 2 images (rows=${PROCESSED_ROWS})"
+            exit 1
+          fi
+
+      - name: Generate build attestation
+        id: attestation
+        shell: bash
+        env:
+          SIGNING_SECRET: ${{ secrets.KESTREL_BUILD_SIGNING_SECRET }}
+        run: |
+          set -euo pipefail
+          if [ -z "${SIGNING_SECRET:-}" ]; then
+            echo "::warning::KESTREL_BUILD_SIGNING_SECRET is not set; skipping attestation. This build will be tagged 'legacy' by the API worker."
+            exit 0
+          fi
+          if [ ! -d analyzer ]; then
+            echo "::error::analyzer/ directory is missing — cannot place build_attestation.json"
+            exit 1
+          fi
+
+          # Use python (already installed by setup-python@v5) to keep version-parsing
+          # logic in sync with kestrel_telemetry._read_version. Doing all work in a
+          # single python invocation avoids whitespace-splitting bugs in bash `read`
+          # when the version string contains spaces (e.g. "Nelson's Sparrow").
+          python3 - <<'PY' | tee -a "$GITHUB_OUTPUT"
+          import hashlib, hmac, json, os, time
+
+          def read_version():
+              for cand in ("VERSION.txt", os.path.join("analyzer", "VERSION.txt")):
+                  if not os.path.isfile(cand):
+                      continue
+                  with open(cand, "r", encoding="utf-8") as f:
+                      lines = [l.strip() for l in f if l.strip()]
+                  for line in lines:
+                      if line.lower().startswith("version:"):
+                          return line.split(":", 1)[1].strip()
+                  if len(lines) == 1:
+                      return lines[0]
+              return "unknown"
+
+          version = read_version()
+          sha = os.environ["GITHUB_SHA"]
+          ts = str(int(time.time()))
+          meta = f"{version}|{sha}|{ts}"
+          sig = hmac.new(
+              os.environ["SIGNING_SECRET"].encode("utf-8"),
+              meta.encode("utf-8"),
+              hashlib.sha256,
+          ).hexdigest()
+
+          with open("analyzer/build_attestation.json", "w", encoding="utf-8") as f:
+              json.dump({"meta": meta, "sig": sig}, f, separators=(",", ":"))
+
+          # GITHUB_OUTPUT lines (tee'd by the surrounding bash so they're visible too):
+          print(f"version={version}")
+          print(f"sha={sha}")
+          print(f"ts={ts}")
+          # Diagnostics on stderr so they don't pollute GITHUB_OUTPUT:
+          import sys
+          print(f"Build attestation generated:", file=sys.stderr)
+          print(f"  version : {version}", file=sys.stderr)
+          print(f"  sha     : {sha}", file=sys.stderr)
+          print(f"  ts      : {ts}", file=sys.stderr)
+          print(f"  meta    : {meta}", file=sys.stderr)
+          print(f"  sig     : {sig[:16]}... (truncated)", file=sys.stderr)
+          PY
+
+      - name: Run macOS headless build
+        shell: bash
+        run: |
+          chmod +x packaging/build_app_headless.sh
+          ./packaging/build_app_headless.sh
+
+      - name: Smoke test built executable (first 2 test images)
+        id: smoke_test
+        continue-on-error: true
+        shell: bash
+        run: |
+          set -euo pipefail
+          SMOKE_DIR="${RUNNER_TEMP}/kestrel-smoke-input"
+          rm -rf "${SMOKE_DIR}"
+          mkdir -p "${SMOKE_DIR}"
+
+          # mapfile is unavailable in macOS runner bash (3.2), so use while-read.
+          smoke_imgs=()
+          while IFS= read -r img; do
+            smoke_imgs+=("${img}")
+          done < <(find test_imgs -maxdepth 1 -type f | sort | head -n 2)
+          if [ "${#smoke_imgs[@]}" -lt 2 ]; then
+            echo "Expected at least 2 images in test_imgs/ for smoke test"
+            exit 1
+          fi
+
+          for img in "${smoke_imgs[@]}"; do
+            cp "${img}" "${SMOKE_DIR}/"
+          done
+
+          analyzer/dist/ProjectKestrel/ProjectKestrel --cli "${SMOKE_DIR}" --no-gpu --parallel-prefetch 1
+
+          META_PATH="${SMOKE_DIR}/.kestrel/kestrel_database.csv"
+          if [ ! -f "${META_PATH}" ]; then
+            echo "Smoke test did not produce kestrel_database.csv"
+            exit 1
+          fi
+          PROCESSED_ROWS=$(( $(wc -l < "${META_PATH}") - 1 ))
+          if [ "${PROCESSED_ROWS}" -lt 2 ]; then
+            echo "Smoke test processed fewer than 2 images (rows=${PROCESSED_ROWS})"
+            exit 1
+          fi
+
+      - name: Warn if smoke test failed
+        if: ${{ always() && steps.smoke_test.outcome == 'failure' }}
+        shell: bash
+        run: echo "::warning::Smoke test failed on macOS Intel artifacts build; continuing to publish available artifacts."
+
+      - name: Collect macOS .app at workspace root
+        shell: bash
+        run: |
+          set -e
+          mkdir -p artifact
+          APP_PATH=$(find analyzer/dist -maxdepth 2 -name "*.app" | head -n 1 || true)
+          if [ -z "$APP_PATH" ]; then
+            APP_PATH=$(find release -type d -name "*.app" | head -n 1 || true)
+          fi
+          if [ -z "$APP_PATH" ]; then
+            echo "No .app found to upload"
+            exit 1
+          fi
+          echo "Found .app: $APP_PATH"
+          cp -a "$APP_PATH" artifact/
+
+      # -------------------------------------------------------
+      # SIGNING + NOTARIZATION
+      # -------------------------------------------------------
+
+      - name: Install Apple certificate
+        shell: bash
+        run: |
+          # Decode the certificate from the secret
+          echo "${{ secrets.APPLE_CERTIFICATE_P12 }}" | base64 --decode > certificate.p12
+
+          # Create a temporary keychain so we don't touch the system keychain
+          security create-keychain -p "temp_keychain_password" build.keychain
+          security default-keychain -s build.keychain
+          security unlock-keychain -p "temp_keychain_password" build.keychain
+          security set-keychain-settings -lut 21600 build.keychain
+
+          # Import the certificate into the temporary keychain
+          security import certificate.p12 \
+            -k build.keychain \
+            -P "${{ secrets.APPLE_CERTIFICATE_PASSWORD }}" \
+            -T /usr/bin/codesign
+
+          # Allow codesign to access the key without prompting
+          security set-key-partition-list \
+            -S apple-tool:,apple: \
+            -s -k "temp_keychain_password" build.keychain
+
+          # Clean up decoded file
+          rm certificate.p12
+
+          # Confirm certificate is visible
+          echo "Available signing identities:"
+          security find-identity -v -p codesigning build.keychain
+
+      - name: Sign the .app
+        shell: bash
+        run: |
+          APP_PATH="analyzer/dist/Project Kestrel.app"
+
+          # Sign all .so and .dylib files first (inside-out signing)
+          find "$APP_PATH" -type f \( -name "*.so" -o -name "*.dylib" \) | while read f; do
+            codesign --force --sign "Developer ID Application: Sanjay Soni (${{ secrets.APPLE_TEAM_ID }})" \
+              --options runtime \
+              "$f"
+          done
+
+          # Sign any nested executables
+          find "$APP_PATH/Contents/MacOS" -type f | while read f; do
+            codesign --force --sign "Developer ID Application: Sanjay Soni (${{ secrets.APPLE_TEAM_ID }})" \
+              --options runtime \
+              "$f"
+          done
+
+          # Sign the entire .app bundle
+          codesign --deep --force --options runtime \
+            --sign "Developer ID Application: Sanjay Soni (${{ secrets.APPLE_TEAM_ID }})" \
+            "$APP_PATH"
+
+          # Verify
+          echo "Verifying signature..."
+          codesign --verify --deep --strict --verbose=2 "$APP_PATH"
+
+      - name: Notarize the .app
+        shell: bash
+        run: |
+          APP_PATH="analyzer/dist/Project Kestrel.app"
+
+          # Zip for notarization submission
+          ditto -c -k --keepParent "$APP_PATH" "artifact/ProjectKestrel_notarize.zip"
+
+          # Submit to Apple and wait for result
+          xcrun notarytool submit "artifact/ProjectKestrel_notarize.zip" \
+            --apple-id "${{ secrets.APPLE_ID }}" \
+            --team-id "${{ secrets.APPLE_TEAM_ID }}" \
+            --password "${{ secrets.APPLE_APP_PASSWORD }}" \
+            --wait \
+            --timeout 30m
+
+          # Staple the notarization ticket to the .app
+          xcrun stapler staple "$APP_PATH"
+
+          # Clean up the zip used for submission
+          rm "artifact/ProjectKestrel_notarize.zip"
+
+          echo "Notarization and stapling complete."
+
+      # -------------------------------------------------------
+      # DMG PACKAGING
+      # -------------------------------------------------------
+
+      - name: Create DMG
+        shell: bash
+        run: |
+          brew install create-dmg
+
+          create-dmg \
+            --volname "Project Kestrel" \
+            --window-size 540 380 \
+            --icon-size 128 \
+            --icon "Project Kestrel.app" 140 190 \
+            --app-drop-link 400 190 \
+            --hide-extension "Project Kestrel.app" \
+            "artifact/ProjectKestrel.dmg" \
+            "analyzer/dist/Project Kestrel.app"
+
+      # -------------------------------------------------------
+      # ARTIFACTS
+      # -------------------------------------------------------
+
+      - name: Upload macOS DMG
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: macos-intel-dmg
+          path: artifact/ProjectKestrel.dmg
+
+      - name: Upload macOS .app (zipped)
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: macos-intel-app-ditto
+          path: artifact/ProjectKestrel.zip
+
+      - name: Upload macOS .app (folder)
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: macos-intel-app
+          path: artifact/
+
+      - name: Upload macOS onedir bundle
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: macos-intel-bundle
+          path: analyzer/dist/ProjectKestrel/
+
+      - name: Register build with worker
+        if: ${{ always() && steps.attestation.outputs.sha != '' }}
+        shell: bash
+        continue-on-error: true
+        env:
+          SIGNING_SECRET: ${{ secrets.KESTREL_BUILD_SIGNING_SECRET }}
+          BUILD_VERSION:  ${{ steps.attestation.outputs.version }}
+          BUILD_SHA:      ${{ steps.attestation.outputs.sha }}
+          BUILD_TS:       ${{ steps.attestation.outputs.ts }}
+        run: |
+          set -euo pipefail
+          if [ -z "${SIGNING_SECRET:-}" ]; then
+            echo "::warning::No signing secret available; skipping build registration."
+            exit 0
+          fi
+
+          # Build JSON via python to avoid quoting headaches when version contains apostrophes.
+          BODY=$(BUILD_VERSION="$BUILD_VERSION" BUILD_SHA="$BUILD_SHA" BUILD_TS="$BUILD_TS" \
+                 RUN_ID="$GITHUB_RUN_ID" ACTOR="$GITHUB_ACTOR" python3 -c '
+          import json, os
+          print(json.dumps({
+              "version": os.environ["BUILD_VERSION"],
+              "sha":     os.environ["BUILD_SHA"],
+              "ts":      os.environ["BUILD_TS"],
+              "run_id":  os.environ["RUN_ID"],
+              "actor":   os.environ["ACTOR"],
+          }))
+          ')
+
+          # --fail makes curl exit non-zero on HTTP errors; --max-time 15 bounds the call.
+          # Capture both stdout and exit code so failure is logged but non-blocking.
+          set +e
+          RESP=$(curl --silent --show-error --fail --max-time 15 \
+            -H "X-Kestrel-Signing-Token: ${SIGNING_SECRET}" \
+            -H "Content-Type: application/json" \
+            --data-raw "${BODY}" \
+            "https://api.projectkestrel.org/api/builds/register" 2>&1)
+          RC=$?
+          set -e
+
+          if [ "$RC" -eq 0 ]; then
+            echo "Build registered with worker: ${RESP}"
+          else
+            echo "::warning::Build registration failed (non-blocking, rc=${RC}): ${RESP}"
+          fi


### PR DESCRIPTION
## Summary

Adds a manual-trigger-only GitHub Actions workflow to build a signed and notarized Intel (x86_64) macOS DMG, so Intel builds can be produced periodically without running on every push.

- New file: `.github/workflows/build-macos-intel.yml`, cloned from the existing `.github/workflows/build-macos.yml` (checkout, smoke test, build attestation, headless build, codesign, notarize, DMG packaging, artifact upload, worker registration).
- Trigger is `workflow_dispatch` only — no `push` trigger, unlike the existing ARM workflow.
- Runs on `macos-15-intel`, the current GitHub-hosted Intel runner. (`macos-13`, the previous Intel image, was deprecated in Sept–Dec 2025.)
- Artifact names are suffixed `-intel` (`macos-intel-dmg`, `macos-intel-app-ditto`, `macos-intel-app`, `macos-intel-bundle`) to keep them distinguishable from the existing ARM workflow's artifacts.
- Reuses the same Apple signing/notarization secrets (`APPLE_CERTIFICATE_P12`, `APPLE_CERTIFICATE_PASSWORD`, `APPLE_TEAM_ID`, `APPLE_ID`, `APPLE_APP_PASSWORD`) and `KESTREL_BUILD_SIGNING_SECRET` as the existing macOS build workflow — no new secrets added.

## Test plan
- [x] Validated workflow YAML syntax locally
- [ ] Trigger the workflow manually via `workflow_dispatch` and confirm a signed, notarized DMG is produced and uploaded as an artifact
