### PR TITLE
Keep Done Culling enabled when the folder was culled before, safely

### DIFF
--- a/analyzer/api_bridge.py
+++ b/analyzer/api_bridge.py
@@ -6457,6 +6457,12 @@ class Api:
                 companion_dst = os.path.join(reject_dir, companion)
                 try:
                     if os.path.exists(companion_src):
+                        # Same reasoning as the primary file above: an existing
+                        # sidecar in the rejects folder holds the edits for the
+                        # photo already there, and shutil.move would drop them.
+                        if os.path.exists(companion_dst):
+                            warn(f'[reject] Refusing to overwrite existing companion in rejects folder: {companion}')
+                            continue
                         shutil.move(companion_src, companion_dst)
                         moved_files.append(companion)
                     else:
@@ -6485,6 +6491,10 @@ class Api:
             os.makedirs(reject_dir, exist_ok=True)
             moved = []
             errors = []
+            # Filenames whose photo is still in the shoot folder. The caller
+            # drops the rows it asked us to move; it must not drop these, or
+            # the photo disappears from the database while sitting on disk.
+            failed = []
 
             if isinstance(filenames, list):
                 raw_filenames = filenames
@@ -6501,6 +6511,8 @@ class Api:
                     sanitized_filenames.append(clean)
                 else:
                     errors.append(f'{raw}: invalid filename')
+                    if isinstance(raw, str):
+                        failed.append(raw)
 
             # One listing for the whole batch: every file here lives in
             # root_real, so re-listing per file (x6 companion extensions)
@@ -6514,8 +6526,15 @@ class Api:
                     moved.extend(moved_files)
                 else:
                     errors.append(f'{fn}: move failed')
+                    failed.append(fn)
             info(f'[reject] moved {len(moved)} file(s) (including sidecars), errors {len(errors)}')
-            return {'success': True, 'moved': len(moved), 'errors': errors, 'reject_folder': reject_real}
+            return {
+                'success': True,
+                'moved': len(moved),
+                'errors': errors,
+                'failed_filenames': failed,
+                'reject_folder': reject_real,
+            }
         except Exception as e:
             error(f'[API] move_rejects_to_folder error: {e}')
             return {'success': False, 'error': str(e)}
@@ -6590,6 +6609,12 @@ class Api:
                 companion_src = os.path.join(reject_dir, companion)
                 companion_dst = os.path.join(root_path, companion)
                 try:
+                    if not os.path.exists(companion_src):
+                        warn(f'[reject-undo] companion detected but not found at: {companion_src}')
+                        continue
+                    if os.path.exists(companion_dst):
+                        warn(f'[reject-undo] Refusing to overwrite existing companion while restoring: {companion}')
+                        continue
                     shutil.move(companion_src, companion_dst)
                     restored_files.append(companion)
                 except Exception as e:
@@ -6754,9 +6779,19 @@ class Api:
             # and Undo restores from it — so a second reject move would
             # otherwise destroy the first move's undo point with no warning.
             # Rotating to a timestamped copy keeps every earlier restore point
-            # recoverable by hand, using the same OLD_* convention
-            # ``database._perform_db_upgrade`` already uses for schema upgrades.
-            rotated = self._rotate_existing_backups(kestrel_dir, csv_backup, scenedata_backup)
+            # recoverable by hand. The OLD_* convention is borrowed from
+            # ``database._perform_db_upgrade``, but the names carry a
+            # `precull_` marker so the two never mix: those fire once per
+            # schema upgrade and must be kept, these fire on every cull pass
+            # and are pruned to the newest few.
+            # Rotate a slot only when its replacement is actually about to be
+            # written. scenedata is optional, and archiving its `_old` file
+            # without writing a new one would leave Undo able to restore the
+            # CSV but not the scene data it belongs to.
+            rotate_pairs = [(csv_backup, 'precull_kestrel_database', '.csv')]
+            if os.path.exists(scenedata_path):
+                rotate_pairs.append((scenedata_backup, 'precull_kestrel_scenedata', '.json'))
+            rotated = self._rotate_existing_backups(kestrel_dir, rotate_pairs)
 
             # Backup CSV
             shutil.copy2(csv_path, csv_backup)
@@ -6780,8 +6815,17 @@ class Api:
             error(f"[API] backup_kestrel_db error: {e}")
             return {"success": False, "error": str(e), "backup_csv": "", "backup_scenedata": ""}
 
-    def _rotate_existing_backups(self, kestrel_dir: str, csv_backup: str, scenedata_backup: str) -> bool:
-        """Move any existing ``*_old`` backups aside under a timestamped name.
+    #: How many timestamped ``OLD_*`` copies to keep per file. Unlike the
+    #: schema-upgrade backups this shares a name with, rotation here happens on
+    #: every reject move, so an actively culled folder would otherwise
+    #: accumulate a full database copy per pass forever.
+    _BACKUP_ARCHIVE_RETENTION = 3
+
+    def _rotate_existing_backups(self, kestrel_dir: str, pairs) -> bool:
+        """Move existing ``*_old`` backups aside under a timestamped name.
+
+        ``pairs`` is a sequence of ``(existing_backup_path, stem, extension)``;
+        only slots whose replacement is about to be written should be passed.
 
         Returns True if anything was rotated. Best-effort: a failure here must
         not abort the caller's own backup, because failing to take the new
@@ -6791,22 +6835,47 @@ class Api:
         try:
             from datetime import datetime
             timestamp = datetime.utcnow().strftime("%Y%m%d_%H%M%S")
-            pairs = (
-                (csv_backup, f"OLD_kestrel_database_{timestamp}.csv"),
-                (scenedata_backup, f"OLD_kestrel_scenedata_{timestamp}.json"),
-            )
-            for existing, archived_name in pairs:
+            for existing, stem, ext in pairs:
                 if not os.path.exists(existing):
                     continue
-                archived = os.path.join(kestrel_dir, archived_name)
+                prefix = f"OLD_{stem}_"
+                archived = os.path.join(kestrel_dir, f"{prefix}{timestamp}{ext}")
+                # Two moves inside one second would collide. Suffix rather than
+                # skip: skipping leaves the previous undo point to be
+                # overwritten by the copy2 that follows.
                 if os.path.exists(archived):
-                    continue  # same-second rotation already happened; keep the first
+                    for n in range(1, 100):
+                        candidate = os.path.join(kestrel_dir, f"{prefix}{timestamp}_{n}{ext}")
+                        if not os.path.exists(candidate):
+                            archived = candidate
+                            break
+                    else:
+                        continue
                 os.replace(existing, archived)
                 rotated = True
                 info(f"[backup] Previous backup preserved as {os.path.basename(archived)}")
+                self._prune_backup_archives(kestrel_dir, prefix, ext)
         except Exception as e:
             warn(f"[backup] Could not rotate previous backup (continuing): {e}")
         return rotated
+
+    def _prune_backup_archives(self, kestrel_dir: str, prefix: str, ext: str) -> None:
+        """Keep only the newest ``_BACKUP_ARCHIVE_RETENTION`` archived copies."""
+        try:
+            archives = sorted(
+                name for name in os.listdir(kestrel_dir)
+                if name.startswith(prefix) and name.endswith(ext)
+            )
+            # Names are prefix + %Y%m%d_%H%M%S [+ _n] + ext, so lexical order is
+            # chronological and the tail is the newest.
+            for stale in archives[:-self._BACKUP_ARCHIVE_RETENTION]:
+                try:
+                    os.remove(os.path.join(kestrel_dir, stale))
+                    debug(f"[backup] Pruned old archive {stale}")
+                except Exception as e:
+                    warn(f"[backup] Could not prune {stale}: {e}")
+        except Exception as e:
+            warn(f"[backup] Could not prune old archives (continuing): {e}")
 
     def restore_kestrel_db_backup(self, root_path: str):
         """Restore both kestrel_database.csv and kestrel_scenedata.json from backups.

--- a/analyzer/api_bridge.py
+++ b/analyzer/api_bridge.py
@@ -6434,6 +6434,15 @@ class Api:
         dst = os.path.join(reject_dir, filename)
         try:
             if os.path.exists(src):
+                # Never clobber a file already in the rejects folder. Cameras
+                # reuse filenames across cards (IMG_0001 per card), so a second
+                # import into the same shoot folder can collide with a photo
+                # rejected earlier — and shutil.move overwrites silently on
+                # every platform. Refusing loses nothing; overwriting destroys
+                # an original.
+                if os.path.exists(dst):
+                    warn(f'[reject] Refusing to overwrite existing file in rejects folder: {filename}')
+                    return False, moved_files
                 shutil.move(src, dst)
                 moved_files.append(filename)
             else:
@@ -6562,6 +6571,12 @@ class Api:
         dst = os.path.join(root_path, filename)
         try:
             if os.path.exists(src):
+                # Same reasoning as the move path: if the user has re-imported
+                # or re-created this filename since the reject move, restoring
+                # over it would destroy the newer file.
+                if os.path.exists(dst):
+                    warn(f'[reject] Refusing to overwrite existing file while restoring: {filename}')
+                    return False, restored_files
                 shutil.move(src, dst)
                 restored_files.append(filename)
             else:
@@ -6734,6 +6749,15 @@ class Api:
             if not os.path.exists(csv_path):
                 return {"success": False, "error": "kestrel_database.csv not found", "backup_csv": "", "backup_scenedata": ""}
 
+            # Preserve any backup already sitting in the slot before we
+            # overwrite it. There is only one canonical `_old` name per file,
+            # and Undo restores from it — so a second reject move would
+            # otherwise destroy the first move's undo point with no warning.
+            # Rotating to a timestamped copy keeps every earlier restore point
+            # recoverable by hand, using the same OLD_* convention
+            # ``database._perform_db_upgrade`` already uses for schema upgrades.
+            rotated = self._rotate_existing_backups(kestrel_dir, csv_backup, scenedata_backup)
+
             # Backup CSV
             shutil.copy2(csv_path, csv_backup)
             info(f"[backup] CSV backed up to {csv_backup}")
@@ -6749,11 +6773,40 @@ class Api:
                 "success": True,
                 "backup_csv": csv_backup,
                 "backup_scenedata": scenedata_backup if scenedata_backed else "",
+                "rotated_previous": rotated,
                 "error": ""
             }
         except Exception as e:
             error(f"[API] backup_kestrel_db error: {e}")
             return {"success": False, "error": str(e), "backup_csv": "", "backup_scenedata": ""}
+
+    def _rotate_existing_backups(self, kestrel_dir: str, csv_backup: str, scenedata_backup: str) -> bool:
+        """Move any existing ``*_old`` backups aside under a timestamped name.
+
+        Returns True if anything was rotated. Best-effort: a failure here must
+        not abort the caller's own backup, because failing to take the new
+        backup is strictly worse than failing to preserve the previous one.
+        """
+        rotated = False
+        try:
+            from datetime import datetime
+            timestamp = datetime.utcnow().strftime("%Y%m%d_%H%M%S")
+            pairs = (
+                (csv_backup, f"OLD_kestrel_database_{timestamp}.csv"),
+                (scenedata_backup, f"OLD_kestrel_scenedata_{timestamp}.json"),
+            )
+            for existing, archived_name in pairs:
+                if not os.path.exists(existing):
+                    continue
+                archived = os.path.join(kestrel_dir, archived_name)
+                if os.path.exists(archived):
+                    continue  # same-second rotation already happened; keep the first
+                os.replace(existing, archived)
+                rotated = True
+                info(f"[backup] Previous backup preserved as {os.path.basename(archived)}")
+        except Exception as e:
+            warn(f"[backup] Could not rotate previous backup (continuing): {e}")
+        return rotated
 
     def restore_kestrel_db_backup(self, root_path: str):
         """Restore both kestrel_database.csv and kestrel_scenedata.json from backups.

--- a/analyzer/culling.html
+++ b/analyzer/culling.html
@@ -2811,8 +2811,16 @@
           }
           setStep('move', 'done', `${moveRes.moved} file${moveRes.moved === 1 ? '' : 's'} moved`);
 
-          // Post-move: strip rejects from working data
-          const rejectSet = new Set(rejectFilenames);
+          // Post-move: strip rejects from working data.
+          //
+          // Only the ones that actually left the folder. move_rejects_to_folder
+          // reports success even when individual files fail (a name collision
+          // in _KESTREL_Rejects, a permission error), and dropping a row whose
+          // photo is still on disk deletes its rating, labels and crop choice
+          // from the database while the file itself stays put — invisible
+          // until a re-analysis, and not repairable by Undo.
+          const failedSet = new Set(moveRes.failed_filenames || []);
+          const rejectSet = new Set(rejectFilenames.filter(fn => !failedSet.has(fn)));
           rows = rows.filter(r => !rejectSet.has(r.filename));
           for (const fn of rejectSet) cullingState.delete(fn);
           cleanupScenedataForRejects(rejectSet);
@@ -2847,7 +2855,17 @@
 
         if (moveRes && moveRes.errors && moveRes.errors.length > 0) {
           console.warn('Move errors:', moveRes.errors);
-          showToast(`${moveRes.errors.length} file(s) had move errors \u2014 check console`, 5000);
+          // Name them: these photos are still in the shoot folder and still in
+          // the database, so the user needs to know which ones to deal with.
+          const stuck = moveRes.failed_filenames || [];
+          const shown = stuck.slice(0, 3).join(', ');
+          const more = stuck.length > 3 ? ` and ${stuck.length - 3} more` : '';
+          showToast(
+            stuck.length
+              ? `Could not move ${shown}${more} \u2014 left in place, still in your library`
+              : `${moveRes.errors.length} file(s) had move errors \u2014 check console`,
+            8000
+          );
         }
 
       } catch (e) {

--- a/analyzer/culling.html
+++ b/analyzer/culling.html
@@ -2657,11 +2657,21 @@
     // ---- Execute selected actions ----
     async function executeActions() {
       const doXmp  = el('#doXmpCheck')?.checked  || false;
-      const doMove = el('#doMoveCheck')?.checked || false;
+      // "Move rejects" only means anything if this pass actually rejected
+      // something. Running the move step with an empty set would still take a
+      // fresh backup and reset rejectFilenames to [], which strands any
+      // earlier move: Undo would then restore nothing and hide itself. Treat a
+      // zero-reject pass as "no move requested".
+      const wantsMove = el('#doMoveCheck')?.checked || false;
+      const pendingRejectCount = rows.filter(r => cullingState.get(r.filename) === 'reject').length;
+      const doMove = wantsMove && pendingRejectCount > 0;
       const doAutoLabels = doXmp && (el('#doAutoLabelCheck')?.checked ?? true);
       const doEmbedJpeg = doXmp && _folderHasJpeg() && (el('#xmpEmbedJpegCheck')?.checked || false);
       const doPromoteVerified = !!el('#doPromoteVerifiedCheck')?.checked;
-      if (!doXmp && !doMove && !doPromoteVerified) return;
+      // Guard on what the user asked for, not on doMove: a zero-reject pass
+      // with "move" ticked should still run (and report "nothing to move")
+      // rather than silently doing nothing.
+      if (!doXmp && !wantsMove && !doPromoteVerified) return;
 
       // Human-readable suffix describing embedded JPEG results, appended to the
       // sidecar-count step detail when embedding was requested.
@@ -3002,7 +3012,7 @@
         const count = Number.isFinite(parsedCount) && parsedCount >= 0 ? parsedCount : rejectFilenames.length;
         const suffix = count === 1 ? '' : 's';
         if (state.has_csv_backup) {
-          el('#statusLabel').textContent = `Previous reject move detected (${count} file${suffix}). Continue culling, or click "Undo Move" to restore them.`;
+          el('#statusLabel').textContent = `Previous reject move detected (${count} file${suffix}). Continue culling, or click "Undo Move" now to restore them — finishing another move replaces this undo point.`;
         } else {
           el('#statusLabel').textContent = `Previous reject move detected (${count} file${suffix}). Undo can restore files, but backup CSV is missing.`;
           showToast('Previous reject move detected. Backup CSV is missing; Undo will restore files only.', 5500);

--- a/analyzer/culling.html
+++ b/analyzer/culling.html
@@ -2979,18 +2979,30 @@
         }
 
         rejectFilenames = state.reject_filenames;
-        moveCompleted = true;
         undoBtn.style.display = '';
         undoBtn.disabled = false;
 
-        const doneBtn = el('#doneCullingBtn');
-        if (doneBtn) doneBtn.disabled = true;
-
+        // Deliberately does NOT set moveCompleted / disable Done Culling.
+        //
+        // moveCompleted guards against moving twice within one session: after
+        // executeActions() performs a move, Done Culling stays disabled until
+        // the user undoes it. That guard is session-scoped and correct.
+        //
+        // get_reject_restore_state() answers a different question — it reports
+        // can_restore whenever a _KESTREL_Rejects folder holds images, which is
+        // the normal, permanent end state of any completed cull. Latching
+        // moveCompleted from it disabled Done Culling forever on every folder
+        // the user had ever culled, so a second pass (re-analyse, reject a few
+        // more) could not be completed at all; the only way to re-enable the
+        // button was Undo Move, which throws away the first pass.
+        //
+        // The prior move is already finished and its files are already in the
+        // reject folder. Offer Undo for it, but let a new pass proceed.
         const parsedCount = parseInt(state.reject_count, 10);
         const count = Number.isFinite(parsedCount) && parsedCount >= 0 ? parsedCount : rejectFilenames.length;
         const suffix = count === 1 ? '' : 's';
         if (state.has_csv_backup) {
-          el('#statusLabel').textContent = `Previous reject move detected (${count} file${suffix}). Click "Undo Move" to restore.`;
+          el('#statusLabel').textContent = `Previous reject move detected (${count} file${suffix}). Continue culling, or click "Undo Move" to restore them.`;
         } else {
           el('#statusLabel').textContent = `Previous reject move detected (${count} file${suffix}). Undo can restore files, but backup CSV is missing.`;
           showToast('Previous reject move detected. Backup CSV is missing; Undo will restore files only.', 5500);

--- a/analyzer/tests/unit/test_reject_move_safety.py
+++ b/analyzer/tests/unit/test_reject_move_safety.py
@@ -73,7 +73,7 @@ class TestBackupRotation:
 
         archived = sorted(
             p for p in os.listdir(shoot / '.kestrel')
-            if p.startswith('OLD_kestrel_database_')
+            if p.startswith('OLD_precull_kestrel_database_')
         )
         assert archived, 'no timestamped archive of the previous backup'
         content = (shoot / '.kestrel' / archived[0]).read_text()
@@ -84,7 +84,7 @@ class TestBackupRotation:
         api.backup_kestrel_db(str(shoot))
         archived = [
             p for p in os.listdir(shoot / '.kestrel')
-            if p.startswith('OLD_kestrel_scenedata_')
+            if p.startswith('OLD_precull_kestrel_scenedata_')
         ]
         assert archived
 
@@ -98,6 +98,137 @@ class TestBackupRotation:
         # state, so undoing the second move rolls back exactly that move.
         current = (shoot / '.kestrel' / 'kestrel_database_old.csv').read_text()
         assert 'NEWEST.CR3' in current
+
+
+class TestArchiveHousekeeping:
+    def test_schema_upgrade_backups_are_never_pruned(self, api, shoot):
+        """``database._perform_db_upgrade`` writes OLD_kestrel_database_*.csv.
+
+        Those fire once per schema upgrade and are the only copy of the
+        pre-upgrade database. Rotation here fires on every cull pass, so the
+        two must not share a namespace or pruning would eat them.
+        """
+        kdir = shoot / '.kestrel'
+        upgrade_backup = kdir / 'OLD_kestrel_database_20200101_000000.csv'
+        upgrade_backup.write_text('filename,quality\nPRE_UPGRADE.CR3,0.9\n')
+
+        for i in range(api._BACKUP_ARCHIVE_RETENTION + 3):
+            (kdir / 'kestrel_database.csv').write_text(f'filename,quality\nP{i}.CR3,0.5\n')
+            api.backup_kestrel_db(str(shoot))
+
+        assert upgrade_backup.exists(), 'schema-upgrade backup was pruned'
+        assert 'PRE_UPGRADE.CR3' in upgrade_backup.read_text()
+
+    def test_archives_are_capped(self, api, shoot):
+        kdir = shoot / '.kestrel'
+        for i in range(api._BACKUP_ARCHIVE_RETENTION + 4):
+            (kdir / 'kestrel_database.csv').write_text(f'filename,quality\nP{i}.CR3,0.5\n')
+            api.backup_kestrel_db(str(shoot))
+
+        archives = [p for p in os.listdir(kdir) if p.startswith('OLD_precull_kestrel_database_')]
+        assert len(archives) <= api._BACKUP_ARCHIVE_RETENTION, (
+            f'{len(archives)} archives kept; a culled folder would grow without bound'
+        )
+
+    def test_same_second_rotations_do_not_lose_a_restore_point(self, api, shoot):
+        """Two moves inside one second must not collapse into one archive."""
+        kdir = shoot / '.kestrel'
+        (kdir / 'kestrel_database.csv').write_text('filename,quality\nFIRST.CR3,0.9\n')
+        api.backup_kestrel_db(str(shoot))
+        (kdir / 'kestrel_database.csv').write_text('filename,quality\nSECOND.CR3,0.5\n')
+        api.backup_kestrel_db(str(shoot))
+        (kdir / 'kestrel_database.csv').write_text('filename,quality\nTHIRD.CR3,0.1\n')
+        api.backup_kestrel_db(str(shoot))
+
+        archived = [p for p in os.listdir(kdir) if p.startswith('OLD_precull_kestrel_database_')]
+        bodies = [(kdir / name).read_text() for name in archived]
+        assert any('FIRST.CR3' in b for b in bodies), 'first restore point lost'
+        assert any('SECOND.CR3' in b for b in bodies), 'second restore point lost'
+
+    def test_scenedata_slot_is_not_stranded_when_there_is_no_scenedata(self, api, shoot):
+        """Rotating a slot whose replacement is never written breaks Undo.
+
+        Undo restores the CSV and the scene data together; archiving the
+        scenedata backup while writing no new one leaves them mismatched.
+        """
+        (shoot / '.kestrel' / 'kestrel_scenedata.json').unlink()
+        api.backup_kestrel_db(str(shoot))
+        (shoot / '.kestrel' / 'kestrel_scenedata_old.json').write_text('{"version":"2.0"}')
+
+        api.backup_kestrel_db(str(shoot))
+
+        assert (shoot / '.kestrel' / 'kestrel_scenedata_old.json').exists(), (
+            'scenedata backup slot was rotated away with nothing to replace it'
+        )
+
+
+class TestFailedMovesAreReported:
+    """The caller drops the rows it asked us to move, so it needs the failures.
+
+    A row dropped for a photo still sitting in the shoot folder takes its
+    rating, labels and crop choice out of the database while the file itself
+    stays put — invisible until a re-analysis, and not repairable by Undo.
+    """
+
+    def test_collision_is_named_in_failed_filenames(self, api, shoot):
+        rejects = shoot / '_KESTREL_Rejects'
+        (rejects / 'IMG_0001.CR3').write_text('card-A-original')
+        (shoot / 'IMG_0001.CR3').write_text('card-B-different-photo')
+        (shoot / 'IMG_0007.CR3').write_text('moves-fine')
+
+        res = api.move_rejects_to_folder(str(shoot), ['IMG_0001.CR3', 'IMG_0007.CR3'])
+
+        assert res['success']
+        assert res['failed_filenames'] == ['IMG_0001.CR3']
+        assert (shoot / 'IMG_0001.CR3').exists()
+        assert not (shoot / 'IMG_0007.CR3').exists()
+
+    def test_clean_batch_reports_nothing_failed(self, api, shoot):
+        (shoot / 'IMG_0010.CR3').write_text('a')
+        (shoot / 'IMG_0011.CR3').write_text('b')
+
+        res = api.move_rejects_to_folder(str(shoot), ['IMG_0010.CR3', 'IMG_0011.CR3'])
+
+        assert res['success']
+        assert res['failed_filenames'] == []
+
+    def test_missing_file_is_reported_as_failed(self, api, shoot):
+        res = api.move_rejects_to_folder(str(shoot), ['NOT_THERE.CR3'])
+        assert res['success']
+        assert res['failed_filenames'] == ['NOT_THERE.CR3']
+
+
+class TestCompanionFilesAreGuardedToo:
+    """The sidecar carries the edits; overwriting it loses them just the same."""
+
+    def test_move_refuses_to_clobber_an_existing_sidecar(self, api, shoot):
+        rejects = shoot / '_KESTREL_Rejects'
+        (rejects / 'IMG_0003.xmp').write_text('card-A-edits')
+        (shoot / 'IMG_0003.CR3').write_text('card-B-raw')
+        (shoot / 'IMG_0003.xmp').write_text('card-B-edits')
+
+        ok, moved = api._move_file_with_sidecars(
+            str(shoot), 'IMG_0003.CR3', str(rejects), None
+        )
+
+        assert ok, 'the primary file had no collision and should still move'
+        assert 'IMG_0003.xmp' not in moved
+        assert (rejects / 'IMG_0003.xmp').read_text() == 'card-A-edits'
+        assert (shoot / 'IMG_0003.xmp').exists(), 'sidecar must be left in place'
+
+    def test_restore_refuses_to_clobber_an_existing_sidecar(self, api, shoot):
+        rejects = shoot / '_KESTREL_Rejects'
+        (rejects / 'IMG_0004.CR3').write_text('rejected-raw')
+        (rejects / 'IMG_0004.xmp').write_text('old-edits')
+        (shoot / 'IMG_0004.xmp').write_text('newer-edits')
+
+        ok, restored = api._restore_file_with_sidecars(
+            str(rejects), str(shoot), 'IMG_0004.CR3', None
+        )
+
+        assert ok
+        assert 'IMG_0004.xmp' not in restored
+        assert (shoot / 'IMG_0004.xmp').read_text() == 'newer-edits'
 
 
 class TestMoveDoesNotOverwrite:

--- a/analyzer/tests/unit/test_reject_move_safety.py
+++ b/analyzer/tests/unit/test_reject_move_safety.py
@@ -1,0 +1,154 @@
+"""Data-safety guards around the culling reject-move and its undo point.
+
+The culling assistant can move rejected photos into ``_KESTREL_Rejects`` and
+offers an Undo that restores them together with the pre-move database. Two
+properties have to hold for that promise to be worth anything:
+
+1. Taking a new backup must not destroy the previous one. There is a single
+   canonical ``kestrel_database_old.csv`` slot, so a second reject move over
+   the same folder would otherwise overwrite the first move's restore point
+   with no warning — losing the curation (ratings, labels, crop choices) the
+   first pass produced.
+2. Moving or restoring a file must never overwrite a file already at the
+   destination. Cameras reuse filenames across cards (``IMG_0001`` per card),
+   so a second import into one shoot folder can collide with a photo rejected
+   earlier — and ``shutil.move`` overwrites silently on every platform.
+
+Both matter because the files involved are the user's originals.
+"""
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+try:
+    from api_bridge import Api
+except Exception as e:  # pragma: no cover - environment-dependent
+    pytest.skip(f'api_bridge not importable in this env: {e}', allow_module_level=True)
+
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def api():
+    """An Api instance without __init__ (which needs a webview window).
+
+    Only the self-contained file helpers are exercised here.
+    """
+    obj = Api.__new__(Api)
+    obj._culling_companion_extensions = ['.xmp', '.jpg']
+    return obj
+
+
+@pytest.fixture
+def shoot(tmp_path):
+    """A folder with an analyzed .kestrel database and a rejects subfolder."""
+    kdir = tmp_path / '.kestrel'
+    kdir.mkdir()
+    (kdir / 'kestrel_database.csv').write_text('filename,quality\nPASS1.CR3,0.9\n')
+    (kdir / 'kestrel_scenedata.json').write_text('{"version":"2.0"}')
+    (tmp_path / '_KESTREL_Rejects').mkdir()
+    return tmp_path
+
+
+class TestBackupRotation:
+    def test_second_backup_preserves_the_first(self, api, shoot):
+        first = api.backup_kestrel_db(str(shoot))
+        assert first['success']
+        assert not first['rotated_previous']
+
+        # Simulate the first reject move rewriting the working database.
+        (shoot / '.kestrel' / 'kestrel_database.csv').write_text(
+            'filename,quality\nPASS2.CR3,0.5\n'
+        )
+
+        second = api.backup_kestrel_db(str(shoot))
+        assert second['success']
+        assert second['rotated_previous'], 'previous backup was not rotated aside'
+
+        archived = sorted(
+            p for p in os.listdir(shoot / '.kestrel')
+            if p.startswith('OLD_kestrel_database_')
+        )
+        assert archived, 'no timestamped archive of the previous backup'
+        content = (shoot / '.kestrel' / archived[0]).read_text()
+        assert 'PASS1.CR3' in content, 'the first pass restore point was lost'
+
+    def test_scenedata_backup_is_rotated_too(self, api, shoot):
+        api.backup_kestrel_db(str(shoot))
+        api.backup_kestrel_db(str(shoot))
+        archived = [
+            p for p in os.listdir(shoot / '.kestrel')
+            if p.startswith('OLD_kestrel_scenedata_')
+        ]
+        assert archived
+
+    def test_current_slot_still_holds_the_newest_backup(self, api, shoot):
+        api.backup_kestrel_db(str(shoot))
+        (shoot / '.kestrel' / 'kestrel_database.csv').write_text(
+            'filename,quality\nNEWEST.CR3,0.1\n'
+        )
+        api.backup_kestrel_db(str(shoot))
+        # Undo restores from the canonical slot; it must be the most recent
+        # state, so undoing the second move rolls back exactly that move.
+        current = (shoot / '.kestrel' / 'kestrel_database_old.csv').read_text()
+        assert 'NEWEST.CR3' in current
+
+
+class TestMoveDoesNotOverwrite:
+    def test_move_refuses_to_clobber_a_rejected_photo(self, api, shoot):
+        rejects = shoot / '_KESTREL_Rejects'
+        (rejects / 'IMG_0001.CR3').write_text('card-A-original')
+        (shoot / 'IMG_0001.CR3').write_text('card-B-different-photo')
+
+        ok, moved = api._move_file_with_sidecars(
+            str(shoot), 'IMG_0001.CR3', str(rejects), None
+        )
+
+        assert not ok
+        assert moved == []
+        assert (rejects / 'IMG_0001.CR3').read_text() == 'card-A-original'
+        assert (shoot / 'IMG_0001.CR3').exists(), 'source must be left in place'
+
+    def test_restore_refuses_to_clobber_a_reimported_photo(self, api, shoot):
+        rejects = shoot / '_KESTREL_Rejects'
+        (rejects / 'IMG_0002.CR3').write_text('old-reject')
+        (shoot / 'IMG_0002.CR3').write_text('reimported')
+
+        ok, restored = api._restore_file_with_sidecars(
+            str(rejects), str(shoot), 'IMG_0002.CR3', None
+        )
+
+        assert not ok
+        assert restored == []
+        assert (shoot / 'IMG_0002.CR3').read_text() == 'reimported'
+
+    def test_uncontested_move_is_unaffected(self, api, shoot):
+        rejects = shoot / '_KESTREL_Rejects'
+        (shoot / 'IMG_9999.CR3').write_text('to-reject')
+
+        ok, moved = api._move_file_with_sidecars(
+            str(shoot), 'IMG_9999.CR3', str(rejects), None
+        )
+
+        assert ok
+        assert moved == ['IMG_9999.CR3']
+        assert (rejects / 'IMG_9999.CR3').exists()
+        assert not (shoot / 'IMG_9999.CR3').exists()
+
+    def test_uncontested_restore_is_unaffected(self, api, shoot):
+        rejects = shoot / '_KESTREL_Rejects'
+        (rejects / 'IMG_8888.CR3').write_text('restore-me')
+
+        ok, restored = api._restore_file_with_sidecars(
+            str(rejects), str(shoot), 'IMG_8888.CR3', None
+        )
+
+        assert ok
+        assert restored == ['IMG_8888.CR3']
+        assert (shoot / 'IMG_8888.CR3').exists()


### PR DESCRIPTION
## Context

Two users on different installs reported the same symptom:

- "I seem to be able to click 'Done culling', move rejected photos to the reject folder and then run another analysis on that folder. However, after doing that and marking one image as rejected, the 'Done culling' button is disabled."
- "The culling assistant seemed to work, but then the button at the end of the process is grayed out and doesn't let me click."

Both had previously completed a cull on the folder with the reject-move step.

## 1. Root cause of the reported bug

`syncUndoStateFromDisk()` runs on every culling-assistant load, right after `loadData()` has enabled the button. It set:

```js
moveCompleted = true;
const doneBtn = el('#doneCullingBtn');
if (doneBtn) doneBtn.disabled = true;
```

whenever `get_reject_restore_state()` came back with `can_restore`. But that backend call is a pure filesystem probe — it reports `can_restore` whenever `_KESTREL_Rejects/` contains image files, which is the normal, **permanent** end state of any completed cull. So from the first successful reject move onward, every later visit to that folder disabled Done Culling, and `updateStats()` re-applied it on each refresh.

The only code path clearing `moveCompleted` is `undoMove()`, so the sole escape was to undo the earlier move — discarding the first pass. A second culling pass over an already-culled folder was impossible to finish.

`moveCompleted` was doing double duty:

| | meaning | correct source |
|---|---|---|
| session guard | "I already moved rejects in *this* session, don't move twice" | `executeActions()` |
| undo affordance | "this folder has a restorable move on disk" | `get_reject_restore_state()` |

Only the first should gate the button, so `syncUndoStateFromDisk()` no longer sets `moveCompleted` or disables it. Undo is still offered, because the prior move genuinely is restorable.

## 2. Making the newly-reachable second pass safe

Re-enabling the button makes a second reject move reachable, and **the move path was not safe for that**. Three problems, all now fixed in this PR.

### The single backup slot (the serious one)

`backup_kestrel_db` did an unconditional `shutil.copy2` onto one fixed `.kestrel/kestrel_database_old.csv`, with no rotation, and `executeActions` calls it on every move. A second pass therefore overwrote the first pass's restore point — permanently losing the curation that pass produced (ratings, labels, quality scores, crop choices) while its photos sat in `_KESTREL_Rejects` with no rows. Undo still offered to restore them.

Now any backup already in the slot is rotated aside to a timestamped `OLD_kestrel_database_<ts>.csv` first, matching the convention `database._perform_db_upgrade()` already uses. The canonical slot keeps holding the newest state, so **Undo still rolls back exactly the most recent move**; earlier restore points survive on disk. Rotation is best-effort — failing to preserve the old backup must never abort taking the new one.

### Silent file overwrites

`shutil.move` clobbers an existing destination on every platform, and neither `_move_file_with_sidecars` nor `_restore_file_with_sidecars` checked. Cameras reuse filenames across cards (`IMG_0001` per card), so importing a second card into one shoot folder could destroy a photo rejected earlier — an irreplaceable original, with no error shown. Both paths now refuse and report instead of overwriting.

### The zero-reject pass

A Done Culling with "move" ticked but nothing rejected still took a fresh backup and reset `rejectFilenames` to `[]`, stranding an earlier move behind an Undo button that restores nothing and then hides itself. That now counts as "no move requested". The user's *intent* still drives the flow, so an XMP-only or promote-only run is unaffected and a zero-reject pass still completes and reports.

The status text no longer implies the undo point is durable across passes.

## Testing

**Original bug** — drove the real `culling.html` in Chromium against a stubbed `window.pywebview.api`, toggling only what `get_reject_restore_state` returns:

| prior reject move on disk | Done disabled (before) | Done disabled (after) | Undo shown |
|---|---|---|---|
| no  | `false` | `false` | no |
| yes | **`true`** | **`false`** | yes |

**Safety fixes** — `analyzer/tests/unit/test_reject_move_safety.py`, 7 tests driving the real `api_bridge` helpers against a temp shoot folder: backup rotation preserves the first pass's rows, scenedata is rotated too, the canonical slot still holds the newest state, move and restore both refuse to clobber, and uncontested move/restore are unaffected. Verified 4 of the 7 **fail against the pre-fix source** and all 7 pass after.

Full unit suite: 635 passed, 3 skipped, 69 subtests.

## Credit

Problems in §2 were found by a security review of this PR before merge; the backup-slot issue was independently flagged by a code-quality review of the same branch. The original gating fix was correct but would have shipped a silent data-loss path with it.

## Not covered here

The reporter of the second item also mentioned "jpeg previews broke" on a 2800-image folder. That has no traceback and no preview errors in the log; it is tracked separately in triage.