### PR TITLE
Add 7/8/9 as alternate Accept/Undecided/Reject keys in scene review

### DIFF
--- a/analyzer/js/scene-dialog.js
+++ b/analyzer/js/scene-dialog.js
@@ -1904,8 +1904,13 @@
             }
           }
           break;
+        // Cull decisions. ZXC is the home-row set; 789 is the right-hand
+        // alternate (top row or numpad with NumLock on), which sits directly
+        // above the 1–5 rating keys on a numpad and keeps the whole review
+        // flow on one hand for left-handed mouse users.
         case 'z':
         case 'Z':
+        case '7':
           e.preventDefault();
           if (images[currentImageIndex]) {
             setCullStatus(images[currentImageIndex], 'accept');
@@ -1914,6 +1919,7 @@
           break;
         case 'x':
         case 'X':
+        case '8':
           e.preventDefault();
           if (images[currentImageIndex]) {
             setCullStatus(images[currentImageIndex], '');
@@ -1922,6 +1928,7 @@
           break;
         case 'c':
         case 'C':
+        case '9':
           e.preventDefault();
           if (images[currentImageIndex]) {
             setCullStatus(images[currentImageIndex], 'reject');

--- a/analyzer/visualizer.html
+++ b/analyzer/visualizer.html
@@ -371,9 +371,9 @@
         <span><kbd>Enter</kbd> Promote active crop</span>
         <span><kbd>Tab</kbd> Next scene</span>
         <span><kbd>Shift</kbd>+<kbd>Tab</kbd> or <kbd>Ctrl</kbd>/<kbd>Cmd</kbd>+<kbd>Tab</kbd> Previous scene</span>
-        <span><kbd>Z</kbd> Accept</span>
-        <span><kbd>X</kbd> Reset</span>
-        <span><kbd>C</kbd> Reject</span>
+        <span><kbd>Z</kbd> or <kbd>7</kbd> Accept</span>
+        <span><kbd>X</kbd> or <kbd>8</kbd> Reset</span>
+        <span><kbd>C</kbd> or <kbd>9</kbd> Reject</span>
         <span><kbd>1</kbd>–<kbd>5</kbd> Rate</span>
         <span><kbd>Space</kbd> Open in editor</span>
         <span><kbd>M1</kbd> RAW Zoom (Scroll to zoom in/out)</span>
@@ -437,9 +437,9 @@
           <div class="scene-info-stars" id="sceneInfoStars"></div>
           <div class="scene-info-quality" id="sceneInfoQuality">—</div>
           <div class="scene-cull-toggle" id="sceneCullToggle">
-            <button class="cull-btn accept" data-cull="accept" title="Accept (Z)">✓ Accept</button>
-            <button class="cull-btn unrated" data-cull="none" title="Reset (X)">Undecided</button>
-            <button class="cull-btn reject" data-cull="reject" title="Reject (C)">✗ Reject</button>
+            <button class="cull-btn accept" data-cull="accept" title="Accept (Z or 7)">✓ Accept</button>
+            <button class="cull-btn unrated" data-cull="none" title="Reset (X or 8)">Undecided</button>
+            <button class="cull-btn reject" data-cull="reject" title="Reject (C or 9)">✗ Reject</button>
           </div>
           <div class="scene-info-meta" id="sceneInfoMeta">
             <span class="scene-info-meta-text" id="sceneInfoMetaText">—</span>


### PR DESCRIPTION
## What

Binds `7` / `8` / `9` as alternates for **Accept** / **Undecided** / **Reject** in the scene-review dialog, alongside the existing `Z` / `X` / `C`.

## Why

A user reported that `ZXC` sits on the left of the keyboard, which is the mouse hand for left-handed photographers — so every cull decision means moving the hand across. Other culling tools (e.g. DxO PhotoLab) offer `789` for the same three decisions. On a numpad, `789` also sits directly above the `1`–`5` rating keys that Kestrel already binds, so the whole review flow — cull decision *plus* star rating — lands under one hand.

The reporter's first preference was fully user-remappable shortcuts; that's a larger piece of work (a settings surface, persistence, conflict validation) and is left for a separate decision. This implements their explicitly-stated fallback.

## Changes

- `analyzer/js/scene-dialog.js` — `_sceneKeyHandler`: `case '7'` / `'8'` / `'9'` added to the existing accept / reset / reject branches.
- `analyzer/visualizer.html` — keyboard-shortcut legend now reads `Z or 7` / `X or 8` / `C or 9`; the Accept / Undecided / Reject button tooltips match.

## Notes / safety

- `Z` / `X` / `C` are unchanged — this is purely additive.
- No other scene-dialog binding uses `7`, `8`, or `9`; ratings are `1`–`5` only.
- The new cases match on `e.key`, so they fire for top-row digits and for numpad digits **with NumLock on**. With NumLock off the numpad emits `Home` / `ArrowUp` / `PageUp`, which keep their current navigation behaviour — no regression there.
- The Culling Assistant (`analyzer/culling.html`) has no `ZXC` bindings, so nothing to mirror.

## Testing

`node --check` on the modified JS; change reviewed by inspection. No automated UI test harness exists for the scene dialog.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BPyy97WGmAm5cDXqrza215)_