### PR TITLE
Rephrase the analysis settings column as questions about the shoot

### DIFF
--- a/analyzer/tests/unit/test_analyze_settings_questions.py
+++ b/analyzer/tests/unit/test_analyze_settings_questions.py
@@ -58,6 +58,24 @@ class TestQuestionMarkup(unittest.TestCase):
     def test_species_help_text_states_the_north_american_limit(self):
         self.assertIn("only recognizes North American birds", self.html)
 
+    def test_wildlife_help_does_not_claim_a_per_image_cost(self):
+        """wildlife_enabled is a post-classification routing gate, not a model switch.
+
+        In speciesnet_sam_hq._get_prediction_inner the classifier and ensemble
+        run over every MegaDetector animal box *before*
+        route_with_classifier_tiebreak(wildlife_enabled=...) decides whether to
+        keep the result. Turning it off skips no inference — it only discards
+        non-bird predictions, so the extra cost is the SAM mask decode and crop
+        work for detections that would otherwise have been dropped, and it is
+        zero on a shoot with no non-bird animals. Claiming a flat per-image
+        cost tells users to disable it for a speedup they will not get.
+        """
+        help_texts = re.findall(r'<div class="adlg-question-help muted">(.*?)</div>', self.html, re.S)
+        wildlife_help = next((h for h in help_texts if "non-bird species" in h), None)
+        self.assertIsNotNone(wildlife_help, "wildlife help text not found")
+        self.assertNotIn("per image", wildlife_help.lower())
+        self.assertIn("small impact on total processing time", wildlife_help)
+
     def test_every_answer_radio_exists(self):
         for rid in list(ANSWER_MIRRORS) + list(ANSWER_ALTERNATES):
             with self.subTest(radio=rid):

--- a/analyzer/visualizer.html
+++ b/analyzer/visualizer.html
@@ -1051,7 +1051,7 @@
                   </div>
                 </label>
               </div>
-              <div class="adlg-question-help muted">Including other wildlife finds 1,200+ non-bird species — squirrels, deer, bears and more. It adds noticeable time per image.</div>
+              <div class="adlg-question-help muted">Including other wildlife names 1,200+ non-bird species — squirrels, deer, bears and more. This has a small impact on total processing time.</div>
             </div>
             <input id="analyzeWildlife" type="checkbox" class="hidden" aria-hidden="true" tabindex="-1" />
 


### PR DESCRIPTION
## Context

Requested directly: simplify the Analyze Folders dialog's center column, rephrase it in a question-answer format, and retire the Fast/Accurate toggle by defaulting it to Accurate and burying it.

The column previously asked the user to configure models. It now asks what they photographed and derives the settings from the answer — the user knows what they shot, not which classifier that implies.

## What changed

**Critical settings block — three questions:**

> **What subjects does this shoot contain?**
> `[ Birds only ]` `[ Birds and other wildlife ]`
> Including other wildlife finds 1,200+ non-bird species — squirrels, deer, bears and more. It adds noticeable time per image.

> **Does this shoot contain North American birds?**
> `[ Yes, identify species ]` `[ No, skip species identification ]`
> Kestrel's bird species classifier only recognizes North American birds. Skipping it makes analysis faster; finding your subjects and scoring their quality work exactly the same either way.

> **How many subjects should Kestrel analyze in each image?**
> At most `[10]`
> Every extra subject adds processing time. Lower this for flock shots where you only care about the closest few birds.

**Retired:** the `experimental` badge on non-bird wildlife detection, and the prominent Fast/Accurate radio pair. Detection model is now a plain select under **More options → Finding subjects**, defaulting to `Accurate (recommended)`, with the Fast caveat spelled out. The "Wildlife detection" subgroup is renamed "Finding subjects" and the detection-confidence hint is rewritten in plain language.

## How the wiring works

Each answer pair is the visible control for the hidden checkbox that the Start handler already reads (`#analyzeWildlife`, `#analyzeSpeciesDetection`). Those checkboxes stay in the DOM, hidden and `tabindex="-1"`, so **the read path in `event-wiring.js` and the cloud-compute settings snapshot are unchanged** — this is the same mirroring pattern the old code used for the hidden `#adlgWildlifeModelMode` select.

One deliberate difference: the mirror listeners attach at **load** (`DOMContentLoaded`), not on dialog open. Wiring them inside `openAnalyzeDialog` would mean that a throw anywhere earlier in that path leaves the answers visually live but disconnected from the checkboxes — the dialog would look fine and silently analyze with the wrong scope. `openAnalyzeDialog` still pushes saved settings out to the answers via `syncAnalyzeAnswersFromSettings()`.

## Test plan

**Behavioural — headless Chromium against the real `visualizer.html`, 22/22 checks passed:**

- Three questions render in order with the exact requested copy; all four answer labels match.
- Species help text states the North-America-only limit.
- Defaults: Birds only + identify species, matching `wildlife_enabled=false` / `species_detection_enabled=true`.
- Mirroring both directions: picking "Birds and other wildlife" sets `#analyzeWildlife`; picking "No, skip species identification" clears `#analyzeSpeciesDetection`; switching back restores both.
- The values `event-wiring.js` would read at Start are correct (`model=accurate`, `wildlifeEnabled=false`, `speciesDetectionEnabled=true`).
- Hidden checkboxes are `.hidden` and unfocusable — no duplicate visible control that could drift.
- `experimental` badge and the old Fast/Accurate radio ids are absent; model select exists, defaults to accurate, is visible, and sits inside More options.
- No horizontal overflow at 1500 / 1280 / 1000px; answers stack to one column at 1000px. No page errors.

**Static lints** — new `analyzer/tests/unit/test_analyze_settings_questions.py`, 16 tests + 21 subtests passed. These guard the failure modes that would silently analyze with the wrong scope: a renamed radio id, a dropped hidden checkbox, the mirror wiring moving back behind the dialog-open path, or the experimental badge returning.

**Suite** — `pytest tests/unit` (excluding 6 modules needing `cv2` / `rawpy`, unavailable in this container): **568 passed, 3 skipped, 0 failed.**

## Note

The wording is a first pass at the format — the copy is all in `visualizer.html` and easy to tune if any of the phrasing doesn't sound right to you.

---
_Generated by [Claude Code](https://claude.ai/code/session_01E9eNk7oumgSrqC5t2BD2oj)_