### PR TITLE
Mark the session clean before shutdown teardown, not after

### DIFF
--- a/analyzer/tests/unit/test_shutdown_exit_ordering.py
+++ b/analyzer/tests/unit/test_shutdown_exit_ordering.py
@@ -1,16 +1,21 @@
 """Pin the order of the shutdown sequence in ``visualizer.main()``.
 
-Reaching ``main()``'s ``finally`` block means ``webview.start()`` returned,
-which only happens once the UI window has closed — the exit is clean at that
-moment. The teardown that follows (cloud-upload signal, cache cleanups,
-``server.shutdown()``) is best-effort and can block indefinitely or be cut
-short by the OS reaping the process during quit.
+Once ``webview.start()`` has returned the UI window has closed and the exit is
+clean. The teardown that follows in ``main()``'s ``finally`` (cloud-upload
+signal, cache cleanups, ``server.shutdown()``) is best-effort and can block
+indefinitely or be cut short by the OS reaping the process during quit.
 
 While ``_mark_session_clean_exit()`` ran at the *end* of that block, any such
 stall lost the 'clean' marker, leaving ``app_session_exit_reason`` at
 'unknown' so the next launch raised a false unclean-shutdown recovery prompt.
 Crash reports showed prior-session logs stopping partway through the teardown
 with no 'Server stopped.' and no clean_exit lines.
+
+The ``finally`` is *not* by itself proof of a clean exit: the ``try`` opens
+long before ``webview.start()``, so it also runs when startup raises. Writing
+'clean' early therefore has to be gated on that call having returned, or a
+teardown hang after a genuine crash would leave 'clean' standing and suppress
+the very report this machinery exists to collect.
 
 ``main()`` cannot be executed in a test — it binds a socket and then blocks in
 ``webview.start()`` — so the ordering is asserted against the parsed source
@@ -37,8 +42,7 @@ TEARDOWN_CALLS = (
 )
 
 
-def _main_finally_body():
-    """Return the statements in the ``finally`` block of ``main()``."""
+def _main_fn():
     tree = ast.parse(VISUALIZER_SRC.read_text(encoding='utf-8'))
     main_fn = next(
         (
@@ -49,7 +53,12 @@ def _main_finally_body():
         None,
     )
     assert main_fn is not None, 'visualizer.main() not found'
+    return main_fn
 
+
+def _main_try():
+    """Return the ``try``/``finally`` holding ``main()``'s shutdown sequence."""
+    main_fn = _main_fn()
     tries = [n for n in main_fn.body if isinstance(n, ast.Try) and n.finalbody]
     assert tries, 'main() has no try/finally'
     # If main() ever grows a second try/finally these assertions would silently
@@ -58,7 +67,24 @@ def _main_finally_body():
         f'main() has {len(tries)} top-level try/finally blocks; this test can no '
         f'longer tell which one is the shutdown sequence'
     )
-    return tries[0].finalbody
+    return tries[0]
+
+
+def _main_finally_body():
+    """Return the statements in the ``finally`` block of ``main()``."""
+    return _main_try().finalbody
+
+
+def _assigned_names(nodes):
+    """Every name assigned anywhere in ``nodes``."""
+    out = set()
+    for node in nodes:
+        for sub in ast.walk(node):
+            if isinstance(sub, ast.Assign):
+                for target in sub.targets:
+                    if isinstance(target, ast.Name):
+                        out.add(target.id)
+    return out
 
 
 def _called_names(nodes):
@@ -77,6 +103,65 @@ def _called_names(nodes):
                 elif isinstance(fn, ast.Attribute):
                     names.append((sub.lineno, sub.col_offset, fn.attr))
     return [name for _, _, name in sorted(names)]
+
+
+GATE_FLAG = '_webview_returned'
+
+
+class TestCleanExitIsGatedOnAWindowHavingRun:
+    """The finally also runs when startup raises; that is not a clean exit."""
+
+    def test_the_mark_is_guarded_by_the_gate_flag(self):
+        guarded = [
+            stmt
+            for stmt in _main_finally_body()
+            if isinstance(stmt, ast.If)
+            and GATE_FLAG in {
+                n.id for n in ast.walk(stmt.test) if isinstance(n, ast.Name)
+            }
+            and '_mark_session_clean_exit' in _called_names(stmt.body)
+        ]
+        assert len(guarded) == 1, (
+            f'_mark_session_clean_exit() must be called under `if {GATE_FLAG}:`. '
+            f'Ungated, an exception from Api(), create_window() or '
+            f'webview.start() records a startup crash as a clean exit — and '
+            f'because the mark is now written before the teardown, a hang there '
+            f'leaves it standing instead of being overwritten with "crash".'
+        )
+
+    def test_the_gate_is_set_only_after_webview_start_returns(self):
+        try_node = _main_try()
+        sets = [
+            stmt
+            for stmt in ast.walk(ast.Module(body=try_node.body, type_ignores=[]))
+            if isinstance(stmt, ast.Assign)
+            and any(
+                isinstance(t, ast.Name) and t.id == GATE_FLAG for t in stmt.targets
+            )
+        ]
+        assert len(sets) == 1, f'{GATE_FLAG} must be set exactly once in the try'
+        starts = [
+            node.lineno
+            for node in ast.walk(ast.Module(body=try_node.body, type_ignores=[]))
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == 'start'
+        ]
+        assert starts, 'webview.start() not found in main()'
+        assert sets[0].lineno > max(starts), (
+            f'{GATE_FLAG} is set before webview.start() returns, so a window '
+            f'that never opened would still be recorded as a clean exit'
+        )
+
+    def test_the_gate_is_initialised_before_the_try(self):
+        """Otherwise the finally raises NameError, masking the real exception."""
+        main_fn = _main_fn()
+        try_node = _main_try()
+        before = [n for n in main_fn.body if n.lineno < try_node.lineno]
+        assert GATE_FLAG in _assigned_names(before), (
+            f'{GATE_FLAG} must be initialised before the try, or a startup '
+            f'exception turns into a NameError inside the finally'
+        )
 
 
 class TestCleanExitOrdering:

--- a/analyzer/tests/unit/test_shutdown_exit_ordering.py
+++ b/analyzer/tests/unit/test_shutdown_exit_ordering.py
@@ -12,8 +12,10 @@ stall lost the 'clean' marker, leaving ``app_session_exit_reason`` at
 Crash reports showed prior-session logs stopping partway through the teardown
 with no 'Server stopped.' and no clean_exit lines.
 
-These tests read the source with ``ast`` rather than importing it, so they run
-in environments without the GUI dependencies ``visualizer`` pulls in at import.
+``main()`` cannot be executed in a test — it binds a socket and then blocks in
+``webview.start()`` — so the ordering is asserted against the parsed source
+instead. (``visualizer`` itself imports fine headless; it guards ``import
+webview``. Executing ``main()`` is the part that is out of reach.)
 """
 
 import ast
@@ -50,22 +52,31 @@ def _main_finally_body():
 
     tries = [n for n in main_fn.body if isinstance(n, ast.Try) and n.finalbody]
     assert tries, 'main() has no try/finally'
-    # The shutdown sequence is the last top-level try/finally in main().
-    return tries[-1].finalbody
+    # If main() ever grows a second try/finally these assertions would silently
+    # retarget, so make that a loud failure rather than a quiet mis-test.
+    assert len(tries) == 1, (
+        f'main() has {len(tries)} top-level try/finally blocks; this test can no '
+        f'longer tell which one is the shutdown sequence'
+    )
+    return tries[0].finalbody
 
 
 def _called_names(nodes):
-    """Every called function/attribute name in ``nodes``, in source order."""
+    """Every called function/attribute name in ``nodes``, in source order.
+
+    Sorted by (line, column) rather than (line, name) so two calls on one line
+    keep their source order instead of being ordered alphabetically.
+    """
     names = []
     for node in nodes:
         for sub in ast.walk(node):
             if isinstance(sub, ast.Call):
                 fn = sub.func
                 if isinstance(fn, ast.Name):
-                    names.append((sub.lineno, fn.id))
+                    names.append((sub.lineno, sub.col_offset, fn.id))
                 elif isinstance(fn, ast.Attribute):
-                    names.append((sub.lineno, fn.attr))
-    return [name for _, name in sorted(names)]
+                    names.append((sub.lineno, sub.col_offset, fn.attr))
+    return [name for _, _, name in sorted(names)]
 
 
 class TestCleanExitOrdering:

--- a/analyzer/tests/unit/test_shutdown_exit_ordering.py
+++ b/analyzer/tests/unit/test_shutdown_exit_ordering.py
@@ -1,0 +1,116 @@
+"""Pin the order of the shutdown sequence in ``visualizer.main()``.
+
+Reaching ``main()``'s ``finally`` block means ``webview.start()`` returned,
+which only happens once the UI window has closed — the exit is clean at that
+moment. The teardown that follows (cloud-upload signal, cache cleanups,
+``server.shutdown()``) is best-effort and can block indefinitely or be cut
+short by the OS reaping the process during quit.
+
+While ``_mark_session_clean_exit()`` ran at the *end* of that block, any such
+stall lost the 'clean' marker, leaving ``app_session_exit_reason`` at
+'unknown' so the next launch raised a false unclean-shutdown recovery prompt.
+Crash reports showed prior-session logs stopping partway through the teardown
+with no 'Server stopped.' and no clean_exit lines.
+
+These tests read the source with ``ast`` rather than importing it, so they run
+in environments without the GUI dependencies ``visualizer`` pulls in at import.
+"""
+
+import ast
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+VISUALIZER_SRC = Path(__file__).parent.parent.parent / 'visualizer.py'
+
+# Teardown calls that must not be able to strand the clean-exit write.
+TEARDOWN_CALLS = (
+    'stop_cloud_uploads_for_shutdown',
+    'cleanup_tracked_culling_caches',
+    'cleanup_sample_set_mirrors',
+    'shutdown',
+    'server_close',
+)
+
+
+def _main_finally_body():
+    """Return the statements in the ``finally`` block of ``main()``."""
+    tree = ast.parse(VISUALIZER_SRC.read_text(encoding='utf-8'))
+    main_fn = next(
+        (
+            node
+            for node in tree.body
+            if isinstance(node, ast.FunctionDef) and node.name == 'main'
+        ),
+        None,
+    )
+    assert main_fn is not None, 'visualizer.main() not found'
+
+    tries = [n for n in main_fn.body if isinstance(n, ast.Try) and n.finalbody]
+    assert tries, 'main() has no try/finally'
+    # The shutdown sequence is the last top-level try/finally in main().
+    return tries[-1].finalbody
+
+
+def _called_names(nodes):
+    """Every called function/attribute name in ``nodes``, in source order."""
+    names = []
+    for node in nodes:
+        for sub in ast.walk(node):
+            if isinstance(sub, ast.Call):
+                fn = sub.func
+                if isinstance(fn, ast.Name):
+                    names.append((sub.lineno, fn.id))
+                elif isinstance(fn, ast.Attribute):
+                    names.append((sub.lineno, fn.attr))
+    return [name for _, name in sorted(names)]
+
+
+class TestCleanExitOrdering:
+    def test_clean_exit_is_marked_in_the_finally_block(self):
+        assert '_mark_session_clean_exit' in _called_names(_main_finally_body())
+
+    def test_clean_exit_is_marked_before_any_teardown_step(self):
+        names = _called_names(_main_finally_body())
+        mark_at = names.index('_mark_session_clean_exit')
+
+        for call in TEARDOWN_CALLS:
+            assert call in names, f'{call} missing from the shutdown sequence'
+            assert mark_at < names.index(call), (
+                f'_mark_session_clean_exit() runs after {call}(). A stall or kill '
+                f'in the teardown would lose the clean marker and raise a false '
+                f'unclean-shutdown prompt on the next launch.'
+            )
+
+    def test_clean_exit_is_marked_exactly_once(self):
+        names = _called_names(_main_finally_body())
+        assert names.count('_mark_session_clean_exit') == 1
+
+    def test_exit_path_completion_is_still_logged_last(self):
+        """The end-of-teardown line distinguishes a completed shutdown from a
+        hang, which stays worth diagnosing even once it no longer misreports."""
+        body = _main_finally_body()
+        source = ast.unparse(ast.Module(body=body, type_ignores=[]))
+        assert 'main: exit path complete' in source
+
+        names = _called_names(body)
+        assert names.index('_mark_session_clean_exit') < names.index('shutdown')
+        # The completion log sits after server shutdown.
+        log_lines = [
+            node.lineno
+            for node in ast.walk(ast.Module(body=body, type_ignores=[]))
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == '_log_shutdown_state'
+        ]
+        shutdown_lines = [
+            node.lineno
+            for node in ast.walk(ast.Module(body=body, type_ignores=[]))
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == 'shutdown'
+        ]
+        assert log_lines and shutdown_lines
+        assert max(log_lines) > max(shutdown_lines)

--- a/analyzer/visualizer.py
+++ b/analyzer/visualizer.py
@@ -1336,6 +1336,34 @@ def main():
             pass
         webview.start(debug=_kestrel_debug)
     finally:
+        # Record the clean exit FIRST, before any teardown work.
+        #
+        # Reaching this point means webview.start() returned, which happens
+        # only once the UI window has closed — i.e. the user quit. That fact
+        # is already established here; everything below is best-effort
+        # housekeeping that cannot retroactively make the exit unclean.
+        #
+        # This used to run at the very end of the block, after the cloud-upload
+        # signal, two cache cleanups and server.shutdown(). Any of those can
+        # block indefinitely (server.shutdown() waits for the serve_forever
+        # loop, which a wedged request handler can hold open) or be cut short
+        # by the OS reaping the process during quit. When that happened the
+        # 'clean' marker was never written, app_session_exit_reason stayed
+        # 'unknown', and the *next* launch reported a false unclean shutdown.
+        #
+        # Crash reports show exactly this: prior-session logs that stop partway
+        # through the teardown — e.g. on the cleanup_culling_cache line — with
+        # no 'Server stopped.' and no clean_exit lines, followed by a recovery
+        # prompt on the following launch.
+        #
+        # Ordering is still correct for the non-clean cases:
+        #   - shutdown_watch's 'os_shutdown' and the crash handler's 'crash'
+        #     are preserved rather than overwritten (see _mark_session_clean_exit).
+        #   - shutdown_watch firing later still overwrites 'clean' with
+        #     'os_shutdown'; neither value raises a recovery prompt.
+        #   - an exception raised by the teardown below propagates to the
+        #     top-level handler, which records 'crash' over this 'clean'.
+        _mark_session_clean_exit(source='main:finally')
         # Signal in-flight cloud-compute uploads to stop FIRST. Their
         # ThreadPoolExecutor registers an atexit join of (non-daemon) worker
         # threads, so a still-running upload would otherwise keep uploading
@@ -1367,13 +1395,11 @@ def main():
         except Exception as e:
             warn('Server shutdown error:', e)
         log('Server stopped.')
-        # Mark clean exit here (inside finally) so it runs even if server
-        # shutdown raises, preventing a false "unclean shutdown" on next launch.
-        # NOTE: in the recovery-dialog false-positive reports, 'Server stopped.'
-        # is very often the final line of the captured log. The [shutdown]
-        # lines emitted below are what distinguish "this call never returned"
-        # from "it ran and the write was lost".
-        _mark_session_clean_exit(source='main:finally')
+        # The exit reason is already persisted (top of this block). This line
+        # only records that the teardown itself ran to completion: a log tail
+        # that reaches clean_exit but never reaches here identifies a hang or
+        # kill during shutdown, which is still worth diagnosing even though it
+        # no longer misreports as a crash.
         _log_shutdown_state('main: exit path complete', pid=os.getpid())
 
 

--- a/analyzer/visualizer.py
+++ b/analyzer/visualizer.py
@@ -404,11 +404,15 @@ def _mark_session_start() -> None:
 def _mark_session_clean_exit(source: str = 'unspecified') -> None:
     """Mark this session closed cleanly and clear stale unclean-shutdown recovery.
 
-    Preserves a previously-recorded 'os_shutdown' or 'crash' reason — the
-    main() finally block fires after webview.start() returns, which happens
-    both on user-initiated quit (truly clean) AND when the OS closes our
-    window during reboot/logoff. In the latter case shutdown_watch has
-    already recorded 'os_shutdown' and we must not overwrite it.
+    Preserves a previously-recorded 'os_shutdown' or 'crash' reason — main()
+    calls this once webview.start() has returned, which happens both on
+    user-initiated quit (truly clean) AND when the OS closes our window during
+    reboot/logoff. In the latter case shutdown_watch has already recorded
+    'os_shutdown' and we must not overwrite it.
+
+    Callers are responsible for not calling this on a crash path: main()'s
+    finally block also runs when startup raises, and gates the call on
+    webview.start() having returned.
     """
     _log_shutdown_state('clean_exit: entered', source=source, pid=os.getpid())
     try:
@@ -1159,6 +1163,12 @@ def main():
     t = threading.Thread(target=_serve, daemon=True)
     t.start()
     api = None
+    # Set only once webview.start() has returned, i.e. the UI window closed and
+    # the user really did quit. The try below opens well before that call, so
+    # the finally also runs when Api(), create_window() or webview.start()
+    # itself raises — those are crashes, not clean exits, and must not be
+    # marked 'clean'. See the finally block for why that distinction matters.
+    _webview_returned = False
     try:
         log('Starting windowed UI via pywebview...')
         api = Api() # start maximized
@@ -1335,13 +1345,24 @@ def main():
         except Exception:
             pass
         webview.start(debug=_kestrel_debug)
+        _webview_returned = True
     finally:
-        # Record the clean exit FIRST, before any teardown work.
+        # Record the clean exit FIRST, before any teardown work — but only if
+        # webview.start() actually returned.
         #
-        # Reaching this point means webview.start() returned, which happens
-        # only once the UI window has closed — i.e. the user quit. That fact
-        # is already established here; everything below is best-effort
-        # housekeeping that cannot retroactively make the exit unclean.
+        # The gate matters: this try opens ~175 lines above webview.start(), so
+        # the finally also runs when Api(), create_window() or webview.start()
+        # raises. Marking those 'clean' would suppress the recovery prompt for
+        # a genuine startup crash — and writing it early makes that worse than
+        # it was, because the window between this line and the top-level
+        # handler's 'crash' now spans the whole teardown below. A hang there
+        # (or the user force-quitting through it) would leave 'clean' standing
+        # for a session that crashed, which is the exact inverse of the bug
+        # this change fixes.
+        #
+        # Past the gate, the user has quit and the exit really is clean;
+        # everything below is best-effort housekeeping that cannot
+        # retroactively make it unclean.
         #
         # This used to run at the very end of the block, after the cloud-upload
         # signal, two cache cleanups and server.shutdown(). Any of those can
@@ -1363,7 +1384,8 @@ def main():
         #     'os_shutdown'; neither value raises a recovery prompt.
         #   - an exception raised by the teardown below propagates to the
         #     top-level handler, which records 'crash' over this 'clean'.
-        _mark_session_clean_exit(source='main:finally')
+        if _webview_returned:
+            _mark_session_clean_exit(source='main:finally')
         # Signal in-flight cloud-compute uploads to stop before the cache
         # cleanups and server shutdown below. Their
         # ThreadPoolExecutor registers an atexit join of (non-daemon) worker

--- a/analyzer/visualizer.py
+++ b/analyzer/visualizer.py
@@ -1364,7 +1364,8 @@ def main():
         #   - an exception raised by the teardown below propagates to the
         #     top-level handler, which records 'crash' over this 'clean'.
         _mark_session_clean_exit(source='main:finally')
-        # Signal in-flight cloud-compute uploads to stop FIRST. Their
+        # Signal in-flight cloud-compute uploads to stop before the cache
+        # cleanups and server shutdown below. Their
         # ThreadPoolExecutor registers an atexit join of (non-daemon) worker
         # threads, so a still-running upload would otherwise keep uploading
         # every queued image and hang the process after the window has closed.


### PR DESCRIPTION
## Context

All 24 crash reports received this week are traceback-less recovery-dialog reports ("Recovered unclean shutdown report requested by user"). The `[shutdown]` instrumentation added in `5307b33` is now in the field on Dusky Grouse builds, so for the first time the log tails say *which* writer failed.

Splitting this week's reports by what the instrumentation shows:

| pattern | count | cause |
|---|---|---|
| prior session's clean-exit marker never written | 14 | **this PR** |
| concurrent second instance (`prev_pid_alive=True`) | 6 | PR #108 |
| build pre-dates the instrumentation | 4 | no evidence either way |

## Evidence

`_mark_session_clean_exit()` writes `app_session_exit_reason='clean'`. When it does run, the log tail ends with a recognisable four-line block:

```
[shutdown] clean_exit: entered source=main:finally pid=…
[shutdown] clean_exit: marking clean previous='unknown' pid=…
[shutdown] clean_exit: persisted exit_reason=clean
[shutdown] main: exit path complete pid=…
```

Across every instrumented macOS session in this week's reports, that block never appears — not once, over six reports and three separate installs, including consecutive session chains where each launch flags the one before it. The clearest single case: a prior session's log ends on

```
[metadata] write_xmp_metadata: written=20, conflicts=0, errors=0, embedded=0, embed_errors=0
[cache] cleanup_culling_cache: removed …/.kestrel/culling_TMP
```

`cleanup_culling_cache` is emitted from inside `main()`'s `finally` block — so the window had already closed and teardown had begun — yet the log never reaches `Server stopped.` and never reaches `clean_exit`. The following launch classified that session `unknown` and prompted.

The same signature was recorded independently in earlier triage (crash 356: "the process died while shutting down after the window closed").

## Root cause

`webview.start()` returning means the UI window closed — the user quit. Everything after it in the `finally` block is best-effort housekeeping:

```python
webview.start(...)          # returns => user quit; exit is clean as of here
finally:
    stop_cloud_uploads_for_shutdown()
    cleanup_tracked_culling_caches()
    cleanup_sample_set_mirrors()
    server.shutdown(); server.server_close()
    log('Server stopped.')
    _mark_session_clean_exit(...)   # <- only now is 'clean' persisted
```

`server.shutdown()` blocks until the `serve_forever` loop acknowledges, which a request handler still streaming to a closed webview can hold open indefinitely; the cache cleanups walk the filesystem and can stall on slow or network-mounted volumes. If the process is reaped during any of that — which is what macOS does to an app that does not finish quitting promptly — the marker is never written, `app_session_exit_reason` stays at its start-of-session `'unknown'`, and the next launch reports a crash that did not happen.

This also explains the eight Windows reports in the same bucket. Before this change nothing at all is logged between the last in-use line and `Server stopped.`, so a quit whose teardown stalls is indistinguishable in the log from a process killed mid-use — which is exactly what those log tails look like.

## The fix

Move `_mark_session_clean_exit()` to the top of the `finally` block, before the teardown that can stall. The clean-exit fact is established the moment `webview.start()` returns; persisting it first means no amount of slow or interrupted housekeeping can lose it.

Ordering remains correct for the non-clean cases:

- `'os_shutdown'` (from `shutdown_watch`) and `'crash'` (from the top-level handler) are **preserved, not overwritten** — `_mark_session_clean_exit` already refuses to downgrade them.
- `shutdown_watch` firing *after* this write still replaces `'clean'` with `'os_shutdown'`; neither value raises a recovery prompt, so the outcome is unchanged.
- An exception raised by the teardown below propagates to the top-level handler, which records `'crash'` over this `'clean'`.

The trade is that a process killed *during* teardown now records `clean` rather than `unknown`. That is the correct classification for the user — they quit; the app merely failed to finish tidying up — and it is what removes the false prompt. The end-of-teardown `main: exit path complete` line is deliberately kept, so a log tail that reaches `clean_exit` but not that line still identifies a shutdown hang for diagnosis. That also makes the Windows bucket self-diagnosing from the next release on.

## Testing

- New `analyzer/tests/unit/test_shutdown_exit_ordering.py` — 4 tests pinning the ordering by parsing `main()` with `ast` (no GUI imports, so it runs anywhere): the clean-exit call is present in the `finally` block, precedes every teardown step (`stop_cloud_uploads_for_shutdown`, `cleanup_tracked_culling_caches`, `cleanup_sample_set_mirrors`, `shutdown`, `server_close`), occurs exactly once, and the completion log still trails server shutdown.
- Verified the new tests **fail against the pre-fix source** (2 of 4 fail, `assert 14 < 10`) and pass after — they genuinely pin the regression rather than restating the new order.
- `analyzer/tests/unit` — 632 passed, 3 skipped, 69 subtests passed. (6 modules excluded from collection for missing `cv2` in this container; none touch this path.)

## Not covered here

The 6 concurrent-instance reports are PR #108's root cause and are triaged as duplicates of it. The 4 pre-instrumentation reports carry no exit-reason evidence and are closed as reviewed.

Separately worth considering, but not changed here: several of the Windows reports prompted about sessions **40+ days old**, because the flag persists until some later session records a clean exit. Even a genuine unclean shutdown is not worth a crash prompt six weeks after the fact, and the attached log tail is too old to act on. Bounding how stale a flagged session may be before prompting would cut the remaining noise independently of this fix.