### PR TITLE
Culling Assistant: cut by quality score, with star thresholds on the slider

### DIFF
--- a/analyzer/api_bridge.py
+++ b/analyzer/api_bridge.py
@@ -2152,6 +2152,45 @@ class Api:
             error(f'[API] get_settings error: {e}')
             return {'success': False, 'error': str(e), 'settings': {}}
 
+    def get_rating_thresholds(self):
+        """Return the active rating profile's quality-score cutoffs for each star.
+
+        The frontend needs these to draw star positions on a quality-score
+        number line (Culling Assistant) and to convert a manual star rating
+        back into the quality band it represents. Served from
+        ``kestrel_analyzer.ratings`` so the table has exactly one definition.
+
+        Returns:
+            {
+              'success': bool,
+              'profile': str,                # active rating_profile setting
+              'thresholds': {'five': float, 'four': float, 'three': float, 'two': float},
+              'profiles': {name: thresholds, ...},   # every built-in profile
+              'error': str,
+            }
+        """
+        try:
+            try:
+                from kestrel_analyzer.ratings import RATING_PROFILES, get_profile_thresholds
+            except ImportError:
+                from analyzer.kestrel_analyzer.ratings import (  # type: ignore
+                    RATING_PROFILES,
+                    get_profile_thresholds,
+                )
+
+            settings = load_persisted_settings()
+            profile = str(settings.get('rating_profile', 'balanced') or 'balanced').lower()
+            return {
+                'success': True,
+                'profile': profile,
+                'thresholds': dict(get_profile_thresholds(profile)),
+                'profiles': {k: dict(v) for k, v in RATING_PROFILES.items()},
+                'error': '',
+            }
+        except Exception as e:
+            error(f'[API] get_rating_thresholds error: {e}')
+            return {'success': False, 'error': str(e), 'profile': '', 'thresholds': {}, 'profiles': {}}
+
     def save_settings_data(self, settings_dict):
         """Persist settings from JavaScript (wraps save_persisted_settings)."""
         try:

--- a/analyzer/css/dialogs/analyze.css
+++ b/analyzer/css/dialogs/analyze.css
@@ -193,6 +193,43 @@
 }
 .adlg-radio-inline input[type="radio"] { accent-color: #2b6ec8; }
 
+/* Question-and-answer settings blocks. Each block is one question about the
+   shoot with its answers directly beneath, so the column reads as a short
+   interview rather than a list of model parameters. */
+.adlg-question {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 12px 0 0;
+  border-top: 1px solid #2a3445;
+}
+.adlg-question:first-child {
+  border-top: none;
+  padding-top: 0;
+}
+.adlg-question-text {
+  font-size: 13.5px;
+  font-weight: 600;
+  color: #e1e5ec;
+  line-height: 1.35;
+}
+/* Answers sit side by side, and wrap to one per row when the dialog is too
+   narrow to keep both labels on a single line. */
+.adlg-answer-pair {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
+}
+@media (max-width: 1100px) {
+  .adlg-answer-pair { grid-template-columns: 1fr; }
+}
+.adlg-answer-pair .adlg-radio-row-horiz { align-items: center; }
+.adlg-question-help {
+  font-size: 12px;
+  line-height: 1.45;
+  color: var(--muted);
+}
+
 /* "More options" collapsible — flat list of less-critical settings. */
 .analyze-dlg-more-options {
   border: 1px solid #2a3040;

--- a/analyzer/culling.html
+++ b/analyzer/culling.html
@@ -906,6 +906,70 @@
       min-width: 24px;
       text-align: left;
     }
+    /* Quality-score cutoff: a 0.00–1.00 slider with the active profile's star
+       thresholds drawn underneath, so the number always reads against the star
+       scale used everywhere else in the app. */
+    .auto-cat-panel .quality-cutoff-group {
+      min-width: 250px;
+    }
+    .auto-cat-panel .quality-scale-wrap {
+      position: relative;
+      width: 190px;
+      padding-bottom: 15px;
+    }
+    .auto-cat-panel .quality-scale-wrap input[type="range"] {
+      width: 100%;
+      display: block;
+      margin: 0;
+      position: relative;
+      z-index: 1;
+    }
+    .auto-cat-panel .quality-scale-ticks {
+      position: absolute;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      height: 15px;
+      pointer-events: none;
+    }
+    .auto-cat-panel .quality-tick {
+      position: absolute;
+      top: 0;
+      /* left is set inline from the threshold's position on the 0–1 scale */
+      transform: translateX(-50%);
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      font-size: 9px;
+      line-height: 1;
+      color: var(--muted);
+      white-space: nowrap;
+    }
+    .auto-cat-panel .quality-tick::before {
+      content: '';
+      width: 1px;
+      height: 4px;
+      background: #3a4557;
+      margin-bottom: 2px;
+    }
+    /* The star bands at or above the cutoff are the ones that will be
+       accepted — brighten those so the split is readable at a glance. */
+    .auto-cat-panel .quality-tick.above {
+      color: #f5c542;
+    }
+    .auto-cat-panel .quality-tick.above::before {
+      background: #f5c542;
+    }
+    .auto-cat-panel .quality-scale-note {
+      font-size: 10px;
+      color: var(--muted);
+      line-height: 1.3;
+      max-width: 250px;
+    }
+    .auto-cat-panel .slider-val#qualityCutoffVal {
+      min-width: 34px;
+      font-variant-numeric: tabular-nums;
+    }
     .auto-cat-panel .unrated-group {
       justify-content: flex-end;
     }
@@ -991,12 +1055,20 @@
       </div>
       <!-- Auto-categorize settings panel (hidden by default) -->
       <div class="auto-cat-panel hidden" id="autoCatPanel">
-        <div class="slider-group">
-          <label for="qualityCutoffSlider">Accept if rated above</label>
+        <div class="slider-group quality-cutoff-group">
+          <label for="qualityCutoffSlider">Accept if quality is at least</label>
           <div class="slider-row">
-            <input type="range" id="qualityCutoffSlider" min="0" max="5" value="3" step="1" />
-            <span class="slider-val" id="qualityCutoffVal">★3</span>
+            <div class="quality-scale-wrap">
+              <input type="range" id="qualityCutoffSlider" min="0" max="1" value="0.60" step="0.01"
+                     aria-describedby="qualityScaleTicks" />
+              <!-- Star cutoffs for the active rating profile, drawn at their
+                   quality positions so the score always reads against the
+                   star scale the rest of the app uses. -->
+              <div class="quality-scale-ticks" id="qualityScaleTicks" aria-hidden="true"></div>
+            </div>
+            <span class="slider-val" id="qualityCutoffVal">0.60</span>
           </div>
+          <div class="quality-scale-note" id="qualityCutoffNote"></div>
         </div>
         <div class="slider-group">
           <label for="minPerSceneSlider">Min Accepted Per Scene</label>
@@ -1810,29 +1882,129 @@
       return list;
     }
 
+    // ---- Rating profile thresholds ----
+    // Quality-score cutoff for each star band, from the active rating_profile
+    // setting. Seeded with the 'balanced' defaults from
+    // kestrel_analyzer/ratings.py so the panel is usable before the bridge
+    // answers (and if it never does, e.g. browser preview).
+    let _ratingThresholds = { five: 0.85, four: 0.60, three: 0.40, two: 0.15 };
+    const _STAR_KEYS = [
+      { star: 2, key: 'two' },
+      { star: 3, key: 'three' },
+      { star: 4, key: 'four' },
+      { star: 5, key: 'five' },
+    ];
+
+    async function loadRatingThresholds() {
+      try {
+        const res = await window.pywebview.api.get_rating_thresholds();
+        const t = res?.success ? res.thresholds : null;
+        if (t && ['five', 'four', 'three', 'two'].every(k => Number.isFinite(Number(t[k])))) {
+          _ratingThresholds = {
+            five: Number(t.five), four: Number(t.four),
+            three: Number(t.three), two: Number(t.two),
+          };
+        }
+      } catch (e) { console.warn('loadRatingThresholds:', e); }
+      renderQualityScaleTicks();
+      updateSliderLabels(true);
+    }
+
+    // Lowest quality score that still earns `star`. Star 1 is everything below
+    // the two-star cutoff, so its floor is 0.
+    function qualityFloorForStar(star) {
+      const hit = _STAR_KEYS.find(s => s.star === star);
+      return hit ? Number(_ratingThresholds[hit.key]) : 0;
+    }
+
+    // Mirror of quality_to_rating() in kestrel_analyzer/ratings.py.
+    function starForQuality(q) {
+      const v = Number(q);
+      if (!Number.isFinite(v) || v < 0) return 0;
+      if (v >= _ratingThresholds.five)  return 5;
+      if (v >= _ratingThresholds.four)  return 4;
+      if (v >= _ratingThresholds.three) return 3;
+      if (v >= _ratingThresholds.two)   return 2;
+      return 1;
+    }
+
+    // The quality score an image effectively sits at for cutoff purposes.
+    // A manual star rating is an explicit user statement, so it wins over the
+    // computed score: treat the image as sitting at the floor of that band.
+    function effectiveQuality(row) {
+      if (getOrigin(row) === 'manual') {
+        const star = getRating(row);
+        // A manual 0 means "unrated" and is handled by the unrated default,
+        // never by the cutoff comparison.
+        if (star > 0) return qualityFloorForStar(star);
+      }
+      return parseNumber(row?.quality);
+    }
+
+    function renderQualityScaleTicks() {
+      const host = el('#qualityScaleTicks');
+      if (!host) return;
+      const cutoff = getSliderValues().qualityCutoff;
+      host.innerHTML = '';
+      for (const { star, key } of _STAR_KEYS) {
+        const pos = Number(_ratingThresholds[key]);
+        if (!Number.isFinite(pos)) continue;
+        const tick = document.createElement('div');
+        tick.className = 'quality-tick' + (pos >= cutoff ? ' above' : '');
+        tick.style.left = (Math.max(0, Math.min(1, pos)) * 100) + '%';
+        tick.appendChild(document.createTextNode('★' + star));
+        host.appendChild(tick);
+      }
+    }
+
     // ---- Auto-categorize helpers ----
     function getSliderValues() {
-      const cutoff  = parseInt(el('#qualityCutoffSlider')?.value ?? '3', 10);
+      const rawCutoff = parseFloat(el('#qualityCutoffSlider')?.value ?? '0.60');
+      const qualityCutoff = Number.isFinite(rawCutoff) ? Math.max(0, Math.min(1, rawCutoff)) : 0.60;
       const minKeep = parseInt(el('#minPerSceneSlider')?.value  ?? '0', 10);
       const maxRaw  = parseInt(el('#maxPerSceneSlider')?.value  ?? '0', 10);
       const maxKeep = maxRaw === 0 ? Infinity : maxRaw;
       const unratedDefault = (el('#unratedDefaultSelect')?.value === 'accept') ? 'accept' : 'reject';
-      return { cutoff, minKeep, maxKeep, unratedDefault };
+      return { qualityCutoff, minKeep, maxKeep, unratedDefault };
     }
 
     let _autoRulesLoaded = false; // set true after first settings load so initial load doesn't flash
     function updateSliderLabels(fromLoad = false) {
-      const { cutoff, minKeep, maxKeep, unratedDefault } = getSliderValues();
+      const { qualityCutoff, minKeep, maxKeep, unratedDefault } = getSliderValues();
       const qEl   = el('#qualityCutoffVal');
       const minEl = el('#minPerSceneVal');
       const maxEl = el('#maxPerSceneVal');
-      if (qEl)   qEl.textContent   = '\u2605' + cutoff;
+      const cutoffText = qualityCutoff.toFixed(2);
+      if (qEl)   qEl.textContent   = cutoffText;
       if (minEl) minEl.textContent = String(minKeep);
       if (maxEl) maxEl.textContent = maxKeep === Infinity ? '\u221e' : String(maxKeep);
+
+      // Say which star band the cutoff currently lands in, so the score stays
+      // legible to anyone who thinks in stars.
+      const noteEl = el('#qualityCutoffNote');
+      if (noteEl) {
+        const star = starForQuality(qualityCutoff);
+        const floor = qualityFloorForStar(star);
+        if (qualityCutoff <= 0) {
+          noteEl.textContent = 'Accepts every rated image.';
+        } else if (Math.abs(qualityCutoff - floor) < 0.005) {
+          // Cutoff sits exactly on a star boundary \u2014 the whole band is in.
+          noteEl.textContent = `Accepts \u2605${star} and above (\u2605${star} starts at ${floor.toFixed(2)}).`;
+        } else if (star >= 5) {
+          noteEl.textContent = 'Inside the \u26055 band \u2014 accepts only the strongest \u26055 images.';
+        } else {
+          // Cutoff splits a band: only the upper part of it is accepted, so
+          // don't claim the whole star level is in.
+          noteEl.textContent =
+            `Inside the \u2605${star} band \u2014 accepts \u2605${star + 1} and above, plus stronger \u2605${star} images.`;
+        }
+      }
+      renderQualityScaleTicks();
+
       const unratedLabel = unratedDefault === 'accept' ? 'Auto-Accept' : 'Auto-Reject';
       const summary = el('#autoCatSummary');
       if (summary) summary.textContent =
-        `Rated > \u2605${cutoff} \u00b7 Min ${minKeep} \u00b7 Max ${maxKeep === Infinity ? '\u221e' : maxKeep} \u00b7 Unrated \u2192 ${unratedLabel}`;
+        `Quality \u2265 ${cutoffText} \u00b7 Min ${minKeep} \u00b7 Max ${maxKeep === Infinity ? '\u221e' : maxKeep} \u00b7 Unrated \u2192 ${unratedLabel}`;
       // Highlight Re-apply button when rules change (but not on initial page load)
       if (!fromLoad && _autoRulesLoaded) {
         el('#reapplyAutoBtn')?.classList.add('needs-reapply');
@@ -1840,7 +2012,7 @@
     }
 
     function applyAutoCategorize(preserveManual = true) {
-      const { cutoff, minKeep, maxKeep, unratedDefault } = getSliderValues();
+      const { qualityCutoff, minKeep, maxKeep, unratedDefault } = getSliderValues();
       for (const scene of scenes) {
         // Sort by rating desc, then quality score desc
         const sorted = scene.images.slice().sort((a, b) => {
@@ -1853,7 +2025,7 @@
           sorted.filter(r => {
             const rt = getRating(r);
             if (rt === 0) return unratedDefault === 'accept';
-            return rt > cutoff;
+            return effectiveQuality(r) >= qualityCutoff;
           })
                 .map(r => r.filename)
         );
@@ -2850,11 +3022,26 @@
           if (sl) { sl.value = rawZoom; if (lb) lb.textContent = rawZoom + '\u00d7'; }
         }
         // Auto-categorize slider settings
-        const qCutoff = parseInt(s.culling_quality_cutoff, 10);
         const minPS   = parseInt(s.culling_min_per_scene,  10);
         const maxPS   = parseInt(s.culling_max_per_scene,  10);
         const unratedDefault = String(s.culling_unrated_default || 'reject').toLowerCase();
-        if (qCutoff >= 0 && qCutoff <= 5)  { const sl = el('#qualityCutoffSlider'); if (sl) sl.value = qCutoff; }
+
+        // The cutoff is a quality score now. Fall back to the legacy star
+        // cutoff (culling_quality_cutoff, an int 0–5 meaning "accept stars
+        // above this") by converting it to the floor of the lowest star it
+        // accepted, which preserves the user's existing split.
+        const qScore = parseFloat(s.culling_quality_score_cutoff);
+        const legacyStar = parseInt(s.culling_quality_cutoff, 10);
+        let cutoff = null;
+        if (Number.isFinite(qScore) && qScore >= 0 && qScore <= 1) {
+          cutoff = qScore;
+        } else if (Number.isFinite(legacyStar) && legacyStar >= 0 && legacyStar <= 5) {
+          cutoff = legacyStar >= 5 ? 1 : qualityFloorForStar(legacyStar + 1);
+        }
+        if (cutoff !== null) {
+          const sl = el('#qualityCutoffSlider');
+          if (sl) sl.value = String(Math.max(0, Math.min(1, cutoff)));
+        }
         if (minPS   >= 0 && minPS   <= 5)  { const sl = el('#minPerSceneSlider');   if (sl) sl.value = minPS; }
         if (maxPS   >= 0 && maxPS   <= 20) { const sl = el('#maxPerSceneSlider');   if (sl) sl.value = maxPS; }
         const unratedSel = el('#unratedDefaultSelect');
@@ -2862,6 +3049,8 @@
         updateSliderLabels(true);
         _autoRulesLoaded = true;
       } catch (e) { console.warn('loadCullingSettings:', e); }
+      // Settled marker for UI tests driving this page headlessly.
+      window.__cullingSettingsLoaded = true;
     }
 
     function saveCullingSettings() {
@@ -2872,7 +3061,11 @@
           const s = (res?.success ? res.settings : {}) || {};
           s.culling_card_zoom       = parseInt(document.getElementById('cardZoomSlider')?.value, 10) || 150;
           s.culling_raw_zoom        = parseInt(document.getElementById('previewZoomSlider')?.value, 10) || 5;
-          s.culling_quality_cutoff  = parseInt(el('#qualityCutoffSlider')?.value, 10) || 3;
+          const _cut = getSliderValues().qualityCutoff;
+          s.culling_quality_score_cutoff = Number(_cut.toFixed(2));
+          // Keep the legacy star key roughly in step so an older build reading
+          // these settings still lands on a comparable split.
+          s.culling_quality_cutoff  = Math.max(0, starForQuality(_cut) - 1);
           s.culling_min_per_scene   = parseInt(el('#minPerSceneSlider')?.value,   10) || 0;
           s.culling_max_per_scene   = parseInt(el('#maxPerSceneSlider')?.value,   10) || 0;
           s.culling_unrated_default = (el('#unratedDefaultSelect')?.value === 'accept') ? 'accept' : 'reject';
@@ -3393,6 +3586,10 @@
         return;
       }
 
+      // Thresholds first: loadCullingSettings converts a legacy star cutoff
+      // into a quality score using them, so stale defaults here would migrate
+      // the user onto the wrong split.
+      await loadRatingThresholds();
       updateSliderLabels(); // apply defaults before settings load
       await loadCullingSettings();
 

--- a/analyzer/js/analyze-dialog.js
+++ b/analyzer/js/analyze-dialog.js
@@ -1107,6 +1107,53 @@
     }
 
     // ── Dialog open / settings hydration ────────────────────────────────────────
+    // ── Shoot questions ↔ hidden checkboxes ───────────────────────────────────
+    // The two "what did you shoot" questions are the visible controls for
+    // #analyzeWildlife and #analyzeSpeciesDetection. Those checkboxes stay in
+    // the DOM (hidden) because event-wiring.js reads them when Start is
+    // clicked, and the cloud-compute snapshot reads them too — mirroring keeps
+    // that single read path intact while the user only ever sees the questions.
+    //
+    // Listeners are attached at load rather than on dialog open: a throw
+    // anywhere earlier in the open path would otherwise leave the answers
+    // visually live but disconnected, silently analyzing with the wrong scope.
+    const _ANSWER_PAIRS = [
+      { on: 'adlgSubjectScopeWildlife', off: 'adlgSubjectScopeBirds', box: 'analyzeWildlife' },
+      { on: 'adlgSpeciesScopeYes', off: 'adlgSpeciesScopeNo', box: 'analyzeSpeciesDetection' },
+    ];
+
+    // Push the checkbox state out to the radios (settings → UI).
+    function syncAnalyzeAnswersFromSettings() {
+      for (const { on, off, box } of _ANSWER_PAIRS) {
+        const onEl = document.getElementById(on);
+        const offEl = document.getElementById(off);
+        const boxEl = document.getElementById(box);
+        if (!onEl || !offEl || !boxEl) continue;
+        onEl.checked = !!boxEl.checked;
+        offEl.checked = !boxEl.checked;
+      }
+    }
+
+    // Attach the radios → checkbox mirror once (UI → settings).
+    function wireAnalyzeAnswerMirrors() {
+      for (const { on, off, box } of _ANSWER_PAIRS) {
+        const onEl = document.getElementById(on);
+        const offEl = document.getElementById(off);
+        const boxEl = document.getElementById(box);
+        if (!onEl || !offEl || !boxEl || onEl.dataset.wiredMirror) continue;
+        onEl.dataset.wiredMirror = '1';
+        const sync = () => { boxEl.checked = !!onEl.checked; };
+        onEl.addEventListener('change', sync);
+        offEl.addEventListener('change', sync);
+      }
+    }
+
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', wireAnalyzeAnswerMirrors, { once: true });
+    } else {
+      wireAnalyzeAnswerMirrors();
+    }
+
     async function openAnalyzeDialog() {
       if (!hasPywebviewApi) {
         alert('Analysis queue is only available in the desktop (pywebview) mode.\n\nRun kestrel_visualizer as a desktop app to use this feature.');
@@ -1123,26 +1170,13 @@
           }
         }).catch(() => {});
       }
-      // Hydrate critical settings from persisted values. The radios mirror to
-      // the hidden #adlgWildlifeModelMode <select> so existing read/write paths
-      // (event-wiring.js Start handler) keep working unchanged.
-      const _hiddenModelSelect = document.getElementById('adlgWildlifeModelMode');
+      // Detection model now lives as a plain <select> in More options →
+      // Finding subjects, defaulting to Accurate. Anything that isn't an
+      // explicit 'fast' resolves to 'accurate'.
+      const _modelSelect = document.getElementById('adlgWildlifeModelMode');
       const savedMode = String(getSetting('wildlife_model_mode', 'accurate') || 'accurate').toLowerCase();
       const modeFinal = (savedMode === 'fast') ? 'fast' : 'accurate';
-      if (_hiddenModelSelect) _hiddenModelSelect.value = modeFinal;
-      const _modeAccurate = document.getElementById('adlgWildlifeModelModeAccurate');
-      const _modeFast = document.getElementById('adlgWildlifeModelModeFast');
-      if (_modeAccurate && _modeFast) {
-        _modeAccurate.checked = (modeFinal === 'accurate');
-        _modeFast.checked = (modeFinal === 'fast');
-        // Mirror radio change → hidden select (so the existing read path works).
-        const _syncModeRadios = () => {
-          const v = _modeAccurate.checked ? 'accurate' : 'fast';
-          if (_hiddenModelSelect) _hiddenModelSelect.value = v;
-        };
-        _modeAccurate.addEventListener('change', _syncModeRadios);
-        _modeFast.addEventListener('change', _syncModeRadios);
-      }
+      if (_modelSelect) _modelSelect.value = modeFinal;
 
       // Hydrate "More options" settings from persisted values (same keys as before).
       // Default 0.15 now matches the suggested-baseline message shown by the
@@ -1184,6 +1218,9 @@
       if (_adlgWildlife) _adlgWildlife.checked = !!getSetting('wildlife_enabled', false);
       const _adlgSpecies = document.getElementById('analyzeSpeciesDetection');
       if (_adlgSpecies) _adlgSpecies.checked = getSetting('species_detection_enabled') !== false;
+
+      // Point the visible answers at the freshly-hydrated checkbox state.
+      syncAnalyzeAnswersFromSettings();
 
       // Unlock checkbox state — reset every open. User must explicitly re-tick
       // it to unlock destructive re-analysis on each queue.

--- a/analyzer/tests/unit/test_analyze_settings_questions.py
+++ b/analyzer/tests/unit/test_analyze_settings_questions.py
@@ -1,0 +1,164 @@
+"""Static wiring tests for the question-and-answer analysis settings column.
+
+The critical settings block in the Analyze Folders dialog is phrased as
+questions about the shoot. Each answer pair is the visible control for a
+hidden checkbox (``#analyzeWildlife`` / ``#analyzeSpeciesDetection``) that
+``event-wiring.js`` reads when Start is clicked.
+
+The repo has no JS test runner, so these are source-level lints in the same
+spirit as ``test_raw_warn_banner.py``. They catch the failure modes that would
+silently analyze with the wrong scope: a renamed radio id, a dropped hidden
+checkbox, or the mirror wiring being moved back behind the dialog-open path.
+
+Behavioural coverage (mirroring in both directions, defaults, responsive
+wrapping) was verified in a headless Chromium harness; see the PR description.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import unittest
+
+_THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+_ANALYZER_DIR = os.path.dirname(os.path.dirname(_THIS_DIR))
+
+# Radio id -> the hidden checkbox it mirrors onto.
+ANSWER_MIRRORS = {
+    "adlgSubjectScopeWildlife": "analyzeWildlife",
+    "adlgSpeciesScopeYes": "analyzeSpeciesDetection",
+}
+# The "negative" half of each pair; present so the group has two answers.
+ANSWER_ALTERNATES = ("adlgSubjectScopeBirds", "adlgSpeciesScopeNo")
+
+QUESTIONS = (
+    "What subjects does this shoot contain?",
+    "Does this shoot contain North American birds?",
+)
+
+# The Start handler in event-wiring.js reads these; they must survive the
+# rephrasing or analysis silently runs with the wrong options.
+START_HANDLER_IDS = ("analyzeWildlife", "analyzeSpeciesDetection", "adlgWildlifeModelMode")
+
+
+def _read(*parts: str) -> str:
+    with open(os.path.join(_ANALYZER_DIR, *parts), "r", encoding="utf-8") as f:
+        return f.read()
+
+
+class TestQuestionMarkup(unittest.TestCase):
+    def setUp(self):
+        self.html = _read("visualizer.html")
+
+    def test_questions_are_present(self):
+        for q in QUESTIONS:
+            with self.subTest(question=q):
+                self.assertIn(q, self.html)
+
+    def test_species_help_text_states_the_north_american_limit(self):
+        self.assertIn("only recognizes North American birds", self.html)
+
+    def test_every_answer_radio_exists(self):
+        for rid in list(ANSWER_MIRRORS) + list(ANSWER_ALTERNATES):
+            with self.subTest(radio=rid):
+                self.assertRegex(self.html, rf'id="{rid}"')
+
+    def test_answer_pairs_share_a_radio_group_name(self):
+        for name, count in (("adlgSubjectScope", 2), ("adlgSpeciesScope", 2)):
+            with self.subTest(group=name):
+                self.assertEqual(len(re.findall(rf'name="{name}"', self.html)), count)
+
+    def test_start_handler_ids_survive(self):
+        for eid in START_HANDLER_IDS:
+            with self.subTest(element=eid):
+                self.assertRegex(self.html, rf'id="{eid}"')
+
+    def test_mirrored_checkboxes_are_hidden_and_unfocusable(self):
+        """A visible duplicate control would let the two drift apart."""
+        for box in ANSWER_MIRRORS.values():
+            with self.subTest(checkbox=box):
+                tag = re.search(rf'<input id="{box}"[^>]*>', self.html)
+                self.assertIsNotNone(tag, f"{box} input tag not found")
+                self.assertIn('class="hidden"', tag.group(0))
+                self.assertIn('tabindex="-1"', tag.group(0))
+
+    def test_experimental_badge_is_retired(self):
+        """The owner asked for the badge to go when wildlife became an answer."""
+        critical = re.search(
+            r'<div class="analyze-dlg-settings-critical">(.*?)\n          </div>',
+            self.html,
+            re.S,
+        )
+        self.assertIsNotNone(critical, "critical settings block not found")
+        self.assertNotIn("adlg-tag", critical.group(1))
+        self.assertNotIn("experimental", critical.group(1).lower())
+
+
+class TestDetectionModelIsBuried(unittest.TestCase):
+    def setUp(self):
+        self.html = _read("visualizer.html")
+
+    def test_old_fast_accurate_radio_pair_is_gone(self):
+        for rid in ("adlgWildlifeModelModeAccurate", "adlgWildlifeModelModeFast"):
+            with self.subTest(radio=rid):
+                self.assertNotIn(rid, self.html)
+
+    def test_model_select_defaults_to_accurate(self):
+        sel = re.search(r'<select id="adlgWildlifeModelMode".*?</select>', self.html, re.S)
+        self.assertIsNotNone(sel, "model select not found")
+        self.assertRegex(sel.group(0), r'<option value="accurate"[^>]*selected')
+
+    def test_model_select_is_visible_and_inside_more_options(self):
+        sel = re.search(r'<select id="adlgWildlifeModelMode"[^>]*>', self.html)
+        self.assertIsNotNone(sel)
+        self.assertNotIn("hidden", sel.group(0))
+
+        more = self.html.index('<details class="analyze-dlg-more-options"')
+        self.assertGreater(
+            self.html.index('id="adlgWildlifeModelMode"'),
+            more,
+            "detection model should sit inside More options, not the critical block",
+        )
+
+
+class TestMirrorWiring(unittest.TestCase):
+    def setUp(self):
+        self.js = _read("js", "analyze-dialog.js")
+
+    def test_pairs_table_maps_each_radio_to_its_checkbox(self):
+        table = re.search(r"const _ANSWER_PAIRS = \[(.*?)\];", self.js, re.S)
+        self.assertIsNotNone(table, "_ANSWER_PAIRS table not found")
+        for radio, box in ANSWER_MIRRORS.items():
+            with self.subTest(radio=radio):
+                self.assertRegex(table.group(1), rf"'{radio}'.*?'{box}'")
+
+    def test_mirrors_are_wired_at_load_not_on_dialog_open(self):
+        """Wiring inside openAnalyzeDialog would break if that path throws first."""
+        self.assertIn("DOMContentLoaded", self.js)
+        wire_at = self.js.index("wireAnalyzeAnswerMirrors()")
+        open_at = self.js.index("async function openAnalyzeDialog()")
+        self.assertLess(wire_at, open_at, "mirror wiring must run before/independently of dialog open")
+
+    def test_dialog_open_still_pushes_saved_settings_into_the_answers(self):
+        self.assertIn("syncAnalyzeAnswersFromSettings()", self.js)
+
+    def test_stale_radio_sync_removed(self):
+        self.assertNotIn("_syncModeRadios", self.js)
+
+
+class TestQuestionStyles(unittest.TestCase):
+    def setUp(self):
+        self.css = _read("css", "dialogs", "analyze.css")
+
+    def test_question_classes_are_styled(self):
+        for cls in (".adlg-question", ".adlg-question-text", ".adlg-answer-pair", ".adlg-question-help"):
+            with self.subTest(css_class=cls):
+                self.assertIn(cls, self.css)
+
+    def test_answers_collapse_to_one_column_when_narrow(self):
+        """Both answer labels cannot sit side by side in a narrow dialog."""
+        self.assertRegex(self.css, r"@media \(max-width: \d+px\)\s*\{\s*\.adlg-answer-pair")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/analyzer/tests/unit/test_culling_quality_cutoff.py
+++ b/analyzer/tests/unit/test_culling_quality_cutoff.py
@@ -1,0 +1,147 @@
+"""Tests for the Culling Assistant's quality-score accept cutoff.
+
+The auto-categorize cutoff is a quality score (0.00–1.00) with the active
+rating profile's star thresholds drawn on the slider, rather than an integer
+star level.
+
+The Python half (``get_rating_thresholds``) is tested directly. The frontend
+half lives inline in ``culling.html`` and the repo has no JS test runner, so
+those are source-level lints in the spirit of ``test_raw_warn_banner.py``.
+Behavioural coverage (tick positions, band note, legacy migration, the accept
+rule with manual ratings) was verified in a headless Chromium harness; see the
+PR description.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from kestrel_analyzer.ratings import RATING_PROFILES, quality_to_rating
+
+_THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+_ANALYZER_DIR = os.path.dirname(os.path.dirname(_THIS_DIR))
+
+
+def _read(*parts: str) -> str:
+    with open(os.path.join(_ANALYZER_DIR, *parts), "r", encoding="utf-8") as f:
+        return f.read()
+
+
+class TestRatingThresholdsBridge(unittest.TestCase):
+    """api_bridge.get_rating_thresholds is the single source for the frontend."""
+
+    def setUp(self):
+        self.src = _read("api_bridge.py")
+
+    def test_method_exists(self):
+        self.assertIn("def get_rating_thresholds(self)", self.src)
+
+    def test_serves_from_the_ratings_module_not_a_copy(self):
+        body = self.src.split("def get_rating_thresholds(self)", 1)[1].split("\n    def ", 1)[0]
+        self.assertIn("RATING_PROFILES", body)
+        self.assertIn("get_profile_thresholds", body)
+        self.assertIn("rating_profile", body)
+        # A hardcoded threshold number here would silently drift from ratings.py.
+        self.assertNotRegex(body, r"0\.(85|60|40|15)\b")
+
+    def test_returns_the_documented_shape(self):
+        body = self.src.split("def get_rating_thresholds(self)", 1)[1].split("\n    def ", 1)[0]
+        for key in ("'success'", "'profile'", "'thresholds'", "'profiles'", "'error'"):
+            with self.subTest(key=key):
+                self.assertIn(key, body)
+
+
+class TestCullingCutoffMarkup(unittest.TestCase):
+    def setUp(self):
+        self.html = _read("culling.html")
+
+    def test_slider_spans_the_quality_range(self):
+        tag = re.search(r'<input type="range" id="qualityCutoffSlider"[^>]*>', self.html)
+        self.assertIsNotNone(tag, "cutoff slider not found")
+        for attr in ('min="0"', 'max="1"', 'step="0.01"'):
+            with self.subTest(attr=attr):
+                self.assertIn(attr, tag.group(0))
+
+    def test_default_is_the_balanced_four_star_floor(self):
+        tag = re.search(r'<input type="range" id="qualityCutoffSlider"[^>]*>', self.html)
+        self.assertIn('value="0.60"', tag.group(0))
+        self.assertAlmostEqual(RATING_PROFILES["balanced"]["four"], 0.60, places=2)
+
+    def test_star_overlay_and_note_elements_exist(self):
+        for eid in ("qualityScaleTicks", "qualityCutoffNote", "qualityCutoffVal"):
+            with self.subTest(element=eid):
+                self.assertRegex(self.html, rf'id="{eid}"')
+
+    def test_label_asks_for_a_quality_score(self):
+        self.assertIn("Accept if quality is at least", self.html)
+
+    def test_tick_styles_are_defined(self):
+        for cls in (".quality-scale-ticks", ".quality-tick", ".quality-tick.above", ".quality-scale-note"):
+            with self.subTest(css_class=cls):
+                self.assertIn(cls, self.html)
+
+
+class TestCullingCutoffLogic(unittest.TestCase):
+    def setUp(self):
+        self.html = _read("culling.html")
+
+    def test_thresholds_come_from_the_bridge(self):
+        self.assertIn("get_rating_thresholds()", self.html)
+        self.assertIn("function loadRatingThresholds", self.html)
+
+    def test_thresholds_load_before_settings_migration(self):
+        """A legacy star cutoff is converted using the profile thresholds."""
+        init = self.html.index("async function init()")
+        tail = self.html[init:]
+        self.assertLess(
+            tail.index("await loadRatingThresholds()"),
+            tail.index("await loadCullingSettings()"),
+            "thresholds must load before the legacy cutoff is migrated",
+        )
+
+    def test_accept_rule_compares_quality_not_stars(self):
+        self.assertIn("effectiveQuality(r) >= qualityCutoff", self.html)
+        self.assertNotIn("return rt > cutoff;", self.html)
+
+    def test_manual_ratings_still_win_over_the_computed_score(self):
+        body = self.html.split("function effectiveQuality(row)", 1)[1].split("\n    }", 1)[0]
+        self.assertIn("getOrigin(row) === 'manual'", body)
+        self.assertIn("qualityFloorForStar", body)
+
+    def test_unrated_images_still_follow_the_unrated_default(self):
+        self.assertIn("if (rt === 0) return unratedDefault === 'accept';", self.html)
+
+    def test_new_setting_key_is_written_and_read(self):
+        self.assertIn("culling_quality_score_cutoff", self.html)
+        # The legacy key must still be honoured on load for existing installs.
+        self.assertIn("culling_quality_cutoff", self.html)
+
+    def test_star_boundaries_match_the_python_mapping(self):
+        """starForQuality in culling.html mirrors ratings.quality_to_rating."""
+        body = self.html.split("function starForQuality(q)", 1)[1].split("\n    }", 1)[0]
+        order = re.findall(r"_ratingThresholds\.(five|four|three|two)", body)
+        self.assertEqual(
+            order,
+            ["five", "four", "three", "two"],
+            "bands must be checked high-to-low or images land in the wrong star",
+        )
+        returns = re.findall(r"return (\d);", body)
+        self.assertEqual(returns, ["0", "5", "4", "3", "2", "1"])
+
+        # Sanity-check the Python side the JS is mirroring.
+        balanced = RATING_PROFILES["balanced"]
+        self.assertEqual(quality_to_rating(balanced["five"], balanced), 5)
+        self.assertEqual(quality_to_rating(balanced["four"], balanced), 4)
+        self.assertEqual(quality_to_rating(balanced["three"], balanced), 3)
+        self.assertEqual(quality_to_rating(balanced["two"], balanced), 2)
+        self.assertEqual(quality_to_rating(balanced["two"] - 0.01, balanced), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/analyzer/visualizer.html
+++ b/analyzer/visualizer.html
@@ -1028,53 +1028,62 @@
         <!-- ═══ Column 2: Review Settings ═══ -->
         <div class="analyze-dlg-col analyze-dlg-col-settings">
           <div class="analyze-dlg-col-title">⚙ Review settings</div>
+          <!-- Phrased as questions about the shoot rather than as model
+               settings: the user knows what they photographed, not which
+               classifier that implies. Each answer pair mirrors to the hidden
+               input below it, which is what the Start handler in
+               event-wiring.js reads — the read path is unchanged. -->
           <div class="analyze-dlg-settings-critical">
-            <!-- Wildlife detection model — horizontal radio pair for compactness. -->
-            <div class="adlg-radio-group">
-              <div class="adlg-radio-label">Wildlife detection model</div>
-              <div class="adlg-radio-horiz">
+
+            <div class="adlg-question">
+              <div class="adlg-question-text">What subjects does this shoot contain?</div>
+              <div class="adlg-answer-pair" role="radiogroup" aria-label="Subjects in this shoot">
                 <label class="adlg-radio-row adlg-radio-row-horiz">
-                  <input type="radio" name="adlgWildlifeModelMode" id="adlgWildlifeModelModeAccurate" value="accurate" checked />
+                  <input type="radio" name="adlgSubjectScope" id="adlgSubjectScopeBirds" value="birds" checked />
                   <div class="adlg-radio-text">
-                    <span class="adlg-radio-name">Accurate</span>
-                    <span class="adlg-radio-hint muted">Larger model with stronger recall. Slower but catches more subjects, especially distant or partially-obscured birds.</span>
+                    <span class="adlg-radio-name">Birds only</span>
                   </div>
                 </label>
                 <label class="adlg-radio-row adlg-radio-row-horiz">
-                  <input type="radio" name="adlgWildlifeModelMode" id="adlgWildlifeModelModeFast" value="fast" />
+                  <input type="radio" name="adlgSubjectScope" id="adlgSubjectScopeWildlife" value="wildlife" />
                   <div class="adlg-radio-text">
-                    <span class="adlg-radio-name">Fast</span>
-                    <span class="adlg-radio-hint muted">Smaller model — significantly faster but may miss some detections. Good for quick first passes.</span>
+                    <span class="adlg-radio-name">Birds and other wildlife</span>
                   </div>
                 </label>
               </div>
-              <!-- Legacy <select> kept hidden so settings hydrate logic that reads/writes
-                   #adlgWildlifeModelMode keeps working; the radios mirror to it. -->
-              <select id="adlgWildlifeModelMode" class="hidden" aria-hidden="true">
-                <option value="fast">Fast</option>
-                <option value="accurate" selected>Accurate</option>
-              </select>
+              <div class="adlg-question-help muted">Including other wildlife finds 1,200+ non-bird species — squirrels, deer, bears and more. It adds noticeable time per image.</div>
             </div>
-            <label class="adlg-toggle-row">
-              <input id="analyzeSpeciesDetection" type="checkbox" checked />
-              <div class="adlg-toggle-text">
-                <span class="adlg-toggle-label">Identify bird species &amp; family</span>
-                <span class="adlg-toggle-hint muted">Runs the bird species classifier on each cropped bird. Optimized for North American species — disable if shooting elsewhere. Detection &amp; quality scoring are unaffected.</span>
+            <input id="analyzeWildlife" type="checkbox" class="hidden" aria-hidden="true" tabindex="-1" />
+
+            <div class="adlg-question">
+              <div class="adlg-question-text">Does this shoot contain North American birds?</div>
+              <div class="adlg-answer-pair" role="radiogroup" aria-label="Bird species identification">
+                <label class="adlg-radio-row adlg-radio-row-horiz">
+                  <input type="radio" name="adlgSpeciesScope" id="adlgSpeciesScopeYes" value="yes" checked />
+                  <div class="adlg-radio-text">
+                    <span class="adlg-radio-name">Yes, identify species</span>
+                  </div>
+                </label>
+                <label class="adlg-radio-row adlg-radio-row-horiz">
+                  <input type="radio" name="adlgSpeciesScope" id="adlgSpeciesScopeNo" value="no" />
+                  <div class="adlg-radio-text">
+                    <span class="adlg-radio-name">No, skip species identification</span>
+                  </div>
+                </label>
               </div>
-            </label>
-            <div class="adlg-setting-row">
-              <label for="adlgMaxBirdCrops">Maximum subjects per image</label>
-              <input id="adlgMaxBirdCrops" type="number" min="1" max="20" step="1" value="10"
-                style="width:80px" />
+              <div class="adlg-question-help muted">Kestrel's bird species classifier only recognizes North American birds. Skipping it makes analysis faster; finding your subjects and scoring their quality work exactly the same either way.</div>
             </div>
-            <div class="adlg-hint muted">Each additional subject increases processing time. Lower this to cap the number of subjects processed per image.</div>
-            <label class="adlg-toggle-row">
-              <input id="analyzeWildlife" type="checkbox" />
-              <div class="adlg-toggle-text">
-                <span class="adlg-toggle-label">Detect non-bird wildlife <span class="adlg-tag">experimental</span></span>
-                <span class="adlg-toggle-hint muted">Detects 1,200+ non-bird species (squirrels, deer, bears, etc.) using SpeciesNet. Adds noticeable processing time per image.</span>
+            <input id="analyzeSpeciesDetection" type="checkbox" class="hidden" aria-hidden="true" tabindex="-1" checked />
+
+            <div class="adlg-question">
+              <div class="adlg-question-text">How many subjects should Kestrel analyze in each image?</div>
+              <div class="adlg-setting-row">
+                <label for="adlgMaxBirdCrops">At most</label>
+                <input id="adlgMaxBirdCrops" type="number" min="1" max="20" step="1" value="10"
+                  style="width:80px" />
               </div>
-            </label>
+              <div class="adlg-question-help muted">Every extra subject adds processing time. Lower this for flock shots where you only care about the closest few birds.</div>
+            </div>
           </div>
 
           <!-- "More options" expanded by default. Subheadings group settings
@@ -1112,13 +1121,25 @@
               </div>
 
               <div class="adlg-subgroup">
-                <div class="adlg-subgroup-title">Wildlife detection</div>
+                <div class="adlg-subgroup-title">Finding subjects</div>
+                <!-- Was a prominent Fast/Accurate radio pair in the critical
+                     block. Accurate is right for essentially every shoot, so it
+                     is now the default and lives down here instead of asking
+                     every user to make the call up front. -->
+                <div class="adlg-setting-row">
+                  <label for="adlgWildlifeModelMode">Detection model</label>
+                  <select id="adlgWildlifeModelMode" style="flex:1;max-width:200px">
+                    <option value="accurate" selected>Accurate (recommended)</option>
+                    <option value="fast">Fast</option>
+                  </select>
+                </div>
+                <div class="adlg-hint muted">Accurate is the right choice for almost every shoot. Fast uses a smaller model that finishes sooner but misses distant and partly-hidden birds.</div>
                 <div class="adlg-setting-row">
                   <label for="adlgDetectionThreshold">Detection confidence</label>
                   <input id="adlgDetectionThreshold" type="number" min="0.1" max="0.99" step="0.05" value="0.15"
                     style="width:80px" />
                 </div>
-                <div class="adlg-hint muted">Minimum MegaDetector animal confidence (0.10–0.99). Lower values find more subjects.</div>
+                <div class="adlg-hint muted">How sure Kestrel must be that it found an animal before analyzing it (0.10–0.99). Lower values find more subjects.</div>
                 <!-- Live warning when the user picks a value much above the
                      recommended baseline. Wildlife detection models are quite
                      accurate, so high thresholds tend to miss real subjects. -->


### PR DESCRIPTION
## Context

Requested directly, following up on the culling suggestion in #94:

> A few tweaks perhaps to the culling assistant in terms of using quality scores to choose as opposed to stars.

This is the first of the two PRs discussed. The second — a **custom** rating profile whose star thresholds you drag on a similar number line — is separate and not included here.

The auto-categorize cutoff was an integer star level ("accept if rated above ★3"). Stars are a coarse view of the underlying quality score, so the finest split available was a whole band. Worse, the bands move with the `rating_profile` setting and the panel never showed where they actually sat.

## What changed

The cutoff is now the quality score itself, `0.00`–`1.00` in steps of `0.01`, with the active profile's star thresholds drawn underneath the slider at their real positions:

```
Accept if quality is at least
[———————————●————————]  0.60
  ★2   ★3   ★4    ★5
Accepts ★4 and above (★4 starts at 0.60).
```

- **Star ticks** sit at their true quality positions. Bands whose floor clears the cutoff are highlighted gold, so the accept/reject split is readable at a glance.
- **The note** states the split in star terms, including the case where the cutoff lands mid-band — it says `Inside the ★2 band — accepts ★3 and above, plus stronger ★2 images` rather than claiming the whole ★2 level is in, which would be wrong.
- **Reactive to the profile.** Thresholds come from a new `api_bridge.get_rating_thresholds()`, which serves `kestrel_analyzer.ratings` directly so the table keeps exactly one definition. Switch to `strict` and the ticks move to 0.20 / 0.48 / 0.72 / 0.90.
- The toolbar summary now reads `Quality ≥ 0.60 · Min 0 · Max ∞ · Unrated → Auto-Reject`.

## Two behaviours worth confirming

**Manual ratings still win.** A manually-rated image is treated as sitting at the floor of its band, so a user's ★5 on a technically-weak frame still clears a 0.85 cutoff and their ★1 on a sharp one still fails it. Comparing raw quality for those would have silently thrown away explicit user decisions. Unrated images follow the unrated default exactly as before.

**Existing installs migrate.** The cutoff persists as `culling_quality_score_cutoff`. When only the legacy `culling_quality_cutoff` star level is present, it converts to the floor of the lowest star it accepted — old `★>3` becomes `0.60` under balanced, `0.72` under strict — preserving the user's current split. The legacy key is still written on save so an older build reading these settings lands somewhere comparable. (One edge: a legacy cutoff of 5 accepted nothing rated; it maps to 1.00, which accepts a perfect score.)

## Test plan

**Behavioural — headless Chromium against the real `culling.html` with a stubbed bridge, 21/21 checks passed:**

- Slider is `0–1` step `0.01`, defaults to `0.60`, reads out to two decimals.
- Four ticks render at the profile's positions (`15% / 40% / 60% / 85%` balanced, `20% / 48% / 72% / 90%` strict); highlighting follows the cutoff.
- Note is correct on a boundary (`Accepts ★2 and above (★2 starts at 0.15).`) and mid-band.
- Accept rule: auto image above cutoff in, below out; **manual ★5 at quality 0.05 accepted; manual ★1 at quality 0.99 rejected.**
- `starForQuality` matches `ratings.quality_to_rating` at all ten band boundaries.
- Legacy migration: `★>3 → 0.60`, `★>1 → 0.15`, `★>3 under strict → 0.72`; an explicit `culling_quality_score_cutoff` wins over the legacy key.
- No page errors.

**Static lints** — new `analyzer/tests/unit/test_culling_quality_cutoff.py`, 15 tests + 15 subtests. Includes a guard that `get_rating_thresholds` contains no hardcoded threshold numbers (it must serve `ratings.py`, not a copy) and that the JS band checks run high-to-low.

**Suites** — `pytest tests/unit` (excluding 6 modules needing `cv2` / `rawpy`): **583 passed, 3 skipped, 0 failed.** `pytest tests/security tests/compat`: 40 passed, 6 skipped.

## Note

`culling.html` gained one line outside the feature: `window.__cullingSettingsLoaded = true` at the end of the settings load, so a headless harness can wait for the page to settle instead of sleeping.

---
_Generated by [Claude Code](https://claude.ai/code/session_01E9eNk7oumgSrqC5t2BD2oj)_