### PR TITLE
Add a Custom rating profile with draggable star thresholds

### DIFF
--- a/analyzer/api_bridge.py
+++ b/analyzer/api_bridge.py
@@ -1841,13 +1841,13 @@ class Api:
 
             try:
                 from kestrel_analyzer.ratings import (
-                    get_profile_thresholds,
                     quality_to_rating,
+                    resolve_thresholds,
                 )
             except ImportError:
                 from analyzer.kestrel_analyzer.ratings import (
-                    get_profile_thresholds,
                     quality_to_rating,
+                    resolve_thresholds,
                 )
 
             folder_path, kestrel_dir, _, err = self._resolve_folder_root_and_kestrel(
@@ -1865,7 +1865,7 @@ class Api:
 
             settings = load_persisted_settings()
             profile = settings.get('rating_profile', 'balanced')
-            thresholds = get_profile_thresholds(profile)
+            thresholds = resolve_thresholds(profile, settings.get('rating_thresholds_custom'))
 
             df = pd.read_csv(csv_path)
             if df.empty:
@@ -2171,19 +2171,20 @@ class Api:
         """
         try:
             try:
-                from kestrel_analyzer.ratings import RATING_PROFILES, get_profile_thresholds
+                from kestrel_analyzer.ratings import RATING_PROFILES, resolve_thresholds
             except ImportError:
                 from analyzer.kestrel_analyzer.ratings import (  # type: ignore
                     RATING_PROFILES,
-                    get_profile_thresholds,
+                    resolve_thresholds,
                 )
 
             settings = load_persisted_settings()
             profile = str(settings.get('rating_profile', 'balanced') or 'balanced').lower()
+            thresholds = resolve_thresholds(profile, settings.get('rating_thresholds_custom'))
             return {
                 'success': True,
                 'profile': profile,
-                'thresholds': dict(get_profile_thresholds(profile)),
+                'thresholds': dict(thresholds),
                 'profiles': {k: dict(v) for k, v in RATING_PROFILES.items()},
                 'error': '',
             }

--- a/analyzer/api_bridge.py
+++ b/analyzer/api_bridge.py
@@ -2152,6 +2152,45 @@ class Api:
             error(f'[API] get_settings error: {e}')
             return {'success': False, 'error': str(e), 'settings': {}}
 
+    def get_rating_thresholds(self):
+        """Return the active rating profile's quality-score cutoffs for each star.
+
+        The frontend needs these to draw star positions on a quality-score
+        number line (Culling Assistant) and to convert a manual star rating
+        back into the quality band it represents. Served from
+        ``kestrel_analyzer.ratings`` so the table has exactly one definition.
+
+        Returns:
+            {
+              'success': bool,
+              'profile': str,                # active rating_profile setting
+              'thresholds': {'five': float, 'four': float, 'three': float, 'two': float},
+              'profiles': {name: thresholds, ...},   # every built-in profile
+              'error': str,
+            }
+        """
+        try:
+            try:
+                from kestrel_analyzer.ratings import RATING_PROFILES, get_profile_thresholds
+            except ImportError:
+                from analyzer.kestrel_analyzer.ratings import (  # type: ignore
+                    RATING_PROFILES,
+                    get_profile_thresholds,
+                )
+
+            settings = load_persisted_settings()
+            profile = str(settings.get('rating_profile', 'balanced') or 'balanced').lower()
+            return {
+                'success': True,
+                'profile': profile,
+                'thresholds': dict(get_profile_thresholds(profile)),
+                'profiles': {k: dict(v) for k, v in RATING_PROFILES.items()},
+                'error': '',
+            }
+        except Exception as e:
+            error(f'[API] get_rating_thresholds error: {e}')
+            return {'success': False, 'error': str(e), 'profile': '', 'thresholds': {}, 'profiles': {}}
+
     def save_settings_data(self, settings_dict):
         """Persist settings from JavaScript (wraps save_persisted_settings)."""
         try:

--- a/analyzer/css/dialogs/analyze.css
+++ b/analyzer/css/dialogs/analyze.css
@@ -193,6 +193,43 @@
 }
 .adlg-radio-inline input[type="radio"] { accent-color: #2b6ec8; }
 
+/* Question-and-answer settings blocks. Each block is one question about the
+   shoot with its answers directly beneath, so the column reads as a short
+   interview rather than a list of model parameters. */
+.adlg-question {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 12px 0 0;
+  border-top: 1px solid #2a3445;
+}
+.adlg-question:first-child {
+  border-top: none;
+  padding-top: 0;
+}
+.adlg-question-text {
+  font-size: 13.5px;
+  font-weight: 600;
+  color: #e1e5ec;
+  line-height: 1.35;
+}
+/* Answers sit side by side, and wrap to one per row when the dialog is too
+   narrow to keep both labels on a single line. */
+.adlg-answer-pair {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
+}
+@media (max-width: 1100px) {
+  .adlg-answer-pair { grid-template-columns: 1fr; }
+}
+.adlg-answer-pair .adlg-radio-row-horiz { align-items: center; }
+.adlg-question-help {
+  font-size: 12px;
+  line-height: 1.45;
+  color: var(--muted);
+}
+
 /* "More options" collapsible — flat list of less-critical settings. */
 .analyze-dlg-more-options {
   border: 1px solid #2a3040;

--- a/analyzer/css/dialogs/settings.css
+++ b/analyzer/css/dialogs/settings.css
@@ -94,3 +94,134 @@
 
 .stars .star.manual.filled { color: #f5c542; }
 .stars .star.auto.filled { color: #6aa0ff; }
+
+/* ── Custom rating profile editor ──────────────────────────────────────────
+   A 0.00–1.00 number line where each star's cutoff is a draggable handle.
+   Shown only while the Custom profile is selected. */
+.rating-custom-editor {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 14px 14px 12px;
+  margin: -2px 0 12px;
+  background: #0a0d12;
+  border: 1px solid #2a3040;
+  border-radius: 8px;
+}
+.rating-custom-editor.hidden { display: none; }
+
+.rating-custom-track {
+  position: relative;
+  height: 40px;
+  border-radius: 5px;
+  background: #10141c;
+  border: 1px solid #2a3445;
+  /* Handles sit on the track edges at 0.00 and 1.00, so keep room for the
+     half that would otherwise overflow the rounded corners. */
+  margin: 0 11px;
+}
+
+/* Star bands, painted left-to-right as ★1…★5 regions. */
+.rating-custom-bands {
+  position: absolute;
+  inset: 0;
+  border-radius: 4px;
+  overflow: hidden;
+}
+.rating-custom-band {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 11px;
+  color: #8492a8;
+  white-space: nowrap;
+  border-right: 1px solid #2a3445;
+}
+.rating-custom-band:last-child { border-right: none; }
+/* Warmer as the star level climbs, so the ramp is readable at a glance. */
+.rating-custom-band[data-star="1"] { background: rgba(120, 132, 150, 0.07); }
+.rating-custom-band[data-star="2"] { background: rgba(120, 150, 190, 0.09); }
+.rating-custom-band[data-star="3"] { background: rgba(106, 160, 255, 0.11); }
+.rating-custom-band[data-star="4"] { background: rgba(190, 170, 90, 0.13); }
+.rating-custom-band[data-star="5"] { background: rgba(245, 197, 66, 0.17); color: #f5c542; }
+/* A band squeezed to almost nothing can't show its label. */
+.rating-custom-band.narrow { font-size: 0; }
+
+.rating-custom-handles {
+  position: absolute;
+  inset: 0;
+}
+.rating-custom-handle {
+  position: absolute;
+  top: -5px;
+  bottom: -5px;
+  width: 22px;
+  /* left is set inline from the threshold's position on the 0–1 scale */
+  transform: translateX(-50%);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  border: none;
+  padding: 0;
+  cursor: ew-resize;
+  color: #f5c542;
+  font-size: 13px;
+  line-height: 1;
+  touch-action: none;
+}
+.rating-custom-handle::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 50%;
+  width: 2px;
+  margin-left: -1px;
+  background: #f5c542;
+  border-radius: 1px;
+}
+.rating-custom-handle span {
+  position: relative;
+  padding: 1px 2px;
+  background: #0a0d12;
+  border-radius: 3px;
+}
+.rating-custom-handle:hover,
+.rating-custom-handle.dragging { color: #ffd968; }
+.rating-custom-handle:hover::before,
+.rating-custom-handle.dragging::before { background: #ffd968; }
+.rating-custom-handle:focus-visible {
+  outline: 2px solid #2b6ec8;
+  outline-offset: 2px;
+  border-radius: 3px;
+}
+
+.rating-custom-axis {
+  display: flex;
+  justify-content: space-between;
+  margin: 0 11px;
+  font-size: 10.5px;
+  color: var(--muted);
+  font-variant-numeric: tabular-nums;
+}
+.rating-custom-readout {
+  font-size: 11.5px;
+  color: #cbd6e4;
+  font-variant-numeric: tabular-nums;
+  line-height: 1.5;
+}
+.rating-custom-actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+.rating-custom-actions .btn {
+  height: 26px;
+  padding: 2px 10px;
+  font-size: 12px;
+}

--- a/analyzer/culling.html
+++ b/analyzer/culling.html
@@ -906,6 +906,70 @@
       min-width: 24px;
       text-align: left;
     }
+    /* Quality-score cutoff: a 0.00–1.00 slider with the active profile's star
+       thresholds drawn underneath, so the number always reads against the star
+       scale used everywhere else in the app. */
+    .auto-cat-panel .quality-cutoff-group {
+      min-width: 250px;
+    }
+    .auto-cat-panel .quality-scale-wrap {
+      position: relative;
+      width: 190px;
+      padding-bottom: 15px;
+    }
+    .auto-cat-panel .quality-scale-wrap input[type="range"] {
+      width: 100%;
+      display: block;
+      margin: 0;
+      position: relative;
+      z-index: 1;
+    }
+    .auto-cat-panel .quality-scale-ticks {
+      position: absolute;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      height: 15px;
+      pointer-events: none;
+    }
+    .auto-cat-panel .quality-tick {
+      position: absolute;
+      top: 0;
+      /* left is set inline from the threshold's position on the 0–1 scale */
+      transform: translateX(-50%);
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      font-size: 9px;
+      line-height: 1;
+      color: var(--muted);
+      white-space: nowrap;
+    }
+    .auto-cat-panel .quality-tick::before {
+      content: '';
+      width: 1px;
+      height: 4px;
+      background: #3a4557;
+      margin-bottom: 2px;
+    }
+    /* The star bands at or above the cutoff are the ones that will be
+       accepted — brighten those so the split is readable at a glance. */
+    .auto-cat-panel .quality-tick.above {
+      color: #f5c542;
+    }
+    .auto-cat-panel .quality-tick.above::before {
+      background: #f5c542;
+    }
+    .auto-cat-panel .quality-scale-note {
+      font-size: 10px;
+      color: var(--muted);
+      line-height: 1.3;
+      max-width: 250px;
+    }
+    .auto-cat-panel .slider-val#qualityCutoffVal {
+      min-width: 34px;
+      font-variant-numeric: tabular-nums;
+    }
     .auto-cat-panel .unrated-group {
       justify-content: flex-end;
     }
@@ -991,12 +1055,20 @@
       </div>
       <!-- Auto-categorize settings panel (hidden by default) -->
       <div class="auto-cat-panel hidden" id="autoCatPanel">
-        <div class="slider-group">
-          <label for="qualityCutoffSlider">Accept if rated above</label>
+        <div class="slider-group quality-cutoff-group">
+          <label for="qualityCutoffSlider">Accept if quality is at least</label>
           <div class="slider-row">
-            <input type="range" id="qualityCutoffSlider" min="0" max="5" value="3" step="1" />
-            <span class="slider-val" id="qualityCutoffVal">★3</span>
+            <div class="quality-scale-wrap">
+              <input type="range" id="qualityCutoffSlider" min="0" max="1" value="0.60" step="0.01"
+                     aria-describedby="qualityScaleTicks" />
+              <!-- Star cutoffs for the active rating profile, drawn at their
+                   quality positions so the score always reads against the
+                   star scale the rest of the app uses. -->
+              <div class="quality-scale-ticks" id="qualityScaleTicks" aria-hidden="true"></div>
+            </div>
+            <span class="slider-val" id="qualityCutoffVal">0.60</span>
           </div>
+          <div class="quality-scale-note" id="qualityCutoffNote"></div>
         </div>
         <div class="slider-group">
           <label for="minPerSceneSlider">Min Accepted Per Scene</label>
@@ -1810,29 +1882,129 @@
       return list;
     }
 
+    // ---- Rating profile thresholds ----
+    // Quality-score cutoff for each star band, from the active rating_profile
+    // setting. Seeded with the 'balanced' defaults from
+    // kestrel_analyzer/ratings.py so the panel is usable before the bridge
+    // answers (and if it never does, e.g. browser preview).
+    let _ratingThresholds = { five: 0.85, four: 0.60, three: 0.40, two: 0.15 };
+    const _STAR_KEYS = [
+      { star: 2, key: 'two' },
+      { star: 3, key: 'three' },
+      { star: 4, key: 'four' },
+      { star: 5, key: 'five' },
+    ];
+
+    async function loadRatingThresholds() {
+      try {
+        const res = await window.pywebview.api.get_rating_thresholds();
+        const t = res?.success ? res.thresholds : null;
+        if (t && ['five', 'four', 'three', 'two'].every(k => Number.isFinite(Number(t[k])))) {
+          _ratingThresholds = {
+            five: Number(t.five), four: Number(t.four),
+            three: Number(t.three), two: Number(t.two),
+          };
+        }
+      } catch (e) { console.warn('loadRatingThresholds:', e); }
+      renderQualityScaleTicks();
+      updateSliderLabels(true);
+    }
+
+    // Lowest quality score that still earns `star`. Star 1 is everything below
+    // the two-star cutoff, so its floor is 0.
+    function qualityFloorForStar(star) {
+      const hit = _STAR_KEYS.find(s => s.star === star);
+      return hit ? Number(_ratingThresholds[hit.key]) : 0;
+    }
+
+    // Mirror of quality_to_rating() in kestrel_analyzer/ratings.py.
+    function starForQuality(q) {
+      const v = Number(q);
+      if (!Number.isFinite(v) || v < 0) return 0;
+      if (v >= _ratingThresholds.five)  return 5;
+      if (v >= _ratingThresholds.four)  return 4;
+      if (v >= _ratingThresholds.three) return 3;
+      if (v >= _ratingThresholds.two)   return 2;
+      return 1;
+    }
+
+    // The quality score an image effectively sits at for cutoff purposes.
+    // A manual star rating is an explicit user statement, so it wins over the
+    // computed score: treat the image as sitting at the floor of that band.
+    function effectiveQuality(row) {
+      if (getOrigin(row) === 'manual') {
+        const star = getRating(row);
+        // A manual 0 means "unrated" and is handled by the unrated default,
+        // never by the cutoff comparison.
+        if (star > 0) return qualityFloorForStar(star);
+      }
+      return parseNumber(row?.quality);
+    }
+
+    function renderQualityScaleTicks() {
+      const host = el('#qualityScaleTicks');
+      if (!host) return;
+      const cutoff = getSliderValues().qualityCutoff;
+      host.innerHTML = '';
+      for (const { star, key } of _STAR_KEYS) {
+        const pos = Number(_ratingThresholds[key]);
+        if (!Number.isFinite(pos)) continue;
+        const tick = document.createElement('div');
+        tick.className = 'quality-tick' + (pos >= cutoff ? ' above' : '');
+        tick.style.left = (Math.max(0, Math.min(1, pos)) * 100) + '%';
+        tick.appendChild(document.createTextNode('★' + star));
+        host.appendChild(tick);
+      }
+    }
+
     // ---- Auto-categorize helpers ----
     function getSliderValues() {
-      const cutoff  = parseInt(el('#qualityCutoffSlider')?.value ?? '3', 10);
+      const rawCutoff = parseFloat(el('#qualityCutoffSlider')?.value ?? '0.60');
+      const qualityCutoff = Number.isFinite(rawCutoff) ? Math.max(0, Math.min(1, rawCutoff)) : 0.60;
       const minKeep = parseInt(el('#minPerSceneSlider')?.value  ?? '0', 10);
       const maxRaw  = parseInt(el('#maxPerSceneSlider')?.value  ?? '0', 10);
       const maxKeep = maxRaw === 0 ? Infinity : maxRaw;
       const unratedDefault = (el('#unratedDefaultSelect')?.value === 'accept') ? 'accept' : 'reject';
-      return { cutoff, minKeep, maxKeep, unratedDefault };
+      return { qualityCutoff, minKeep, maxKeep, unratedDefault };
     }
 
     let _autoRulesLoaded = false; // set true after first settings load so initial load doesn't flash
     function updateSliderLabels(fromLoad = false) {
-      const { cutoff, minKeep, maxKeep, unratedDefault } = getSliderValues();
+      const { qualityCutoff, minKeep, maxKeep, unratedDefault } = getSliderValues();
       const qEl   = el('#qualityCutoffVal');
       const minEl = el('#minPerSceneVal');
       const maxEl = el('#maxPerSceneVal');
-      if (qEl)   qEl.textContent   = '\u2605' + cutoff;
+      const cutoffText = qualityCutoff.toFixed(2);
+      if (qEl)   qEl.textContent   = cutoffText;
       if (minEl) minEl.textContent = String(minKeep);
       if (maxEl) maxEl.textContent = maxKeep === Infinity ? '\u221e' : String(maxKeep);
+
+      // Say which star band the cutoff currently lands in, so the score stays
+      // legible to anyone who thinks in stars.
+      const noteEl = el('#qualityCutoffNote');
+      if (noteEl) {
+        const star = starForQuality(qualityCutoff);
+        const floor = qualityFloorForStar(star);
+        if (qualityCutoff <= 0) {
+          noteEl.textContent = 'Accepts every rated image.';
+        } else if (Math.abs(qualityCutoff - floor) < 0.005) {
+          // Cutoff sits exactly on a star boundary \u2014 the whole band is in.
+          noteEl.textContent = `Accepts \u2605${star} and above (\u2605${star} starts at ${floor.toFixed(2)}).`;
+        } else if (star >= 5) {
+          noteEl.textContent = 'Inside the \u26055 band \u2014 accepts only the strongest \u26055 images.';
+        } else {
+          // Cutoff splits a band: only the upper part of it is accepted, so
+          // don't claim the whole star level is in.
+          noteEl.textContent =
+            `Inside the \u2605${star} band \u2014 accepts \u2605${star + 1} and above, plus stronger \u2605${star} images.`;
+        }
+      }
+      renderQualityScaleTicks();
+
       const unratedLabel = unratedDefault === 'accept' ? 'Auto-Accept' : 'Auto-Reject';
       const summary = el('#autoCatSummary');
       if (summary) summary.textContent =
-        `Rated > \u2605${cutoff} \u00b7 Min ${minKeep} \u00b7 Max ${maxKeep === Infinity ? '\u221e' : maxKeep} \u00b7 Unrated \u2192 ${unratedLabel}`;
+        `Quality \u2265 ${cutoffText} \u00b7 Min ${minKeep} \u00b7 Max ${maxKeep === Infinity ? '\u221e' : maxKeep} \u00b7 Unrated \u2192 ${unratedLabel}`;
       // Highlight Re-apply button when rules change (but not on initial page load)
       if (!fromLoad && _autoRulesLoaded) {
         el('#reapplyAutoBtn')?.classList.add('needs-reapply');
@@ -1840,7 +2012,7 @@
     }
 
     function applyAutoCategorize(preserveManual = true) {
-      const { cutoff, minKeep, maxKeep, unratedDefault } = getSliderValues();
+      const { qualityCutoff, minKeep, maxKeep, unratedDefault } = getSliderValues();
       for (const scene of scenes) {
         // Sort by rating desc, then quality score desc
         const sorted = scene.images.slice().sort((a, b) => {
@@ -1853,7 +2025,7 @@
           sorted.filter(r => {
             const rt = getRating(r);
             if (rt === 0) return unratedDefault === 'accept';
-            return rt > cutoff;
+            return effectiveQuality(r) >= qualityCutoff;
           })
                 .map(r => r.filename)
         );
@@ -2850,11 +3022,26 @@
           if (sl) { sl.value = rawZoom; if (lb) lb.textContent = rawZoom + '\u00d7'; }
         }
         // Auto-categorize slider settings
-        const qCutoff = parseInt(s.culling_quality_cutoff, 10);
         const minPS   = parseInt(s.culling_min_per_scene,  10);
         const maxPS   = parseInt(s.culling_max_per_scene,  10);
         const unratedDefault = String(s.culling_unrated_default || 'reject').toLowerCase();
-        if (qCutoff >= 0 && qCutoff <= 5)  { const sl = el('#qualityCutoffSlider'); if (sl) sl.value = qCutoff; }
+
+        // The cutoff is a quality score now. Fall back to the legacy star
+        // cutoff (culling_quality_cutoff, an int 0–5 meaning "accept stars
+        // above this") by converting it to the floor of the lowest star it
+        // accepted, which preserves the user's existing split.
+        const qScore = parseFloat(s.culling_quality_score_cutoff);
+        const legacyStar = parseInt(s.culling_quality_cutoff, 10);
+        let cutoff = null;
+        if (Number.isFinite(qScore) && qScore >= 0 && qScore <= 1) {
+          cutoff = qScore;
+        } else if (Number.isFinite(legacyStar) && legacyStar >= 0 && legacyStar <= 5) {
+          cutoff = legacyStar >= 5 ? 1 : qualityFloorForStar(legacyStar + 1);
+        }
+        if (cutoff !== null) {
+          const sl = el('#qualityCutoffSlider');
+          if (sl) sl.value = String(Math.max(0, Math.min(1, cutoff)));
+        }
         if (minPS   >= 0 && minPS   <= 5)  { const sl = el('#minPerSceneSlider');   if (sl) sl.value = minPS; }
         if (maxPS   >= 0 && maxPS   <= 20) { const sl = el('#maxPerSceneSlider');   if (sl) sl.value = maxPS; }
         const unratedSel = el('#unratedDefaultSelect');
@@ -2862,6 +3049,8 @@
         updateSliderLabels(true);
         _autoRulesLoaded = true;
       } catch (e) { console.warn('loadCullingSettings:', e); }
+      // Settled marker for UI tests driving this page headlessly.
+      window.__cullingSettingsLoaded = true;
     }
 
     function saveCullingSettings() {
@@ -2872,7 +3061,11 @@
           const s = (res?.success ? res.settings : {}) || {};
           s.culling_card_zoom       = parseInt(document.getElementById('cardZoomSlider')?.value, 10) || 150;
           s.culling_raw_zoom        = parseInt(document.getElementById('previewZoomSlider')?.value, 10) || 5;
-          s.culling_quality_cutoff  = parseInt(el('#qualityCutoffSlider')?.value, 10) || 3;
+          const _cut = getSliderValues().qualityCutoff;
+          s.culling_quality_score_cutoff = Number(_cut.toFixed(2));
+          // Keep the legacy star key roughly in step so an older build reading
+          // these settings still lands on a comparable split.
+          s.culling_quality_cutoff  = Math.max(0, starForQuality(_cut) - 1);
           s.culling_min_per_scene   = parseInt(el('#minPerSceneSlider')?.value,   10) || 0;
           s.culling_max_per_scene   = parseInt(el('#maxPerSceneSlider')?.value,   10) || 0;
           s.culling_unrated_default = (el('#unratedDefaultSelect')?.value === 'accept') ? 'accept' : 'reject';
@@ -3393,6 +3586,10 @@
         return;
       }
 
+      // Thresholds first: loadCullingSettings converts a legacy star cutoff
+      // into a quality score using them, so stale defaults here would migrate
+      // the user onto the wrong split.
+      await loadRatingThresholds();
       updateSliderLabels(); // apply defaults before settings load
       await loadCullingSettings();
 

--- a/analyzer/js/analyze-dialog.js
+++ b/analyzer/js/analyze-dialog.js
@@ -1107,6 +1107,53 @@
     }
 
     // ── Dialog open / settings hydration ────────────────────────────────────────
+    // ── Shoot questions ↔ hidden checkboxes ───────────────────────────────────
+    // The two "what did you shoot" questions are the visible controls for
+    // #analyzeWildlife and #analyzeSpeciesDetection. Those checkboxes stay in
+    // the DOM (hidden) because event-wiring.js reads them when Start is
+    // clicked, and the cloud-compute snapshot reads them too — mirroring keeps
+    // that single read path intact while the user only ever sees the questions.
+    //
+    // Listeners are attached at load rather than on dialog open: a throw
+    // anywhere earlier in the open path would otherwise leave the answers
+    // visually live but disconnected, silently analyzing with the wrong scope.
+    const _ANSWER_PAIRS = [
+      { on: 'adlgSubjectScopeWildlife', off: 'adlgSubjectScopeBirds', box: 'analyzeWildlife' },
+      { on: 'adlgSpeciesScopeYes', off: 'adlgSpeciesScopeNo', box: 'analyzeSpeciesDetection' },
+    ];
+
+    // Push the checkbox state out to the radios (settings → UI).
+    function syncAnalyzeAnswersFromSettings() {
+      for (const { on, off, box } of _ANSWER_PAIRS) {
+        const onEl = document.getElementById(on);
+        const offEl = document.getElementById(off);
+        const boxEl = document.getElementById(box);
+        if (!onEl || !offEl || !boxEl) continue;
+        onEl.checked = !!boxEl.checked;
+        offEl.checked = !boxEl.checked;
+      }
+    }
+
+    // Attach the radios → checkbox mirror once (UI → settings).
+    function wireAnalyzeAnswerMirrors() {
+      for (const { on, off, box } of _ANSWER_PAIRS) {
+        const onEl = document.getElementById(on);
+        const offEl = document.getElementById(off);
+        const boxEl = document.getElementById(box);
+        if (!onEl || !offEl || !boxEl || onEl.dataset.wiredMirror) continue;
+        onEl.dataset.wiredMirror = '1';
+        const sync = () => { boxEl.checked = !!onEl.checked; };
+        onEl.addEventListener('change', sync);
+        offEl.addEventListener('change', sync);
+      }
+    }
+
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', wireAnalyzeAnswerMirrors, { once: true });
+    } else {
+      wireAnalyzeAnswerMirrors();
+    }
+
     async function openAnalyzeDialog() {
       if (!hasPywebviewApi) {
         alert('Analysis queue is only available in the desktop (pywebview) mode.\n\nRun kestrel_visualizer as a desktop app to use this feature.');
@@ -1123,26 +1170,13 @@
           }
         }).catch(() => {});
       }
-      // Hydrate critical settings from persisted values. The radios mirror to
-      // the hidden #adlgWildlifeModelMode <select> so existing read/write paths
-      // (event-wiring.js Start handler) keep working unchanged.
-      const _hiddenModelSelect = document.getElementById('adlgWildlifeModelMode');
+      // Detection model now lives as a plain <select> in More options →
+      // Finding subjects, defaulting to Accurate. Anything that isn't an
+      // explicit 'fast' resolves to 'accurate'.
+      const _modelSelect = document.getElementById('adlgWildlifeModelMode');
       const savedMode = String(getSetting('wildlife_model_mode', 'accurate') || 'accurate').toLowerCase();
       const modeFinal = (savedMode === 'fast') ? 'fast' : 'accurate';
-      if (_hiddenModelSelect) _hiddenModelSelect.value = modeFinal;
-      const _modeAccurate = document.getElementById('adlgWildlifeModelModeAccurate');
-      const _modeFast = document.getElementById('adlgWildlifeModelModeFast');
-      if (_modeAccurate && _modeFast) {
-        _modeAccurate.checked = (modeFinal === 'accurate');
-        _modeFast.checked = (modeFinal === 'fast');
-        // Mirror radio change → hidden select (so the existing read path works).
-        const _syncModeRadios = () => {
-          const v = _modeAccurate.checked ? 'accurate' : 'fast';
-          if (_hiddenModelSelect) _hiddenModelSelect.value = v;
-        };
-        _modeAccurate.addEventListener('change', _syncModeRadios);
-        _modeFast.addEventListener('change', _syncModeRadios);
-      }
+      if (_modelSelect) _modelSelect.value = modeFinal;
 
       // Hydrate "More options" settings from persisted values (same keys as before).
       // Default 0.15 now matches the suggested-baseline message shown by the
@@ -1184,6 +1218,9 @@
       if (_adlgWildlife) _adlgWildlife.checked = !!getSetting('wildlife_enabled', false);
       const _adlgSpecies = document.getElementById('analyzeSpeciesDetection');
       if (_adlgSpecies) _adlgSpecies.checked = getSetting('species_detection_enabled') !== false;
+
+      // Point the visible answers at the freshly-hydrated checkbox state.
+      syncAnalyzeAnswersFromSettings();
 
       // Unlock checkbox state — reset every open. User must explicitly re-tick
       // it to unlock destructive re-analysis on each queue.

--- a/analyzer/js/settings.js
+++ b/analyzer/js/settings.js
@@ -7,6 +7,223 @@
     }
     function saveSettings(obj) { localStorage.setItem(SETTINGS_KEY, JSON.stringify(obj || {})); }
     function getSetting(k, def) { const s = loadSettings(); return (k in s) ? s[k] : def; }
+
+    // ── Custom rating profile ─────────────────────────────────────────────────
+    // The 'custom' profile's cutoffs live in the rating_thresholds_custom
+    // setting instead of RATING_PROFILES. This editor is the only place they
+    // can be edited; kestrel_analyzer/ratings.py normalizes whatever it is
+    // handed, so the UI is free to be the convenient layer rather than the
+    // authoritative one.
+    const RATING_THRESHOLD_KEYS = ['five', 'four', 'three', 'two'];  // high → low
+    const RATING_MIN_GAP = 0.01;   // must match ratings.MIN_THRESHOLD_GAP
+    const RATING_BALANCED = { five: 0.85, four: 0.60, three: 0.40, two: 0.15 };
+    let _customThresholds = { ...RATING_BALANCED };
+
+    function _round2(v) { return Math.round(v * 100) / 100; }
+
+    // Mirror of ratings.normalize_custom_thresholds: clamp to [0,1], then force
+    // strictly descending so no star band collapses to nothing.
+    function normalizeCustomThresholds(raw) {
+      const src = (raw && typeof raw === 'object') ? raw : {};
+      const out = {};
+      for (const k of RATING_THRESHOLD_KEYS) {
+        // Only numbers and numeric strings count as supplied. Number(null) and
+        // Number('') are 0 and Number(true) is 1, which would silently become
+        // real cutoffs here while Python's float() rejects them — the two
+        // normalizers have to agree or the UI shows bands the backend won't use.
+        const rawV = src[k];
+        const usable =
+          typeof rawV === 'number' ||
+          (typeof rawV === 'string' && rawV.trim() !== '');
+        const v = usable ? Number(rawV) : NaN;
+        out[k] = Number.isFinite(v) ? Math.max(0, Math.min(1, v)) : RATING_BALANCED[k];
+      }
+      let ceiling = 1;
+      for (const k of RATING_THRESHOLD_KEYS) {
+        out[k] = _round2(Math.min(out[k], ceiling));
+        ceiling = _round2(out[k] - RATING_MIN_GAP);
+      }
+      let floor = 0;
+      for (const k of [...RATING_THRESHOLD_KEYS].reverse()) {
+        if (out[k] < floor) out[k] = _round2(floor);
+        floor = _round2(out[k] + RATING_MIN_GAP);
+      }
+      return out;
+    }
+
+    function _isCustomProfileSelected() {
+      return document.getElementById('ratingProfile')?.value === 'custom';
+    }
+
+    // Show the editor only for the Custom profile. Selecting a named profile
+    // seeds the custom values from it, so switching to Custom starts from
+    // whatever the user was already using rather than from balanced.
+    function refreshRatingProfileEditor(seedFromProfile = null) {
+      const editor = document.getElementById('ratingCustomEditor');
+      if (!editor) return;
+      const custom = _isCustomProfileSelected();
+      editor.classList.toggle('hidden', !custom);
+      if (!custom && seedFromProfile) {
+        const t = _ratingProfileTable[seedFromProfile];
+        if (t) _customThresholds = normalizeCustomThresholds(t);
+      }
+      if (custom) renderCustomThresholds();
+    }
+
+    // Built-in profiles, filled in from the bridge so the numbers are not
+    // duplicated here. Falls back to balanced-only if the call fails.
+    let _ratingProfileTable = { balanced: { ...RATING_BALANCED } };
+
+    async function loadRatingProfileTable() {
+      try {
+        const res = await window.pywebview?.api?.get_rating_thresholds?.();
+        if (res?.success && res.profiles && Object.keys(res.profiles).length) {
+          _ratingProfileTable = res.profiles;
+        }
+      } catch (e) { console.warn('loadRatingProfileTable:', e); }
+    }
+
+    function renderCustomThresholds() {
+      const bands = document.getElementById('ratingCustomBands');
+      const handles = document.getElementById('ratingCustomHandles');
+      const readout = document.getElementById('ratingCustomReadout');
+      if (!bands || !handles) return;
+      const t = _customThresholds;
+
+      // Bands run ★1 from 0 up to the two-star cutoff, then each cutoff to the
+      // next, with ★5 running to 1.00.
+      const edges = [0, t.two, t.three, t.four, t.five, 1];
+      bands.innerHTML = '';
+      for (let star = 1; star <= 5; star++) {
+        const from = edges[star - 1];
+        const to = edges[star];
+        const width = Math.max(0, to - from);
+        const band = document.createElement('div');
+        band.className = 'rating-custom-band' + (width < 0.07 ? ' narrow' : '');
+        band.dataset.star = String(star);
+        band.style.left = (from * 100) + '%';
+        band.style.width = (width * 100) + '%';
+        band.textContent = '★' + star;
+        bands.appendChild(band);
+      }
+
+      handles.innerHTML = '';
+      for (const key of RATING_THRESHOLD_KEYS) {
+        const star = { five: 5, four: 4, three: 3, two: 2 }[key];
+        const btn = document.createElement('button');
+        btn.type = 'button';
+        btn.className = 'rating-custom-handle';
+        btn.dataset.thresholdKey = key;
+        btn.style.left = (t[key] * 100) + '%';
+        btn.setAttribute('role', 'slider');
+        btn.setAttribute('aria-label', `Minimum quality score for ${star} stars`);
+        btn.setAttribute('aria-valuemin', '0');
+        btn.setAttribute('aria-valuemax', '1');
+        btn.setAttribute('aria-valuenow', t[key].toFixed(2));
+        btn.title = `★${star} starts at ${t[key].toFixed(2)}`;
+        const label = document.createElement('span');
+        label.textContent = '★' + star;
+        btn.appendChild(label);
+        handles.appendChild(btn);
+      }
+
+      if (readout) {
+        readout.textContent = RATING_THRESHOLD_KEYS
+          .map(k => `★${{ five: 5, four: 4, three: 3, two: 2 }[k]} ≥ ${t[k].toFixed(2)}`)
+          .join('   ·   ');
+      }
+    }
+
+    // Move one cutoff, pushing its neighbours out of the way rather than
+    // letting bands collapse. Returns the normalized set.
+    function setCustomThreshold(key, value) {
+      const next = { ..._customThresholds, [key]: Math.max(0, Math.min(1, Number(value) || 0)) };
+      const idx = RATING_THRESHOLD_KEYS.indexOf(key);
+      // Push higher stars up if this one crossed them.
+      for (let i = idx - 1; i >= 0; i--) {
+        const above = RATING_THRESHOLD_KEYS[i];
+        const minAbove = _round2(next[RATING_THRESHOLD_KEYS[i + 1]] + RATING_MIN_GAP);
+        if (next[above] < minAbove) next[above] = minAbove;
+      }
+      // Push lower stars down likewise.
+      for (let i = idx + 1; i < RATING_THRESHOLD_KEYS.length; i++) {
+        const below = RATING_THRESHOLD_KEYS[i];
+        const maxBelow = _round2(next[RATING_THRESHOLD_KEYS[i - 1]] - RATING_MIN_GAP);
+        if (next[below] > maxBelow) next[below] = maxBelow;
+      }
+      _customThresholds = normalizeCustomThresholds(next);
+      renderCustomThresholds();
+      return _customThresholds;
+    }
+
+    function wireCustomThresholdEditor() {
+      const track = document.getElementById('ratingCustomTrack');
+      const handles = document.getElementById('ratingCustomHandles');
+      if (!track || !handles || handles.dataset.wired) return;
+      handles.dataset.wired = '1';
+
+      let dragKey = null;
+
+      const positionFromEvent = (ev) => {
+        const rect = track.getBoundingClientRect();
+        if (!rect.width) return 0;
+        return Math.max(0, Math.min(1, (ev.clientX - rect.left) / rect.width));
+      };
+
+      handles.addEventListener('pointerdown', (ev) => {
+        const btn = ev.target.closest('.rating-custom-handle');
+        if (!btn) return;
+        dragKey = btn.dataset.thresholdKey;
+        btn.classList.add('dragging');
+        // Capture on the container: re-rendering replaces the button mid-drag,
+        // so the original element would stop receiving moves.
+        handles.setPointerCapture(ev.pointerId);
+        ev.preventDefault();
+      });
+
+      handles.addEventListener('pointermove', (ev) => {
+        if (!dragKey) return;
+        setCustomThreshold(dragKey, _round2(positionFromEvent(ev)));
+      });
+
+      const endDrag = (ev) => {
+        if (!dragKey) return;
+        dragKey = null;
+        handles.querySelectorAll('.dragging').forEach(e => e.classList.remove('dragging'));
+        try { handles.releasePointerCapture(ev.pointerId); } catch (_) {}
+        if (typeof attemptAutoSave === 'function') attemptAutoSave();
+      };
+      handles.addEventListener('pointerup', endDrag);
+      handles.addEventListener('pointercancel', endDrag);
+
+      handles.addEventListener('keydown', (ev) => {
+        const btn = ev.target.closest('.rating-custom-handle');
+        if (!btn) return;
+        const step = ev.shiftKey ? 0.05 : 0.01;
+        const key = btn.dataset.thresholdKey;
+        let delta = 0;
+        if (ev.key === 'ArrowLeft' || ev.key === 'ArrowDown') delta = -step;
+        else if (ev.key === 'ArrowRight' || ev.key === 'ArrowUp') delta = step;
+        else if (ev.key === 'Home') delta = -1;
+        else if (ev.key === 'End') delta = 1;
+        else return;
+        ev.preventDefault();
+        setCustomThreshold(key, _round2(_customThresholds[key] + delta));
+        // Keep focus on the same star after the re-render.
+        document.querySelector(`.rating-custom-handle[data-threshold-key="${key}"]`)?.focus();
+      });
+
+      document.getElementById('ratingCustomReset')?.addEventListener('click', () => {
+        _customThresholds = normalizeCustomThresholds(
+          _ratingProfileTable.balanced || RATING_BALANCED
+        );
+        renderCustomThresholds();
+      });
+
+      document.getElementById('ratingProfile')?.addEventListener('change', (ev) => {
+        refreshRatingProfileEditor(ev.target.value);
+      });
+    }
     
     // Auto-save logic: debounced save when auto-save is enabled
     async function attemptAutoSave() {
@@ -86,6 +303,15 @@
       // Rating profile
       const profileSelect = document.getElementById('ratingProfile');
       if (profileSelect) profileSelect.value = getSetting('rating_profile', 'balanced');
+      // Custom thresholds: seed from the saved set, falling back to the active
+      // named profile so switching to Custom starts where the user already was.
+      await loadRatingProfileTable();
+      const savedCustom = getSetting('rating_thresholds_custom', null);
+      _customThresholds = normalizeCustomThresholds(
+        savedCustom || _ratingProfileTable[getSetting('rating_profile', 'balanced')] || RATING_BALANCED
+      );
+      wireCustomThresholdEditor();
+      refreshRatingProfileEditor();
       // RAW preview cache
       const rawCacheCb = document.getElementById('rawPreviewCacheEnabled');
       if (rawCacheCb) rawCacheCb.checked = getSetting('raw_preview_cache_enabled', true);
@@ -177,6 +403,10 @@
       // Merge into existing settings so keys like machine_id / analytics_consent_shown are preserved
       const existing = loadSettings();
       const prevProfile = existing.rating_profile || 'balanced';
+      // Editing custom thresholds changes every auto rating without changing
+      // the profile name, so compare the cutoffs too.
+      const prevCustom = JSON.stringify(normalizeCustomThresholds(existing.rating_thresholds_custom));
+      const nextCustom = JSON.stringify(normalizeCustomThresholds(_customThresholds));
 
       // ── Species & Region: collect region picker state + show-sci toggle ──
       // An empty selection falls back to ``['NA']`` rather than producing an
@@ -202,6 +432,7 @@
         analytics_opted_in: analyticsOptIn, analytics_consent_shown: true,
         crash_reports_enabled: crashReportsEnabled,
         rating_profile: ratingProfile,
+        rating_thresholds_custom: normalizeCustomThresholds(_customThresholds),
         raw_preview_cache_enabled: rawPreviewCacheEnabled,
         auto_save_enabled: autoSaveEnabled,
         bird_regions: finalRegions,
@@ -220,7 +451,10 @@
       }
       document.getElementById('settingsDlg').close();
       // If rating profile changed and folders are loaded, reapply immediately
-      if (ratingProfile !== prevProfile && rows.length > 0) {
+      const thresholdsChanged =
+        ratingProfile !== prevProfile ||
+        (ratingProfile === 'custom' && nextCustom !== prevCustom);
+      if (thresholdsChanged && rows.length > 0) {
         await reapplyNormalizationForLoadedFolders();
       }
       // Preview exposure-compensation strength is applied live by the shared

--- a/analyzer/kestrel_analyzer/pipeline.py
+++ b/analyzer/kestrel_analyzer/pipeline.py
@@ -40,7 +40,7 @@ from .exposure_compensation import (
     linear_to_srgb_u8,
 )
 from .image_utils import decode_embedded_preview, read_image, read_image_for_pipeline
-from .ratings import quality_to_rating, get_profile_thresholds
+from .ratings import quality_to_rating, resolve_thresholds
 from .similarity import compute_image_similarity_akaze, compute_similarity_timestamp
 from .raw_exif import get_capture_time
 from .logging_utils import get_log_path, log_event, log_exception, log_warning
@@ -499,7 +499,9 @@ class AnalysisPipeline:
             try:
                 sett = load_persisted_settings() or {}
                 rating_profile = str(sett.get('rating_profile', 'balanced') or 'balanced').strip().lower() or 'balanced'
-                rating_thresholds = get_profile_thresholds(rating_profile)
+                rating_thresholds = resolve_thresholds(
+                    rating_profile, sett.get('rating_thresholds_custom')
+                )
                 raw_eq = str(sett.get('exposure_quality', 'balanced') or 'balanced').strip().lower()
                 if raw_eq in {'lenient', 'balanced', 'aggressive'}:
                     exposure_quality = raw_eq

--- a/analyzer/kestrel_analyzer/ratings.py
+++ b/analyzer/kestrel_analyzer/ratings.py
@@ -7,9 +7,81 @@ RATING_PROFILES = {
 }
 
 
+# Profile name for user-defined thresholds. Its values do not live in
+# RATING_PROFILES — they come from the ``rating_thresholds_custom`` setting and
+# are resolved through ``resolve_thresholds``.
+CUSTOM_PROFILE = 'custom'
+
+# High-to-low, which is also the order quality_to_rating tests them in.
+THRESHOLD_KEYS = ('five', 'four', 'three', 'two')
+
+# Star bands must stay distinct: if two cutoffs collapse onto the same value a
+# whole star level becomes unreachable, so dragging one handle past another
+# pushes the neighbour along instead of swallowing it.
+MIN_THRESHOLD_GAP = 0.01
+
+
 def get_profile_thresholds(profile: str) -> dict:
     """Return threshold dict for a named rating profile, defaulting to 'balanced'."""
     return RATING_PROFILES.get(str(profile).lower(), RATING_PROFILES['balanced'])
+
+
+def normalize_custom_thresholds(raw, fallback: dict = None) -> dict:
+    """Coerce user-supplied thresholds into a valid, strictly-descending set.
+
+    Accepts anything (including ``None`` or junk from a hand-edited
+    settings.json) and always returns a usable dict. Values are clamped to
+    [0, 1]; any that are missing or unparseable fall back to the corresponding
+    entry in ``fallback`` (default: the 'balanced' profile). The result is then
+    forced strictly descending by ``MIN_THRESHOLD_GAP`` from 'five' down, so
+    every star band stays reachable.
+    """
+    base = dict(fallback or RATING_PROFILES['balanced'])
+    src = raw if isinstance(raw, dict) else {}
+
+    values = {}
+    for key in THRESHOLD_KEYS:
+        raw_v = src.get(key)
+        # bool is a subclass of int, so float(True) would quietly become a 1.0
+        # cutoff. Treat it as missing, matching the frontend's normalizer —
+        # the two have to agree or the editor shows bands the pipeline won't use.
+        if isinstance(raw_v, bool):
+            raw_v = None
+        try:
+            v = float(raw_v)
+        except (TypeError, ValueError):
+            v = float(base.get(key, RATING_PROFILES['balanced'][key]))
+        if v != v:  # NaN
+            v = float(base.get(key, RATING_PROFILES['balanced'][key]))
+        values[key] = max(0.0, min(1.0, v))
+
+    # Walk high-to-low, pushing each cutoff below the one above it.
+    ceiling = 1.0
+    for key in THRESHOLD_KEYS:
+        ceiling = round(min(values[key], ceiling), 4)
+        values[key] = ceiling
+        ceiling = round(ceiling - MIN_THRESHOLD_GAP, 4)
+
+    # A run of collisions near 0 can drive later keys negative; lift the whole
+    # tail back into range while keeping the gaps.
+    floor = 0.0
+    for key in reversed(THRESHOLD_KEYS):
+        if values[key] < floor:
+            values[key] = round(floor, 4)
+        floor = round(values[key] + MIN_THRESHOLD_GAP, 4)
+
+    return values
+
+
+def resolve_thresholds(profile: str, custom=None) -> dict:
+    """Return the thresholds actually in force for ``profile``.
+
+    Named profiles come from ``RATING_PROFILES``; the 'custom' profile is
+    resolved from ``custom`` (the ``rating_thresholds_custom`` setting).
+    """
+    if str(profile).lower() == CUSTOM_PROFILE:
+        return normalize_custom_thresholds(custom)
+    return get_profile_thresholds(profile)
 
 
 def quality_to_rating(q: float, thresholds: dict = None) -> int:

--- a/analyzer/settings_utils.py
+++ b/analyzer/settings_utils.py
@@ -55,7 +55,11 @@ _ALLOWED_EDITORS = {
     'affinity', 'gimp', 'rawtherapee', 'luminar', 'dxo', 'on1',
     'acdsee', 'paintshop', 'faststone', 'xnview', 'irfanview', 'custom',
 }
-_ALLOWED_RATING_PROFILES = {'very_strict', 'strict', 'balanced', 'lenient', 'very_lenient'}
+# 'custom' carries no built-in thresholds — its cutoffs live in
+# `rating_thresholds_custom` and are resolved by ratings.resolve_thresholds.
+_ALLOWED_RATING_PROFILES = {
+    'very_strict', 'strict', 'balanced', 'lenient', 'very_lenient', 'custom',
+}
 _ALLOWED_EXPOSURE_QUALITY = {'lenient', 'balanced', 'aggressive'}
 _ALLOWED_WILDLIFE_MODEL_MODES = {'fast', 'accurate'}
 _ALLOWED_QUEUE_DETECTOR_NAMES = {'mdv5a', 'mdv1000-cedar'}
@@ -475,6 +479,17 @@ def _sanitize_settings_payload(data: dict, emit_log: bool = False) -> dict:
 
     if 'rating_profile' in data:
         out['rating_profile'] = _coerce_enum(data.get('rating_profile'), _ALLOWED_RATING_PROFILES, default='balanced')
+    if 'rating_thresholds_custom' in data:
+        # Normalized here rather than trusted from the frontend: these cutoffs
+        # decide every auto star rating, and an out-of-order or out-of-range set
+        # would make a star band unreachable. Always yields a valid dict.
+        try:
+            from kestrel_analyzer.ratings import normalize_custom_thresholds
+        except ImportError:
+            from analyzer.kestrel_analyzer.ratings import normalize_custom_thresholds  # type: ignore
+        out['rating_thresholds_custom'] = normalize_custom_thresholds(
+            data.get('rating_thresholds_custom')
+        )
     _set_float('detection_threshold', default=0.25, min_value=0.1, max_value=0.99, digits=4)
     _set_float('scene_time_threshold', default=1.0, min_value=0.0, max_value=60.0, digits=4)
     _set_float('mask_threshold', default=0.5, min_value=0.5, max_value=0.95, digits=4)

--- a/analyzer/tests/unit/test_analyze_settings_questions.py
+++ b/analyzer/tests/unit/test_analyze_settings_questions.py
@@ -1,0 +1,164 @@
+"""Static wiring tests for the question-and-answer analysis settings column.
+
+The critical settings block in the Analyze Folders dialog is phrased as
+questions about the shoot. Each answer pair is the visible control for a
+hidden checkbox (``#analyzeWildlife`` / ``#analyzeSpeciesDetection``) that
+``event-wiring.js`` reads when Start is clicked.
+
+The repo has no JS test runner, so these are source-level lints in the same
+spirit as ``test_raw_warn_banner.py``. They catch the failure modes that would
+silently analyze with the wrong scope: a renamed radio id, a dropped hidden
+checkbox, or the mirror wiring being moved back behind the dialog-open path.
+
+Behavioural coverage (mirroring in both directions, defaults, responsive
+wrapping) was verified in a headless Chromium harness; see the PR description.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import unittest
+
+_THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+_ANALYZER_DIR = os.path.dirname(os.path.dirname(_THIS_DIR))
+
+# Radio id -> the hidden checkbox it mirrors onto.
+ANSWER_MIRRORS = {
+    "adlgSubjectScopeWildlife": "analyzeWildlife",
+    "adlgSpeciesScopeYes": "analyzeSpeciesDetection",
+}
+# The "negative" half of each pair; present so the group has two answers.
+ANSWER_ALTERNATES = ("adlgSubjectScopeBirds", "adlgSpeciesScopeNo")
+
+QUESTIONS = (
+    "What subjects does this shoot contain?",
+    "Does this shoot contain North American birds?",
+)
+
+# The Start handler in event-wiring.js reads these; they must survive the
+# rephrasing or analysis silently runs with the wrong options.
+START_HANDLER_IDS = ("analyzeWildlife", "analyzeSpeciesDetection", "adlgWildlifeModelMode")
+
+
+def _read(*parts: str) -> str:
+    with open(os.path.join(_ANALYZER_DIR, *parts), "r", encoding="utf-8") as f:
+        return f.read()
+
+
+class TestQuestionMarkup(unittest.TestCase):
+    def setUp(self):
+        self.html = _read("visualizer.html")
+
+    def test_questions_are_present(self):
+        for q in QUESTIONS:
+            with self.subTest(question=q):
+                self.assertIn(q, self.html)
+
+    def test_species_help_text_states_the_north_american_limit(self):
+        self.assertIn("only recognizes North American birds", self.html)
+
+    def test_every_answer_radio_exists(self):
+        for rid in list(ANSWER_MIRRORS) + list(ANSWER_ALTERNATES):
+            with self.subTest(radio=rid):
+                self.assertRegex(self.html, rf'id="{rid}"')
+
+    def test_answer_pairs_share_a_radio_group_name(self):
+        for name, count in (("adlgSubjectScope", 2), ("adlgSpeciesScope", 2)):
+            with self.subTest(group=name):
+                self.assertEqual(len(re.findall(rf'name="{name}"', self.html)), count)
+
+    def test_start_handler_ids_survive(self):
+        for eid in START_HANDLER_IDS:
+            with self.subTest(element=eid):
+                self.assertRegex(self.html, rf'id="{eid}"')
+
+    def test_mirrored_checkboxes_are_hidden_and_unfocusable(self):
+        """A visible duplicate control would let the two drift apart."""
+        for box in ANSWER_MIRRORS.values():
+            with self.subTest(checkbox=box):
+                tag = re.search(rf'<input id="{box}"[^>]*>', self.html)
+                self.assertIsNotNone(tag, f"{box} input tag not found")
+                self.assertIn('class="hidden"', tag.group(0))
+                self.assertIn('tabindex="-1"', tag.group(0))
+
+    def test_experimental_badge_is_retired(self):
+        """The owner asked for the badge to go when wildlife became an answer."""
+        critical = re.search(
+            r'<div class="analyze-dlg-settings-critical">(.*?)\n          </div>',
+            self.html,
+            re.S,
+        )
+        self.assertIsNotNone(critical, "critical settings block not found")
+        self.assertNotIn("adlg-tag", critical.group(1))
+        self.assertNotIn("experimental", critical.group(1).lower())
+
+
+class TestDetectionModelIsBuried(unittest.TestCase):
+    def setUp(self):
+        self.html = _read("visualizer.html")
+
+    def test_old_fast_accurate_radio_pair_is_gone(self):
+        for rid in ("adlgWildlifeModelModeAccurate", "adlgWildlifeModelModeFast"):
+            with self.subTest(radio=rid):
+                self.assertNotIn(rid, self.html)
+
+    def test_model_select_defaults_to_accurate(self):
+        sel = re.search(r'<select id="adlgWildlifeModelMode".*?</select>', self.html, re.S)
+        self.assertIsNotNone(sel, "model select not found")
+        self.assertRegex(sel.group(0), r'<option value="accurate"[^>]*selected')
+
+    def test_model_select_is_visible_and_inside_more_options(self):
+        sel = re.search(r'<select id="adlgWildlifeModelMode"[^>]*>', self.html)
+        self.assertIsNotNone(sel)
+        self.assertNotIn("hidden", sel.group(0))
+
+        more = self.html.index('<details class="analyze-dlg-more-options"')
+        self.assertGreater(
+            self.html.index('id="adlgWildlifeModelMode"'),
+            more,
+            "detection model should sit inside More options, not the critical block",
+        )
+
+
+class TestMirrorWiring(unittest.TestCase):
+    def setUp(self):
+        self.js = _read("js", "analyze-dialog.js")
+
+    def test_pairs_table_maps_each_radio_to_its_checkbox(self):
+        table = re.search(r"const _ANSWER_PAIRS = \[(.*?)\];", self.js, re.S)
+        self.assertIsNotNone(table, "_ANSWER_PAIRS table not found")
+        for radio, box in ANSWER_MIRRORS.items():
+            with self.subTest(radio=radio):
+                self.assertRegex(table.group(1), rf"'{radio}'.*?'{box}'")
+
+    def test_mirrors_are_wired_at_load_not_on_dialog_open(self):
+        """Wiring inside openAnalyzeDialog would break if that path throws first."""
+        self.assertIn("DOMContentLoaded", self.js)
+        wire_at = self.js.index("wireAnalyzeAnswerMirrors()")
+        open_at = self.js.index("async function openAnalyzeDialog()")
+        self.assertLess(wire_at, open_at, "mirror wiring must run before/independently of dialog open")
+
+    def test_dialog_open_still_pushes_saved_settings_into_the_answers(self):
+        self.assertIn("syncAnalyzeAnswersFromSettings()", self.js)
+
+    def test_stale_radio_sync_removed(self):
+        self.assertNotIn("_syncModeRadios", self.js)
+
+
+class TestQuestionStyles(unittest.TestCase):
+    def setUp(self):
+        self.css = _read("css", "dialogs", "analyze.css")
+
+    def test_question_classes_are_styled(self):
+        for cls in (".adlg-question", ".adlg-question-text", ".adlg-answer-pair", ".adlg-question-help"):
+            with self.subTest(css_class=cls):
+                self.assertIn(cls, self.css)
+
+    def test_answers_collapse_to_one_column_when_narrow(self):
+        """Both answer labels cannot sit side by side in a narrow dialog."""
+        self.assertRegex(self.css, r"@media \(max-width: \d+px\)\s*\{\s*\.adlg-answer-pair")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/analyzer/tests/unit/test_culling_quality_cutoff.py
+++ b/analyzer/tests/unit/test_culling_quality_cutoff.py
@@ -1,0 +1,147 @@
+"""Tests for the Culling Assistant's quality-score accept cutoff.
+
+The auto-categorize cutoff is a quality score (0.00–1.00) with the active
+rating profile's star thresholds drawn on the slider, rather than an integer
+star level.
+
+The Python half (``get_rating_thresholds``) is tested directly. The frontend
+half lives inline in ``culling.html`` and the repo has no JS test runner, so
+those are source-level lints in the spirit of ``test_raw_warn_banner.py``.
+Behavioural coverage (tick positions, band note, legacy migration, the accept
+rule with manual ratings) was verified in a headless Chromium harness; see the
+PR description.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from kestrel_analyzer.ratings import RATING_PROFILES, quality_to_rating
+
+_THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+_ANALYZER_DIR = os.path.dirname(os.path.dirname(_THIS_DIR))
+
+
+def _read(*parts: str) -> str:
+    with open(os.path.join(_ANALYZER_DIR, *parts), "r", encoding="utf-8") as f:
+        return f.read()
+
+
+class TestRatingThresholdsBridge(unittest.TestCase):
+    """api_bridge.get_rating_thresholds is the single source for the frontend."""
+
+    def setUp(self):
+        self.src = _read("api_bridge.py")
+
+    def test_method_exists(self):
+        self.assertIn("def get_rating_thresholds(self)", self.src)
+
+    def test_serves_from_the_ratings_module_not_a_copy(self):
+        body = self.src.split("def get_rating_thresholds(self)", 1)[1].split("\n    def ", 1)[0]
+        self.assertIn("RATING_PROFILES", body)
+        self.assertIn("get_profile_thresholds", body)
+        self.assertIn("rating_profile", body)
+        # A hardcoded threshold number here would silently drift from ratings.py.
+        self.assertNotRegex(body, r"0\.(85|60|40|15)\b")
+
+    def test_returns_the_documented_shape(self):
+        body = self.src.split("def get_rating_thresholds(self)", 1)[1].split("\n    def ", 1)[0]
+        for key in ("'success'", "'profile'", "'thresholds'", "'profiles'", "'error'"):
+            with self.subTest(key=key):
+                self.assertIn(key, body)
+
+
+class TestCullingCutoffMarkup(unittest.TestCase):
+    def setUp(self):
+        self.html = _read("culling.html")
+
+    def test_slider_spans_the_quality_range(self):
+        tag = re.search(r'<input type="range" id="qualityCutoffSlider"[^>]*>', self.html)
+        self.assertIsNotNone(tag, "cutoff slider not found")
+        for attr in ('min="0"', 'max="1"', 'step="0.01"'):
+            with self.subTest(attr=attr):
+                self.assertIn(attr, tag.group(0))
+
+    def test_default_is_the_balanced_four_star_floor(self):
+        tag = re.search(r'<input type="range" id="qualityCutoffSlider"[^>]*>', self.html)
+        self.assertIn('value="0.60"', tag.group(0))
+        self.assertAlmostEqual(RATING_PROFILES["balanced"]["four"], 0.60, places=2)
+
+    def test_star_overlay_and_note_elements_exist(self):
+        for eid in ("qualityScaleTicks", "qualityCutoffNote", "qualityCutoffVal"):
+            with self.subTest(element=eid):
+                self.assertRegex(self.html, rf'id="{eid}"')
+
+    def test_label_asks_for_a_quality_score(self):
+        self.assertIn("Accept if quality is at least", self.html)
+
+    def test_tick_styles_are_defined(self):
+        for cls in (".quality-scale-ticks", ".quality-tick", ".quality-tick.above", ".quality-scale-note"):
+            with self.subTest(css_class=cls):
+                self.assertIn(cls, self.html)
+
+
+class TestCullingCutoffLogic(unittest.TestCase):
+    def setUp(self):
+        self.html = _read("culling.html")
+
+    def test_thresholds_come_from_the_bridge(self):
+        self.assertIn("get_rating_thresholds()", self.html)
+        self.assertIn("function loadRatingThresholds", self.html)
+
+    def test_thresholds_load_before_settings_migration(self):
+        """A legacy star cutoff is converted using the profile thresholds."""
+        init = self.html.index("async function init()")
+        tail = self.html[init:]
+        self.assertLess(
+            tail.index("await loadRatingThresholds()"),
+            tail.index("await loadCullingSettings()"),
+            "thresholds must load before the legacy cutoff is migrated",
+        )
+
+    def test_accept_rule_compares_quality_not_stars(self):
+        self.assertIn("effectiveQuality(r) >= qualityCutoff", self.html)
+        self.assertNotIn("return rt > cutoff;", self.html)
+
+    def test_manual_ratings_still_win_over_the_computed_score(self):
+        body = self.html.split("function effectiveQuality(row)", 1)[1].split("\n    }", 1)[0]
+        self.assertIn("getOrigin(row) === 'manual'", body)
+        self.assertIn("qualityFloorForStar", body)
+
+    def test_unrated_images_still_follow_the_unrated_default(self):
+        self.assertIn("if (rt === 0) return unratedDefault === 'accept';", self.html)
+
+    def test_new_setting_key_is_written_and_read(self):
+        self.assertIn("culling_quality_score_cutoff", self.html)
+        # The legacy key must still be honoured on load for existing installs.
+        self.assertIn("culling_quality_cutoff", self.html)
+
+    def test_star_boundaries_match_the_python_mapping(self):
+        """starForQuality in culling.html mirrors ratings.quality_to_rating."""
+        body = self.html.split("function starForQuality(q)", 1)[1].split("\n    }", 1)[0]
+        order = re.findall(r"_ratingThresholds\.(five|four|three|two)", body)
+        self.assertEqual(
+            order,
+            ["five", "four", "three", "two"],
+            "bands must be checked high-to-low or images land in the wrong star",
+        )
+        returns = re.findall(r"return (\d);", body)
+        self.assertEqual(returns, ["0", "5", "4", "3", "2", "1"])
+
+        # Sanity-check the Python side the JS is mirroring.
+        balanced = RATING_PROFILES["balanced"]
+        self.assertEqual(quality_to_rating(balanced["five"], balanced), 5)
+        self.assertEqual(quality_to_rating(balanced["four"], balanced), 4)
+        self.assertEqual(quality_to_rating(balanced["three"], balanced), 3)
+        self.assertEqual(quality_to_rating(balanced["two"], balanced), 2)
+        self.assertEqual(quality_to_rating(balanced["two"] - 0.01, balanced), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/analyzer/tests/unit/test_culling_quality_cutoff.py
+++ b/analyzer/tests/unit/test_culling_quality_cutoff.py
@@ -45,7 +45,9 @@ class TestRatingThresholdsBridge(unittest.TestCase):
     def test_serves_from_the_ratings_module_not_a_copy(self):
         body = self.src.split("def get_rating_thresholds(self)", 1)[1].split("\n    def ", 1)[0]
         self.assertIn("RATING_PROFILES", body)
-        self.assertIn("get_profile_thresholds", body)
+        # Whichever resolver is in use, the thresholds must come from
+        # kestrel_analyzer.ratings rather than a local table.
+        self.assertRegex(body, r"(resolve_thresholds|get_profile_thresholds)")
         self.assertIn("rating_profile", body)
         # A hardcoded threshold number here would silently drift from ratings.py.
         self.assertNotRegex(body, r"0\.(85|60|40|15)\b")

--- a/analyzer/tests/unit/test_custom_rating_profile.py
+++ b/analyzer/tests/unit/test_custom_rating_profile.py
@@ -1,0 +1,240 @@
+"""Tests for the user-defined ('custom') rating profile.
+
+The custom profile's cutoffs live in the ``rating_thresholds_custom`` setting
+rather than ``RATING_PROFILES``. ``normalize_custom_thresholds`` is the guard
+that keeps them usable: whatever it is handed, it must return four cutoffs in
+[0, 1] that are strictly descending, because two cutoffs collapsing onto the
+same value makes a whole star band unreachable.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from kestrel_analyzer.ratings import (
+    CUSTOM_PROFILE,
+    MIN_THRESHOLD_GAP,
+    RATING_PROFILES,
+    THRESHOLD_KEYS,
+    normalize_custom_thresholds,
+    quality_to_rating,
+    resolve_thresholds,
+)
+
+_THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+_ANALYZER_DIR = os.path.dirname(os.path.dirname(_THIS_DIR))
+
+
+def _read(*parts: str) -> str:
+    with open(os.path.join(_ANALYZER_DIR, *parts), "r", encoding="utf-8") as f:
+        return f.read()
+
+
+def _descending(t: dict) -> bool:
+    vals = [t[k] for k in THRESHOLD_KEYS]
+    return all(vals[i] > vals[i + 1] for i in range(len(vals) - 1))
+
+
+class TestNormalizeCustomThresholds(unittest.TestCase):
+    def test_none_falls_back_to_balanced(self):
+        self.assertEqual(normalize_custom_thresholds(None), RATING_PROFILES["balanced"])
+
+    def test_a_valid_set_is_returned_unchanged(self):
+        t = {"five": 0.9, "four": 0.7, "three": 0.5, "two": 0.3}
+        self.assertEqual(normalize_custom_thresholds(t), t)
+
+    def test_missing_keys_fall_back_per_key(self):
+        out = normalize_custom_thresholds({"five": 0.95})
+        self.assertEqual(out["five"], 0.95)
+        for key in ("four", "three", "two"):
+            with self.subTest(key=key):
+                self.assertEqual(out[key], RATING_PROFILES["balanced"][key])
+
+    def test_out_of_order_input_is_forced_descending(self):
+        out = normalize_custom_thresholds({"five": 0.3, "four": 0.7, "three": 0.5, "two": 0.9})
+        self.assertTrue(_descending(out), out)
+
+    def test_collapsed_input_keeps_every_band_reachable(self):
+        out = normalize_custom_thresholds({k: 0.5 for k in THRESHOLD_KEYS})
+        self.assertTrue(_descending(out), out)
+        vals = [out[k] for k in THRESHOLD_KEYS]
+        for a, b in zip(vals, vals[1:]):
+            self.assertGreaterEqual(round(a - b, 4), MIN_THRESHOLD_GAP)
+
+    def test_all_zero_input_lifts_off_the_floor(self):
+        out = normalize_custom_thresholds({k: 0 for k in THRESHOLD_KEYS})
+        self.assertTrue(_descending(out), out)
+        self.assertGreaterEqual(min(out.values()), 0.0)
+
+    def test_values_are_clamped_into_range(self):
+        out = normalize_custom_thresholds({"five": 5, "four": 0.7, "three": 0.5, "two": -3})
+        self.assertLessEqual(out["five"], 1.0)
+        self.assertGreaterEqual(out["two"], 0.0)
+
+    def test_junk_values_fall_back(self):
+        out = normalize_custom_thresholds(
+            {"five": "abc", "four": None, "three": float("nan"), "two": [1]}
+        )
+        self.assertTrue(_descending(out), out)
+        self.assertEqual(out["five"], RATING_PROFILES["balanced"]["five"])
+
+    def test_booleans_are_not_thresholds(self):
+        """float(True) is 1.0; accepting it would silently set a 1.00 cutoff.
+
+        The frontend normalizer rejects booleans, so this side must too or the
+        editor would show different bands than the pipeline computes.
+        """
+        out = normalize_custom_thresholds({"five": True, "four": False, "three": 0.5, "two": 0.3})
+        self.assertEqual(out["five"], RATING_PROFILES["balanced"]["five"])
+        self.assertEqual(out["four"], RATING_PROFILES["balanced"]["four"])
+
+    def test_numeric_strings_are_accepted(self):
+        out = normalize_custom_thresholds({"five": "0.9", "four": "0.7", "three": "0.5", "two": "0.3"})
+        self.assertEqual(out, {"five": 0.9, "four": 0.7, "three": 0.5, "two": 0.3})
+
+    def test_non_dict_input_falls_back(self):
+        for junk in ("nope", 42, [], None, object()):
+            with self.subTest(value=repr(junk)):
+                self.assertEqual(normalize_custom_thresholds(junk), RATING_PROFILES["balanced"])
+
+    def test_output_is_always_valid_over_a_fuzz_sweep(self):
+        import random
+
+        random.seed(1234)
+        choices = [
+            lambda: random.random(),
+            lambda: random.uniform(-5, 5),
+            lambda: random.choice(["x", "", "0.5", None, True, False]),
+            lambda: float("nan"),
+        ]
+        for _ in range(3000):
+            raw = {k: random.choice(choices)() for k in THRESHOLD_KEYS}
+            out = normalize_custom_thresholds(raw)
+            self.assertTrue(_descending(out), (raw, out))
+            self.assertTrue(all(0.0 <= v <= 1.0 for v in out.values()), (raw, out))
+
+    def test_every_star_band_stays_reachable(self):
+        """A quality score exists that lands in each of the five bands."""
+        out = normalize_custom_thresholds({k: 0.5 for k in THRESHOLD_KEYS})
+        seen = {quality_to_rating(q / 1000, out) for q in range(0, 1001)}
+        self.assertEqual(seen, {1, 2, 3, 4, 5}, out)
+
+
+class TestResolveThresholds(unittest.TestCase):
+    def test_named_profiles_ignore_the_custom_payload(self):
+        self.assertEqual(
+            resolve_thresholds("strict", {"five": 0.1, "four": 0.09, "three": 0.08, "two": 0.07}),
+            RATING_PROFILES["strict"],
+        )
+
+    def test_custom_profile_uses_the_supplied_thresholds(self):
+        t = {"five": 0.5, "four": 0.4, "three": 0.3, "two": 0.2}
+        self.assertEqual(resolve_thresholds(CUSTOM_PROFILE, t), t)
+
+    def test_custom_profile_without_thresholds_falls_back(self):
+        self.assertEqual(resolve_thresholds(CUSTOM_PROFILE, None), RATING_PROFILES["balanced"])
+
+    def test_unknown_profile_falls_back_to_balanced(self):
+        self.assertEqual(resolve_thresholds("nonsense"), RATING_PROFILES["balanced"])
+
+    def test_profile_name_is_case_insensitive(self):
+        t = {"five": 0.5, "four": 0.4, "three": 0.3, "two": 0.2}
+        self.assertEqual(resolve_thresholds("CUSTOM", t), t)
+
+
+class TestSettingsPlumbing(unittest.TestCase):
+    def setUp(self):
+        self.src = _read("settings_utils.py")
+
+    def test_custom_is_an_allowed_profile(self):
+        block = re.search(r"_ALLOWED_RATING_PROFILES = \{(.*?)\}", self.src, re.S)
+        self.assertIsNotNone(block)
+        self.assertIn("'custom'", block.group(1))
+
+    def test_saved_thresholds_are_normalized_not_trusted(self):
+        self.assertIn("rating_thresholds_custom", self.src)
+        self.assertIn("normalize_custom_thresholds", self.src)
+
+
+class TestResolutionSitesUseTheCustomProfile(unittest.TestCase):
+    """Every place that turns a profile name into cutoffs must handle 'custom'.
+
+    A site still calling get_profile_thresholds would silently fall back to
+    balanced, so a custom profile would apply in some views but not others.
+    """
+
+    def test_api_bridge_resolves_custom(self):
+        src = _read("api_bridge.py")
+        self.assertNotIn("get_profile_thresholds", src)
+        self.assertIn("resolve_thresholds", src)
+        # apply_normalization and get_rating_thresholds are the two sites.
+        self.assertGreaterEqual(src.count("resolve_thresholds("), 2)
+
+    def test_pipeline_resolves_custom(self):
+        src = _read("kestrel_analyzer", "pipeline.py")
+        self.assertNotIn("get_profile_thresholds", src)
+        self.assertIn("rating_thresholds_custom", src)
+
+
+class TestCustomEditorMarkup(unittest.TestCase):
+    def setUp(self):
+        self.html = _read("visualizer.html")
+        self.js = _read("js", "settings.js")
+        self.css = _read("css", "dialogs", "settings.css")
+
+    def test_custom_option_is_offered(self):
+        self.assertRegex(self.html, r'<option value="custom">')
+
+    def test_editor_elements_exist(self):
+        for eid in (
+            "ratingCustomEditor",
+            "ratingCustomTrack",
+            "ratingCustomBands",
+            "ratingCustomHandles",
+            "ratingCustomReadout",
+            "ratingCustomReset",
+        ):
+            with self.subTest(element=eid):
+                self.assertRegex(self.html, rf'id="{eid}"')
+
+    def test_editor_starts_hidden(self):
+        tag = re.search(r'<div class="([^"]*)" id="ratingCustomEditor"', self.html)
+        self.assertIsNotNone(tag)
+        self.assertIn("hidden", tag.group(1))
+
+    def test_editor_styles_are_defined(self):
+        for cls in (".rating-custom-editor", ".rating-custom-band", ".rating-custom-handle"):
+            with self.subTest(css_class=cls):
+                self.assertIn(cls, self.css)
+
+    def test_js_gap_matches_the_python_constant(self):
+        m = re.search(r"const RATING_MIN_GAP = ([\d.]+);", self.js)
+        self.assertIsNotNone(m, "RATING_MIN_GAP not found")
+        self.assertAlmostEqual(float(m.group(1)), MIN_THRESHOLD_GAP, places=6)
+
+    def test_js_keys_match_the_python_order(self):
+        m = re.search(r"const RATING_THRESHOLD_KEYS = \[(.*?)\];", self.js)
+        self.assertIsNotNone(m)
+        keys = tuple(re.findall(r"'(\w+)'", m.group(1)))
+        self.assertEqual(keys, THRESHOLD_KEYS)
+
+    def test_thresholds_are_persisted_and_reapplied(self):
+        self.assertIn("rating_thresholds_custom: normalizeCustomThresholds(_customThresholds)", self.js)
+        # Editing cutoffs changes every auto rating without changing the
+        # profile name, so the re-apply check must compare the values.
+        self.assertIn("nextCustom !== prevCustom", self.js)
+
+    def test_handles_are_keyboard_operable(self):
+        self.assertIn("ArrowLeft", self.js)
+        self.assertIn("aria-valuenow", self.js)
+        self.assertIn("role', 'slider'", self.js)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/analyzer/visualizer.html
+++ b/analyzer/visualizer.html
@@ -1028,53 +1028,62 @@
         <!-- ═══ Column 2: Review Settings ═══ -->
         <div class="analyze-dlg-col analyze-dlg-col-settings">
           <div class="analyze-dlg-col-title">⚙ Review settings</div>
+          <!-- Phrased as questions about the shoot rather than as model
+               settings: the user knows what they photographed, not which
+               classifier that implies. Each answer pair mirrors to the hidden
+               input below it, which is what the Start handler in
+               event-wiring.js reads — the read path is unchanged. -->
           <div class="analyze-dlg-settings-critical">
-            <!-- Wildlife detection model — horizontal radio pair for compactness. -->
-            <div class="adlg-radio-group">
-              <div class="adlg-radio-label">Wildlife detection model</div>
-              <div class="adlg-radio-horiz">
+
+            <div class="adlg-question">
+              <div class="adlg-question-text">What subjects does this shoot contain?</div>
+              <div class="adlg-answer-pair" role="radiogroup" aria-label="Subjects in this shoot">
                 <label class="adlg-radio-row adlg-radio-row-horiz">
-                  <input type="radio" name="adlgWildlifeModelMode" id="adlgWildlifeModelModeAccurate" value="accurate" checked />
+                  <input type="radio" name="adlgSubjectScope" id="adlgSubjectScopeBirds" value="birds" checked />
                   <div class="adlg-radio-text">
-                    <span class="adlg-radio-name">Accurate</span>
-                    <span class="adlg-radio-hint muted">Larger model with stronger recall. Slower but catches more subjects, especially distant or partially-obscured birds.</span>
+                    <span class="adlg-radio-name">Birds only</span>
                   </div>
                 </label>
                 <label class="adlg-radio-row adlg-radio-row-horiz">
-                  <input type="radio" name="adlgWildlifeModelMode" id="adlgWildlifeModelModeFast" value="fast" />
+                  <input type="radio" name="adlgSubjectScope" id="adlgSubjectScopeWildlife" value="wildlife" />
                   <div class="adlg-radio-text">
-                    <span class="adlg-radio-name">Fast</span>
-                    <span class="adlg-radio-hint muted">Smaller model — significantly faster but may miss some detections. Good for quick first passes.</span>
+                    <span class="adlg-radio-name">Birds and other wildlife</span>
                   </div>
                 </label>
               </div>
-              <!-- Legacy <select> kept hidden so settings hydrate logic that reads/writes
-                   #adlgWildlifeModelMode keeps working; the radios mirror to it. -->
-              <select id="adlgWildlifeModelMode" class="hidden" aria-hidden="true">
-                <option value="fast">Fast</option>
-                <option value="accurate" selected>Accurate</option>
-              </select>
+              <div class="adlg-question-help muted">Including other wildlife finds 1,200+ non-bird species — squirrels, deer, bears and more. It adds noticeable time per image.</div>
             </div>
-            <label class="adlg-toggle-row">
-              <input id="analyzeSpeciesDetection" type="checkbox" checked />
-              <div class="adlg-toggle-text">
-                <span class="adlg-toggle-label">Identify bird species &amp; family</span>
-                <span class="adlg-toggle-hint muted">Runs the bird species classifier on each cropped bird. Optimized for North American species — disable if shooting elsewhere. Detection &amp; quality scoring are unaffected.</span>
+            <input id="analyzeWildlife" type="checkbox" class="hidden" aria-hidden="true" tabindex="-1" />
+
+            <div class="adlg-question">
+              <div class="adlg-question-text">Does this shoot contain North American birds?</div>
+              <div class="adlg-answer-pair" role="radiogroup" aria-label="Bird species identification">
+                <label class="adlg-radio-row adlg-radio-row-horiz">
+                  <input type="radio" name="adlgSpeciesScope" id="adlgSpeciesScopeYes" value="yes" checked />
+                  <div class="adlg-radio-text">
+                    <span class="adlg-radio-name">Yes, identify species</span>
+                  </div>
+                </label>
+                <label class="adlg-radio-row adlg-radio-row-horiz">
+                  <input type="radio" name="adlgSpeciesScope" id="adlgSpeciesScopeNo" value="no" />
+                  <div class="adlg-radio-text">
+                    <span class="adlg-radio-name">No, skip species identification</span>
+                  </div>
+                </label>
               </div>
-            </label>
-            <div class="adlg-setting-row">
-              <label for="adlgMaxBirdCrops">Maximum subjects per image</label>
-              <input id="adlgMaxBirdCrops" type="number" min="1" max="20" step="1" value="10"
-                style="width:80px" />
+              <div class="adlg-question-help muted">Kestrel's bird species classifier only recognizes North American birds. Skipping it makes analysis faster; finding your subjects and scoring their quality work exactly the same either way.</div>
             </div>
-            <div class="adlg-hint muted">Each additional subject increases processing time. Lower this to cap the number of subjects processed per image.</div>
-            <label class="adlg-toggle-row">
-              <input id="analyzeWildlife" type="checkbox" />
-              <div class="adlg-toggle-text">
-                <span class="adlg-toggle-label">Detect non-bird wildlife <span class="adlg-tag">experimental</span></span>
-                <span class="adlg-toggle-hint muted">Detects 1,200+ non-bird species (squirrels, deer, bears, etc.) using SpeciesNet. Adds noticeable processing time per image.</span>
+            <input id="analyzeSpeciesDetection" type="checkbox" class="hidden" aria-hidden="true" tabindex="-1" checked />
+
+            <div class="adlg-question">
+              <div class="adlg-question-text">How many subjects should Kestrel analyze in each image?</div>
+              <div class="adlg-setting-row">
+                <label for="adlgMaxBirdCrops">At most</label>
+                <input id="adlgMaxBirdCrops" type="number" min="1" max="20" step="1" value="10"
+                  style="width:80px" />
               </div>
-            </label>
+              <div class="adlg-question-help muted">Every extra subject adds processing time. Lower this for flock shots where you only care about the closest few birds.</div>
+            </div>
           </div>
 
           <!-- "More options" expanded by default. Subheadings group settings
@@ -1112,13 +1121,25 @@
               </div>
 
               <div class="adlg-subgroup">
-                <div class="adlg-subgroup-title">Wildlife detection</div>
+                <div class="adlg-subgroup-title">Finding subjects</div>
+                <!-- Was a prominent Fast/Accurate radio pair in the critical
+                     block. Accurate is right for essentially every shoot, so it
+                     is now the default and lives down here instead of asking
+                     every user to make the call up front. -->
+                <div class="adlg-setting-row">
+                  <label for="adlgWildlifeModelMode">Detection model</label>
+                  <select id="adlgWildlifeModelMode" style="flex:1;max-width:200px">
+                    <option value="accurate" selected>Accurate (recommended)</option>
+                    <option value="fast">Fast</option>
+                  </select>
+                </div>
+                <div class="adlg-hint muted">Accurate is the right choice for almost every shoot. Fast uses a smaller model that finishes sooner but misses distant and partly-hidden birds.</div>
                 <div class="adlg-setting-row">
                   <label for="adlgDetectionThreshold">Detection confidence</label>
                   <input id="adlgDetectionThreshold" type="number" min="0.1" max="0.99" step="0.05" value="0.15"
                     style="width:80px" />
                 </div>
-                <div class="adlg-hint muted">Minimum MegaDetector animal confidence (0.10–0.99). Lower values find more subjects.</div>
+                <div class="adlg-hint muted">How sure Kestrel must be that it found an animal before analyzing it (0.10–0.99). Lower values find more subjects.</div>
                 <!-- Live warning when the user picks a value much above the
                      recommended baseline. Wildlife detection models are quite
                      accurate, so high thresholds tend to miss real subjects. -->

--- a/analyzer/visualizer.html
+++ b/analyzer/visualizer.html
@@ -860,11 +860,31 @@
           <option value="balanced" selected>Balanced &mdash; recommended for most photographers</option>
           <option value="lenient">Lenient</option>
           <option value="very_lenient">Very Lenient &mdash; most rewarding; lowest bar for 4&ndash;5 stars</option>
+          <option value="custom">Custom &mdash; set your own thresholds</option>
         </select>
       </div>
       <div class="muted" style="font-size:12px;margin-top:-6px;margin-bottom:8px">Controls how quality scores are
         converted to star ratings. Each profile uses fixed quality-score thresholds — stricter profiles require
         a higher score to earn 4 or 5 stars. Changes take effect immediately for loaded folders.</div>
+
+      <!-- Custom thresholds editor. Only shown when the Custom profile is
+           selected; the same 0.00–1.00 number line the Culling Assistant
+           draws, except here the star markers are the draggable part. -->
+      <div class="rating-custom-editor hidden" id="ratingCustomEditor">
+        <div class="rating-custom-track" id="ratingCustomTrack" role="group"
+             aria-label="Custom star rating thresholds">
+          <div class="rating-custom-bands" id="ratingCustomBands" aria-hidden="true"></div>
+          <div class="rating-custom-handles" id="ratingCustomHandles"></div>
+        </div>
+        <div class="rating-custom-axis" aria-hidden="true">
+          <span>0.00</span><span>0.25</span><span>0.50</span><span>0.75</span><span>1.00</span>
+        </div>
+        <div class="rating-custom-readout" id="ratingCustomReadout"></div>
+        <div class="rating-custom-actions">
+          <button type="button" class="btn" id="ratingCustomReset">Reset to Balanced</button>
+          <span class="muted" style="font-size:11.5px">Drag a star to move the score it needs. Arrow keys nudge by 0.01.</span>
+        </div>
+      </div>
 
 
       <h4 style="margin:12px 0 8px;padding-top:8px;border-top:1px solid #1d2230;color:#a0a8b8;font-size:13px;text-transform:uppercase;letter-spacing:0.5px">Data &amp; Preview</h4>


### PR DESCRIPTION
## Context

The second of the two PRs discussed, and the other half of the culling suggestion in #94:

> Better yet adding an option to categorise stars based on quality score ranges (which should be user defined but also a default like already exists should be present).

> ⚠️ **Stacked on #103.** This branch is cut from `feat/culling-quality-score-cutoff` because it extends the `get_rating_thresholds` bridge method that PR adds. **Merge #103 first**, then this diff reduces to the custom-profile commit alone. Only the second commit (`8fe6213`) belongs to this PR.

The five built-in profiles are fixed cutoffs. A user whose keeper bar sits between `balanced` and `strict` had no way to say so.

## What changed

A sixth profile, **Custom**, whose cutoffs live in a new `rating_thresholds_custom` setting and are edited on a 0.00–1.00 number line in Settings:

- The line paints the five star bands (warming from grey at ★1 to gold at ★5) and puts a **draggable handle on each cutoff**.
- Dragging a handle past a neighbour **pushes the neighbour along** rather than collapsing the band, so every star level stays reachable.
- Handles are real `<button role="slider">` elements: arrow keys nudge by 0.01, shift+arrow by 0.05, Home/End jump to the ends, and each carries `aria-valuenow`.
- The editor shows only while Custom is selected. Switching to Custom **seeds from whichever named profile was previously active**, so you start from what you were already using.
- **Reset to Balanced** restores the defaults.
- Editing cutoffs re-applies normalization to loaded folders immediately — the profile *name* doesn't change when you drag, so the re-apply check compares the values.

## Validation

`ratings.normalize_custom_thresholds` is the guard for these numbers. It accepts anything — a hand-edited `settings.json`, a partial dict, junk — and always returns four cutoffs in `[0, 1]` that are **strictly descending** by at least `MIN_THRESHOLD_GAP`. Two cutoffs collapsing onto one value would make a whole star band unreachable. `settings_utils` normalizes on save rather than trusting the frontend.

**One consistency fix worth flagging.** Named profiles previously resolved through `get_profile_thresholds` in three places. A site left on it would silently fall back to `balanced`, so a custom profile would apply in the Culling Assistant but not in the analysis pipeline. All three — `api_bridge.apply_normalization`, `api_bridge.get_rating_thresholds`, and `pipeline.process_folder` — now go through `ratings.resolve_thresholds`, and a test asserts `get_profile_thresholds` no longer appears in either file.

The frontend carries its own copy of the normalizer so dragging gives live feedback without a round-trip. The two are checked against each other over a shared case set, and aligning them **turned up a real divergence**: `float(True)` is `1.0` in Python while the JS rejected booleans, so a boolean in the setting would have become a 1.00 cutoff on one side and fallen back on the other. Both now treat it as missing.

## Test plan

**Behavioural — headless Chromium against the real `visualizer.html`, 19/19 checks passed:**

- Custom appears in the profile list; editor hidden for named profiles, shown for Custom.
- Four handles seeded from balanced at `85% / 60% / 40% / 15%`; five bands tile the line exactly (`0–15 / 15–40 / 40–60 / 60–85 / 85–100`).
- **Real mouse drag**: pulling ★4 to mid-track lands it at 0.50 and leaves ★5 and ★3 untouched; dragging ★3 to 95% pushes ★4 and ★5 up ahead of it and every cutoff stays ordered and in range.
- Keyboard: arrow nudges 0.01, shift+arrow 0.05. Reset restores balanced.
- Save writes `rating_profile: "custom"` and the exact cutoffs.
- No new page errors.

**Python — new `analyzer/tests/unit/test_custom_rating_profile.py`, 30 tests + 17 subtests:**

- Normalizer: `None`, partial dicts, out-of-order, all-collapsed, all-zero, out-of-range, junk, booleans, numeric strings, non-dict input.
- A **3000-case fuzz sweep** over random floats, out-of-range values, strings, booleans and NaN — every output strictly descending and within `[0, 1]`.
- `test_every_star_band_stays_reachable` sweeps 0.00→1.00 against a fully-collapsed input and asserts `quality_to_rating` still yields all of `{1,2,3,4,5}`.
- `resolve_thresholds` for named / custom / missing / unknown / mixed-case profiles.
- Guards that all three resolution sites handle custom, and that the JS `RATING_MIN_GAP` and key order match the Python constants.

**Cross-language parity** — the JS normalizer's output for a 9-case set is compared against `normalize_custom_thresholds` directly: **0 mismatches**.

**Suites** — `pytest tests/unit tests/security tests/compat` (excluding 6 modules needing `cv2` / `rawpy`): **653 passed, 9 skipped, 0 failed.**

## Note

One pre-existing page error, `checkLegalAgreement is not defined`, fires when `applySettings()` runs in a stubbed harness. I confirmed it reproduces identically on unmodified `dev`, so it is not from this change — but it may be worth a look separately, since it sits in the settings-save path.

---
_Generated by [Claude Code](https://claude.ai/code/session_01E9eNk7oumgSrqC5t2BD2oj)_