### PR TITLE
Drop stale species labels when an approved scene is split

### DIFF
--- a/analyzer/js/crop-data.js
+++ b/analyzer/js/crop-data.js
@@ -349,12 +349,52 @@
       };
     }
 
-    function _collectCurrentlyVisibleSceneTags(sceneId) {
+    // The species-confidence threshold and secondary-species toggle currently
+    // in effect. Scene tags are derived with these so anything we compute
+    // matches what the grid and the scene dialog are showing right now.
+    function _currentSceneTagSettings() {
       const thresholdEl = el('#speciesConf');
       const confThreshold = thresholdEl ? (parseFloat(thresholdEl.value) || 0) : 0;
       const includeSecondaryCheckbox = document.getElementById('includeSecondarySpecies');
       const includeSecondary = includeSecondaryCheckbox ? includeSecondaryCheckbox.checked : !!getSetting('includeSecondarySpecies', false);
+      return { confThreshold, includeSecondary };
+    }
+
+    function _collectCurrentlyVisibleSceneTags(sceneId) {
+      const { confThreshold, includeSecondary } = _currentSceneTagSettings();
       return _computeSceneTagsFromRows(getSceneRows(sceneId), confThreshold, includeSecondary, true);
+    }
+
+    // Reconcile a finalized scene's stored tags after some of its images have
+    // been moved out (scene split).
+    //
+    // A finalized scene renders `user_tags` verbatim rather than the tags
+    // computed from its rows — see `aggregateScenes` in scenes.js and
+    // `collectSceneSpecies` in scene-dialog.js — so shrinking the scene does
+    // not on its own drop labels that only the departing images justified.
+    //
+    // Only labels we can positively attribute to the departing images are
+    // removed: a label survives if any remaining image still supports it, and
+    // a label no image ever supported (one the user typed in by hand) is left
+    // alone. Returns true when something changed.
+    function _pruneFinalizedSceneTagsAfterRemoval(sceneEntry, remainingRows, removedRows) {
+      const tags = sceneEntry && sceneEntry.user_tags;
+      if (!tags || tags.finalized !== true) return false;
+      const { confThreshold, includeSecondary } = _currentSceneTagSettings();
+      const kept = _computeSceneTagsFromRows(remainingRows || [], confThreshold, includeSecondary, true);
+      const gone = _computeSceneTagsFromRows(removedRows || [], confThreshold, includeSecondary, true);
+      let changed = false;
+      for (const key of ['species', 'families']) {
+        const stillSupported = new Set(kept[key] || []);
+        const departed = new Set(gone[key] || []);
+        const before = Array.isArray(tags[key]) ? tags[key] : [];
+        const after = before.filter(name => stillSupported.has(name) || !departed.has(name));
+        if (after.length !== before.length) {
+          tags[key] = after;
+          changed = true;
+        }
+      }
+      return changed;
     }
 
     function _normalizeScenedataForSave(rp, groupRows) {

--- a/analyzer/js/scene-dialog.js
+++ b/analyzer/js/scene-dialog.js
@@ -2353,10 +2353,16 @@
           const parts2 = String(scene.id).split(':');
           const oldSceneCount = parts2.pop();
           const sd = _initScenedata(rpForSplit);
-          const movedFilenames = sceneRowsBefore.filter(r => _splitSelected.has(r.filename || r.export_path || '')).map(r => r.filename || '').filter(Boolean);
-          const remainFilenames = sceneRowsBefore.filter(r => !_splitSelected.has(r.filename || r.export_path || '')).map(r => r.filename || '').filter(Boolean);
+          const movedRows = sceneRowsBefore.filter(r => _splitSelected.has(r.filename || r.export_path || ''));
+          const remainRows = sceneRowsBefore.filter(r => !_splitSelected.has(r.filename || r.export_path || ''));
+          const movedFilenames = movedRows.map(r => r.filename || '').filter(Boolean);
+          const remainFilenames = remainRows.map(r => r.filename || '').filter(Boolean);
           if (sd.scenes[oldSceneCount]) {
             sd.scenes[oldSceneCount].image_filenames = remainFilenames;
+            // An approved scene shows its stored tags instead of the ones its
+            // rows imply, so without this the original scene keeps species
+            // that only the images we just moved out accounted for.
+            _pruneFinalizedSceneTagsAfterRemoval(sd.scenes[oldSceneCount], remainRows, movedRows);
           }
           sd.scenes[newSceneCount] = {
             scene_id: newSceneCount,


### PR DESCRIPTION
## Context

From a bug report this week (Dusky Grouse, Windows, official build):

> Project Kestrel recognized a scene where two pictures were of a Red-Winged Blackbird and another picture of a Black-Capped Chickadee. It labeled the scene with both types of birds. However, after I split the scene because I wanted the Chickadee picture out of the scene, the scene still had labels for both bird types.

## Root cause

Scene species/family labels have two sources, and the split path only updates one of them.

`aggregateScenes` (`js/scenes.js`) normally derives a scene's labels from its member rows via `_computeSceneTagsFromRows`. But when a scene is **approved** — `user_tags.finalized === true` — it stops computing and renders the stored `user_tags` verbatim:

```js
const isApproved = !!sdScene?.user_tags?.finalized;
if (isApproved) {
  species  = (sdScene.user_tags.species  || []).slice().sort();
  families = (sdScene.user_tags.families || []).slice().sort();
}
```

`collectSceneSpecies` in `js/scene-dialog.js` does the same for the scene dialog.

`applySplitScene` moves the selected images out by reassigning `r.scene_count` and rewriting the original scene's `image_filenames`, but never touches its `user_tags`. For an approved scene the membership changes and the displayed labels do not — so a species whose only image just left stays on the card. Unapproved scenes were already correct, since they recompute from their rows on the next `renderScenes()`.

## The fix

A new helper, `_pruneFinalizedSceneTagsAfterRemoval` in `js/crop-data.js`, reconciles a finalized scene's stored tags against what remains after a split. `applySplitScene` calls it right where it rewrites `image_filenames`.

The prune is deliberately narrow — it only removes labels it can positively attribute to the departing images:

- A label **survives** if any remaining image still supports it (so a species present on both sides of the split is kept).
- A label **no image ever supported** — one the user typed in by hand during scene review — is never touched.
- Support is evaluated with the confidence threshold and secondary-species toggle **currently in effect**, so the result matches what the grid and the dialog are displaying rather than depending on whatever the slider happened to be when the scene was approved.
- Non-finalized scenes are a no-op and return early.

The new scene created by the split keeps its existing behaviour: it starts unapproved with empty `user_tags`, so it displays labels computed from the images that moved into it, which is already correct.

Shared threshold/toggle reading was factored out of `_collectCurrentlyVisibleSceneTags` into `_currentSceneTagSettings()` so both call sites agree; that helper's behaviour is unchanged.

## Testing

The repo has no JS test runner, so this was verified with a standalone Node harness that loads the real helper block out of `analyzer/js/crop-data.js` (rather than a reimplementation) and models the display rule used by `aggregateScenes` / `collectSceneSpecies`. 14 checks, all passing:

- **Reproduction** — approved scene with two Red-winged Blackbird images and one Black-capped Chickadee shows both labels; after the chickadee is split out with no reconciliation, the stale chickadee label persists. This is the reported defect.
- **Fix** — with reconciliation, the original scene shows only Red-winged Blackbird.
- Unapproved scene is left untouched and still computes from its rows.
- A hand-added label with no supporting row survives; the departed label does not.
- A species present on both sides of the split is retained.
- A remaining row below the confidence threshold does not count as support.
- With secondary species enabled, a secondary hit on a remaining image does count as support.
- Families are reconciled the same way as species.
- Null entry, missing `user_tags`, and missing tag arrays all return `false` without throwing.

Also run: `python -m unittest tests.test_security_visualizer_js_xss` — 3 passed (the source-level lint over `analyzer/js/*.js`); `node --check` clean on both modified files.

## Related finding, not fixed here

`executeSelectionMerge` in `js/scene-grid.js` has the mirror-image gap: merging scenes into an **approved** target moves the other scenes' filenames in but leaves the target's finalized `user_tags` alone, so species belonging to the newly absorbed images never appear. Same underlying cause — finalized tags not reconciled when scene membership changes — but the fix there is additive rather than subtractive and raises a separate question about whether automatically adding labels to a scene the user has already signed off on is desirable. Left for a separate change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AvZcmvyCJ1B5g4R14QpuSn)_