### PR TITLE
Write kestrel_database.csv atomically to stop partial reads during analysis

### DIFF
--- a/analyzer/kestrel_analyzer/database.py
+++ b/analyzer/kestrel_analyzer/database.py
@@ -1,5 +1,6 @@
 import json
 import os
+import tempfile
 from datetime import datetime
 
 import pandas as pd
@@ -140,7 +141,7 @@ def _perform_db_upgrade(
             columns=[c for c in LEGACY_USER_COLUMNS if c in database.columns],
             errors="ignore",
         )
-        cleaned.to_csv(db_path, index=False)
+        _to_csv_atomic(cleaned, db_path)
         _info(
             f"[database] Upgrade complete: backup at {os.path.basename(old_path)}, "
             f"new clean {DATABASE_NAME} saved."
@@ -359,6 +360,59 @@ def ensure_columns(database: pd.DataFrame) -> pd.DataFrame:
 # These are NOT in BASE_COLUMNS but may be added by the UI's saveCsv().
 _UI_PRESERVE_COLUMNS = ["culled", "culled_origin"]
 
+# Prefix/suffix for the temp file used by ``_to_csv_atomic``. Distinctive so a
+# temp left behind by a crashed/killed save is identifiable, and so it never
+# collides with the ``OLD_kestrel_database_*.csv`` upgrade backups.
+_TMP_FILE_PREFIX = ".kestrel_database_"
+_TMP_FILE_SUFFIX = ".csv.tmp"
+
+
+def _to_csv_atomic(database: pd.DataFrame, db_path: str) -> None:
+    """Write ``database`` to ``db_path`` so readers never observe a partial file.
+
+    ``DataFrame.to_csv(path)`` truncates the destination and streams rows into
+    it. The analysis pipeline saves after every processed image while the UI's
+    auto-refresh timer reads the same path (``read_kestrel_csv`` /
+    ``apply_normalization``), so a reader landing mid-write sees either an empty
+    file (pandas ``EmptyDataError: No columns to parse from file``) or a row cut
+    inside a quoted field such as ``crops_json`` (pandas ``ParserError: EOF
+    inside string starting at row N``).
+
+    Write to a unique temp file in the same directory and ``os.replace`` it into
+    place instead. ``os.replace`` is atomic on POSIX and on Windows, so a
+    concurrent reader observes either the complete previous file or the complete
+    new one. This mirrors the atomic-save pattern in ``settings_utils.save_settings``.
+    """
+    directory = os.path.dirname(db_path) or "."
+    os.makedirs(directory, exist_ok=True)
+
+    # mkstemp creates with O_EXCL, so concurrent saves can never share a path.
+    tmp_fd, tmp = tempfile.mkstemp(
+        prefix=_TMP_FILE_PREFIX,
+        suffix=_TMP_FILE_SUFFIX,
+        dir=directory,
+    )
+    try:
+        with os.fdopen(tmp_fd, "w", encoding="utf-8", newline="") as f:
+            database.to_csv(f, index=False)
+            try:
+                f.flush()
+                os.fsync(f.fileno())
+            except OSError:
+                # fsync can legitimately fail on some network filesystems
+                # (SMB/NFS shares are a common target); the replace below
+                # still gives readers an all-or-nothing view.
+                pass
+        os.replace(tmp, db_path)
+    except BaseException:
+        # Do NOT fall back to a direct write — that is the partial-read path
+        # this function exists to close. Leave the previous file intact.
+        try:
+            os.remove(tmp)
+        except OSError:
+            pass
+        raise
+
 
 def save_database(database: pd.DataFrame, db_path: str) -> None:
     """Save database to CSV, preserving UI-written columns from disk.
@@ -395,4 +449,4 @@ def save_database(database: pd.DataFrame, db_path: str) -> None:
         except Exception:
             pass  # If we can't read the existing CSV, just write what we have
 
-    database.to_csv(db_path, index=False)
+    _to_csv_atomic(database, db_path)

--- a/analyzer/tests/unit/test_database_atomic_save.py
+++ b/analyzer/tests/unit/test_database_atomic_save.py
@@ -1,0 +1,125 @@
+"""Regression tests for atomic kestrel_database.csv writes.
+
+The analysis pipeline calls ``save_database`` after every processed image while
+the UI auto-refresh timer reads the same path (``read_kestrel_csv`` /
+``apply_normalization``). A non-atomic ``DataFrame.to_csv(path)`` truncates the
+destination and streams rows into it, so a concurrent reader can observe a
+partial file and raise ``EmptyDataError`` or ``ParserError``.
+"""
+
+import os
+import sys
+import threading
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from kestrel_analyzer.database import _to_csv_atomic, save_database
+
+pytestmark = pytest.mark.unit
+
+
+def _frame(rows: int = 2000) -> pd.DataFrame:
+    """A frame whose quoted fields span commas, so truncation lands mid-string."""
+    return pd.DataFrame(
+        {
+            "filename": [f"DSC_{i:04d}.NEF" for i in range(rows)],
+            "quality": [0.5] * rows,
+            "species": ["Northern Cardinal, adult male"] * rows,
+            "crops_json": ['[{"x": 1, "y": 2, "label": "bird, perched"}]'] * rows,
+        }
+    )
+
+
+class TestAtomicCsvWrite:
+    def test_output_is_byte_identical_to_plain_to_csv(self, tmp_path):
+        """The atomic path must not change the file pandas would have written."""
+        df = _frame(50)
+        plain = tmp_path / "plain.csv"
+        atomic = tmp_path / "atomic.csv"
+
+        df.to_csv(plain, index=False)
+        _to_csv_atomic(df, str(atomic))
+
+        assert atomic.read_bytes() == plain.read_bytes()
+
+    def test_no_temp_files_left_behind(self, tmp_path):
+        df = _frame(50)
+        _to_csv_atomic(df, str(tmp_path / "kestrel_database.csv"))
+
+        assert [p.name for p in tmp_path.iterdir()] == ["kestrel_database.csv"]
+
+    def test_existing_file_survives_a_failed_write(self, tmp_path):
+        """A write that raises must leave the previous database intact."""
+        db_path = tmp_path / "kestrel_database.csv"
+        _to_csv_atomic(_frame(10), str(db_path))
+        good = db_path.read_bytes()
+
+        class Exploding(pd.DataFrame):
+            def to_csv(self, *a, **kw):
+                raise OSError("disk full")
+
+        with pytest.raises(OSError):
+            _to_csv_atomic(Exploding(_frame(10)), str(db_path))
+
+        assert db_path.read_bytes() == good
+        assert [p.name for p in tmp_path.iterdir()] == ["kestrel_database.csv"]
+
+    def test_concurrent_reads_never_see_a_partial_file(self, tmp_path):
+        """Reproduces the production race: pipeline saves while the UI reads.
+
+        Against the pre-fix ``database.to_csv(db_path, index=False)`` this fails
+        within a few hundred milliseconds with the two signatures seen in crash
+        reports: ``No columns to parse from file`` and ``EOF inside string``.
+        """
+        db_path = str(tmp_path / "kestrel_database.csv")
+        df = _frame()
+        save_database(df, db_path)
+
+        stop = threading.Event()
+        errors = []
+        reads = []
+
+        def writer():
+            while not stop.is_set():
+                save_database(df, db_path)
+
+        def reader():
+            while not stop.is_set():
+                try:
+                    reads.append(len(pd.read_csv(db_path)))
+                except Exception as exc:  # noqa: BLE001 - recording for assert
+                    errors.append(f"{type(exc).__name__}: {exc}")
+
+        threads = [threading.Thread(target=writer), threading.Thread(target=reader)]
+        for t in threads:
+            t.start()
+        stop.wait(3.0)
+        stop.set()
+        for t in threads:
+            t.join()
+
+        assert not errors, f"{len(errors)} partial read(s), e.g. {errors[0]}"
+        assert reads, "reader never completed a read"
+        # Every successful read must see the whole database, never a prefix.
+        assert set(reads) == {len(df)}
+
+    def test_no_temp_files_survive_concurrent_saves(self, tmp_path):
+        """Parallel saves each get a unique mkstemp path and clean up after."""
+        db_path = str(tmp_path / "kestrel_database.csv")
+        df = _frame(200)
+
+        threads = [
+            threading.Thread(target=lambda: [save_database(df, db_path) for _ in range(5)])
+            for _ in range(4)
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert sorted(os.listdir(tmp_path)) == ["kestrel_database.csv"]
+        assert len(pd.read_csv(db_path)) == len(df)


### PR DESCRIPTION
## Summary

`save_database()` wrote the database with `DataFrame.to_csv(db_path)`, which truncates the destination and streams rows into it. The analysis pipeline calls `save_database` after every processed image, while the UI auto-refresh timer (`silentRefreshPending`, every 7s) reads the same path via `read_kestrel_csv` / `apply_normalization`. A reader landing mid-write observes a partial file.

This has been showing up in crash reports for weeks as repeated log lines:

```
[serve][ERROR] [API] apply_normalization error: No columns to parse from file
[serve][ERROR] [API] apply_normalization error: Error tokenizing data.
    C error: EOF inside string starting at row 243
[serve][ERROR] [API] apply_normalization error: Error tokenizing data.
    C error: EOF inside string starting at row 3002
[serve][ERROR] [API] apply_normalization error: Error tokenizing data.
    C error: EOF inside string starting at row 4556
```

The row number **varies between successive reads of the same database within one session**, which is the signature of a write/read race rather than a corrupt file sitting on disk. Earlier triage passes attributed these to CSV corruption or a malformed user-supplied CSV; that read of the evidence was wrong.

Two distinct pandas errors, one cause:
- `EmptyDataError: No columns to parse from file` — the reader landed between `to_csv`'s truncate and the header flush.
- `ParserError: EOF inside string` — the reader landed on a row cut inside a quoted field such as `crops_json` or `species`.

## Fix

Route both CSV writes in `database.py` through a new `_to_csv_atomic()`: write to a unique `mkstemp` file in the same directory, `fsync`, then `os.replace` into place. `os.replace` is atomic on POSIX and on Windows, so a concurrent reader sees either the complete previous file or the complete new one — never a prefix.

This mirrors the atomic-save pattern already used by `settings_utils.save_settings()`. Fixing the writer fixes every reader at once (`apply_normalization`, `read_kestrel_csv`, `save_database`'s own preserve-columns read), so no reader-side retry logic is needed.

A failed write removes the temp file and re-raises rather than falling back to a direct write, so the previous database survives a full disk or a permissions error intact.

## Test plan

New `analyzer/tests/unit/test_database_atomic_save.py` (5 tests):

- `test_concurrent_reads_never_see_a_partial_file` — runs a writer thread and a reader thread against one database for 3s. **Against the pre-fix code this fails in under a second with the exact production signatures** (512 partial reads, `EmptyDataError: No columns to parse from file`); it passes after the fix.
- `test_output_is_byte_identical_to_plain_to_csv` — guards against the atomic path changing the file pandas would have written (quoting, line endings, encoding).
- `test_existing_file_survives_a_failed_write` — a write that raises leaves the previous database byte-for-byte intact and drops no temp file.
- `test_no_temp_files_left_behind` / `test_no_temp_files_survive_concurrent_saves` — 4 threads × 5 saves leave only `kestrel_database.csv`.

Suite results:
- `pytest tests/unit/test_database_atomic_save.py tests/unit/test_database.py` — 12 passed.
- `pytest tests/unit` (excluding 5 modules that need `cv2`, unavailable in this container) — 507 passed, 1 failed, 2 skipped. The one failure is `test_reject_move.py::test_move_raw_with_real_jpg_companion`, which fails identically on unmodified `dev` — pre-existing and unrelated.

## Notes

Present in both `dev` and the shipped `Rock-Wren` tag, so users on the current release are affected. The reported occurrences were non-fatal — `apply_normalization` returns `{'success': False}` and the UI silently keeps the previous star ratings — so the visible symptom is star ratings intermittently failing to refresh during analysis, not a crash.

---
_Generated by [Claude Code](https://claude.ai/code/session_01E9eNk7oumgSrqC5t2BD2oj)_