### PR TITLE
Don't report an unclean shutdown when a second instance is running

### DIFF
--- a/analyzer/tests/unit/test_session_lifecycle.py
+++ b/analyzer/tests/unit/test_session_lifecycle.py
@@ -17,6 +17,7 @@ try:
     from visualizer import (
         EXIT_REASON_KEY,
         _classify_prior_session,
+        _should_flag_unclean,
     )
 except Exception as e:  # pragma: no cover - environment-dependent
     pytest.skip(f'visualizer module not importable in this env: {e}', allow_module_level=True)
@@ -96,3 +97,55 @@ class TestLegacyMigration:
             'app_session_started_utc': '2026-05-09T12:00:00Z',
         }
         assert _classify_prior_session(settings) == 'os_shutdown'
+
+
+class TestShouldFlagUnclean:
+    """``_should_flag_unclean`` turns a classified prior session plus the
+    liveness of its recorded pid into the "show the recovery dialog"
+    decision. Pure function; ``prev_pid_alive`` is ``None`` when liveness
+    could not be determined."""
+
+    STARTED = '2026-05-09T12:00:00Z'
+    OURS = 4242
+    THEIRS = 1717
+
+    def test_clean_never_flags(self):
+        assert not _should_flag_unclean('clean', self.STARTED, self.THEIRS, False, self.OURS)
+
+    def test_os_shutdown_never_flags(self):
+        # Reboot / logoff is a normal exit, not a crash.
+        assert not _should_flag_unclean('os_shutdown', self.STARTED, self.THEIRS, False, self.OURS)
+
+    def test_no_start_time_never_flags(self):
+        # No evidence a prior session ever ran.
+        assert not _should_flag_unclean('unknown', '', self.THEIRS, False, self.OURS)
+
+    def test_unknown_with_dead_pid_flags(self):
+        # The real unclean shutdown: process is gone and never recorded why.
+        assert _should_flag_unclean('unknown', self.STARTED, self.THEIRS, False, self.OURS)
+
+    def test_unknown_with_undeterminable_pid_flags(self):
+        # Liveness unknown → fall back to the previous behaviour and prompt.
+        assert _should_flag_unclean('unknown', self.STARTED, self.THEIRS, None, self.OURS)
+
+    def test_unknown_with_no_recorded_pid_flags(self):
+        # Installs upgrading from a build that never wrote app_session_pid.
+        assert _should_flag_unclean('unknown', self.STARTED, 0, None, self.OURS)
+
+    def test_unknown_with_live_other_pid_does_not_flag(self):
+        # The false positive this guard exists for: a second instance reading
+        # the still-running first instance's in-flight 'unknown' marker.
+        assert not _should_flag_unclean('unknown', self.STARTED, self.THEIRS, True, self.OURS)
+
+    def test_live_pid_equal_to_ours_still_flags(self):
+        # A recycled pid that happens to equal our own is not evidence of a
+        # concurrent instance — our own process cannot be the prior session.
+        assert _should_flag_unclean('unknown', self.STARTED, self.OURS, True, self.OURS)
+
+    def test_crash_flags_even_with_live_pid(self):
+        # A recorded 'crash' means the top-level handler actually caught an
+        # exception. Surface it regardless of what else is running.
+        assert _should_flag_unclean('crash', self.STARTED, self.THEIRS, True, self.OURS)
+
+    def test_crash_with_dead_pid_flags(self):
+        assert _should_flag_unclean('crash', self.STARTED, self.THEIRS, False, self.OURS)

--- a/analyzer/visualizer.py
+++ b/analyzer/visualizer.py
@@ -315,6 +315,63 @@ def _classify_prior_session(settings: dict) -> str:
     return 'clean'
 
 
+def _is_concurrent_instance(
+    prev_pid: int, prev_pid_alive: Optional[bool], current_pid: int
+) -> bool:
+    """True when the "previous" session's process is still running.
+
+    That is the signature of a second copy of Kestrel starting alongside a
+    live one rather than a relaunch after the first one died. ``prev_pid``
+    is 0 on installs upgrading from a build that never recorded it, and
+    ``prev_pid_alive`` is ``None`` when liveness could not be determined —
+    both are treated as "not concurrent" so the caller keeps its old
+    behaviour.
+    """
+    return bool(prev_pid_alive) and prev_pid > 0 and prev_pid != current_pid
+
+
+def _should_flag_unclean(
+    prev_reason: str,
+    prev_started: str,
+    prev_pid: int,
+    prev_pid_alive: Optional[bool],
+    current_pid: int,
+) -> bool:
+    """Decide whether the prior session should raise the recovery dialog.
+
+    Only 'crash' and 'unknown' are recoverable outcomes: 'os_shutdown' is
+    deliberately suppressed so a reboot or logoff does not look like a crash.
+
+    The concurrent-instance carve-out
+    --------------------------------
+    ``app_session_exit_reason`` is set to 'unknown' for the whole lifetime of
+    a running session and only rewritten at exit. So when a *second* copy of
+    Kestrel launches while the first is still running, it reads the first
+    one's in-flight 'unknown' marker and — before this guard — concluded the
+    "previous" session had died uncleanly, prompting for a crash report
+    seconds after startup with nothing wrong.
+
+    Crash-report log tails show this directly: sessions where the runtime log
+    contains two startup banners and two page loads (two instances appending
+    to the same second-resolution log file) are exactly the sessions that
+    produced a recovery-dialog report, while single-instance sessions on the
+    same install produced none.
+
+    A prior pid that is *still alive* is the signature of that case, so treat
+    it as "not a prior session at all" rather than an unclean shutdown. The
+    carve-out is deliberately limited to 'unknown': a recorded 'crash' means
+    the top-level handler actually ran and caught an exception, which is
+    worth surfacing regardless of what else is running.
+    """
+    if prev_reason not in ('crash', 'unknown') or not prev_started:
+        return False
+    if prev_reason == 'unknown' and _is_concurrent_instance(
+        prev_pid, prev_pid_alive, current_pid
+    ):
+        return False
+    return True
+
+
 def _mark_session_start() -> None:
     """Mark this app session as active and detect unclean prior shutdown.
 
@@ -327,6 +384,10 @@ def _mark_session_start() -> None:
         prev_reason = _classify_prior_session(settings)
         prev_started = str(settings.get('app_session_started_utc', '') or '').strip()
         prev_pid = int(settings.get('app_session_pid', 0) or 0)
+        # True here means the previous session's process is somehow still
+        # running — i.e. this is a second instance starting alongside the
+        # first, not a relaunch after a crash. See _should_flag_unclean.
+        prev_pid_alive = _pid_is_alive(prev_pid)
 
         # Full classification inputs, so a crash-report log tail shows exactly
         # what the detector saw rather than just its verdict.
@@ -336,19 +397,15 @@ def _mark_session_start() -> None:
             classified=prev_reason,
             prev_started=prev_started or "''",
             prev_pid=prev_pid or None,
-            # True here means the previous session's process is somehow still
-            # running — i.e. a second instance is about to overwrite its
-            # bookkeeping. Prime suspect for the false positives.
-            prev_pid_alive=_pid_is_alive(prev_pid),
+            prev_pid_alive=prev_pid_alive,
             legacy_closed_cleanly=settings.get('app_session_closed_cleanly'),
             already_migrated=bool(settings.get(EXIT_REASON_MIGRATION_KEY)),
             last_closed=str(settings.get('last_session_closed_utc', '') or '') or None,
         )
 
-        # Only 'crash' and 'unknown' get surfaced as recoverable unclean
-        # shutdowns. 'os_shutdown' is intentionally suppressed so PC reboots
-        # don't generate false crash dialogs.
-        if prev_reason in ('crash', 'unknown') and prev_started:
+        if _should_flag_unclean(
+            prev_reason, prev_started, prev_pid, prev_pid_alive, os.getpid()
+        ):
             settings['last_unclean_shutdown_utc'] = prev_started
             _log_shutdown_state(
                 'session_start: FLAGGING prior session unclean',
@@ -362,6 +419,14 @@ def _mark_session_start() -> None:
                 'session_start: prior session OK',
                 reason=prev_reason,
                 cleared_stale_flag=had_flag or None,
+                # Set when the recovery prompt was suppressed because the
+                # "previous" session is in fact still running (second
+                # instance). Distinguishes this from a genuinely clean prior
+                # exit in future crash-report log tails.
+                concurrent_instance=True if (
+                    prev_reason in ('crash', 'unknown') and prev_started
+                    and _is_concurrent_instance(prev_pid, prev_pid_alive, os.getpid())
+                ) else None,
             )
         settings['last_exit_reason'] = prev_reason
         settings[EXIT_REASON_MIGRATION_KEY] = True


### PR DESCRIPTION
## Context

Recovery-dialog false positives are the single largest category of incoming crash reports — 167 of the 347 crash reports on record carry the `recovery-dialog` tag, 89 of those explicitly `unclean-shutdown-false-positive`. Every one has an empty traceback, a log tail that looks entirely normal, and no reproducible defect. Up to now they have all been closed as `reviewed`.

The instrumentation added in `5307b33` ("Instrument the clean/unclean shutdown tracker") named a concurrently-running second instance as the prime suspect but deliberately kept it observability-only. This week's reports contain enough evidence to act on that hypothesis.

## Evidence

Three reports arrived within 50 minutes from one Windows install (official Rock Wren build). The install produced four app sessions that day. Counting startup banners and root page loads per runtime log file:

| session | startup banners | root page loads | produced a report? |
|---|---|---|---|
| 1 | 1 | 1 | no |
| 2 | 1 | 1 | no |
| 3 | 2 | 2 | yes |
| 4 | 2 | 2 | yes (x2) |

The doubled sessions contain two complete startup banners and two complete static-asset load sequences one second apart — two processes, both appending to the same runtime log file (the filename is second-resolution, so two launches in the same second collide onto one file). Correlation with the reports is exact: only the doubled sessions produced a recovery prompt.

One of the doubled sessions was launched at `T+0` and the report was submitted 5 seconds later, which matches "dialog appeared immediately at startup", not "something failed during use".

## Root cause

`app_session_exit_reason` is set to `'unknown'` for the entire lifetime of a running session and only rewritten at exit. When a second copy of Kestrel launches while the first is still running:

1. Instance B's `_mark_session_start()` reads instance A's in-flight `'unknown'` marker.
2. `_classify_prior_session()` returns `'unknown'`, which is a recoverable outcome.
3. B sets `last_unclean_shutdown_utc` and the frontend raises the crash-recovery prompt — for a session that is still running normally in another window.

## The fix

`_pid_is_alive()` was already being called at session start, but its result only fed the `[shutdown]` diagnostic line. This wires it into the decision via a new pure helper, `_should_flag_unclean()`.

A prior pid that is *still alive* means this is a second instance, not a relaunch after a death, so the prompt is suppressed. The carve-out is deliberately narrow:

- **`'crash'` still prompts** even alongside a live instance — that value is only written when the top-level handler actually caught an exception, so it is worth surfacing regardless.
- **Undeterminable liveness (`None`)** and **installs with no recorded pid** keep the previous behaviour, so a genuine hard kill, SIGKILL or power loss is still detected.
- **A recorded pid equal to our own** is not treated as concurrent (our own process cannot be the prior session).

The residual risk is pid reuse: if a prior session died hard and the OS recycled its pid onto an unrelated live process, one genuine prompt is missed. That trade is heavily favourable against the current false-positive rate, and the failure mode is a missing prompt rather than a crash.

Suppression is recorded as `concurrent_instance=True` on the existing `session_start: prior session OK` line, so future report log tails distinguish it from a genuinely clean prior exit.

## Testing

- 10 new unit tests in `analyzer/tests/unit/test_session_lifecycle.py` covering the truth table of `_should_flag_unclean` (clean / os_shutdown / crash / unknown x alive / dead / undeterminable / own-pid / no-pid).
- End-to-end check driving the real `_mark_session_start()` against a stubbed settings store with a genuinely live child process as the prior pid: the flag is not written. Control case with the same state but the child killed first: the flag *is* written. Both behave as intended.
- `analyzer/tests/unit` — 638 passed, 3 skipped, 69 subtests passed. (6 modules excluded from collection for missing `cv2`/`pandas`-adjacent deps in this container; none touch this code path.)

## Related finding, not fixed here

`_bind_server_with_fallback()` builds a `ThreadingHTTPServer`, which inherits `allow_reuse_address = 1` from `HTTPServer`. On Windows `SO_REUSEADDR` permits binding a port another socket already holds, so the second instance's bind to `127.0.0.1:8765` succeeds instead of raising `OSError` — the port-fallback path silently never runs, and both instances log the same port (visible in the logs above). Setting `allow_reuse_address = False` on Windows would restore the intended fallback, but it is a separate root cause and is left for a separate change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cxc5s5PZ9vv1n4tDLSsEPf)_