### PR TITLE
Move the shift-click anchor with keyboard grid navigation

### DIFF
--- a/analyzer/js/scene-grid.js
+++ b/analyzer/js/scene-grid.js
@@ -783,6 +783,11 @@
       e.preventDefault();
 
       if (isEnter) {
+        // Mirror the mouse path: opening a scene by click also moves the
+        // shift-click anchor (see the card click handler), so opening one by
+        // keyboard must too, or the anchor is left behind at whichever card
+        // was last clicked.
+        _lastSelectedIdx = _visibleSceneOrder.indexOf(String(_focusedCardId));
         openSceneDialog(_focusedCardId);
         return;
       }
@@ -815,7 +820,18 @@
       }
 
       if (nextIdx >= 0 && nextIdx < cards.length) {
-        _focusGridCard(cards[nextIdx].dataset.sceneId);
+        const nextId = cards[nextIdx].dataset.sceneId;
+        _focusGridCard(nextId);
+        // Keep the shift-click anchor with the focused card. Without this,
+        // arrowing across the grid leaves _lastSelectedIdx wherever the last
+        // mouse click happened, and the next Shift+Click selects everything
+        // between that stale card and the clicked one rather than starting a
+        // fresh range from where the user actually is.
+        //
+        // Safe against clobbering a range selection: this handler returns
+        // early while selectedSceneIds is non-empty, so arrow keys never move
+        // the anchor mid-selection.
+        _lastSelectedIdx = _visibleSceneOrder.indexOf(String(nextId));
       }
     }
     document.addEventListener('keydown', _gridKeyHandler);


### PR DESCRIPTION
## Context

User report this week:

> when navigating with arrow keys + enter key and going into scenes, I might get through many scenes no issues. Then I get to a set of scenes I want to combine. It appears like when I shift click, there is some behavior where it's still storing/remembering a previous selection x number of scenes away. It causes me to unselect the scenes, and then redo the clicks as expected and it functions just fine.

## Root cause

`analyzer/js/scene-grid.js` keeps `_lastSelectedIdx` as the anchor for Shift+Click range selection. The card click handler updates it on every mouse path:

```js
if (ev.ctrlKey || ev.metaKey) { …; _lastSelectedIdx = _visibleSceneOrder.indexOf(sid); … }
if (selectedSceneIds.size > 0)  { …; _lastSelectedIdx = _visibleSceneOrder.indexOf(sid); … }
// Normal: open scene dialog
_lastSelectedIdx = _visibleSceneOrder.indexOf(sid);
openSceneDialog(sid);
```

Keyboard navigation does not. `_gridKeyHandler` moves focus with `_focusGridCard(...)`, which sets `_focusedCardId` and the `.focused` class and nothing else, and Enter calls `openSceneDialog(...)` directly.

So a user who clicks one scene with the mouse, then arrows away across the grid opening scenes with Enter, still has the anchor sitting on that first clicked card. Their next Shift+Click selects everything from there to the clicked card — "a previous selection x number of scenes away" — rather than starting a fresh range from where they are. Doing the clicks again works because the first click of the redo re-anchors.

This matches the report's detail that it happens after arrow+Enter navigation and that redoing the clicks fixes it.

## The fix

Set the anchor alongside the focus:

- on arrow movement, next to `_focusGridCard(nextId)`
- on Enter, mirroring the mouse path that opens a scene

Two safety notes, both captured in comments:

- **It cannot clobber an in-progress range selection.** `_gridKeyHandler` returns early while `selectedSceneIds.size > 0`, so arrow keys never move the anchor mid-selection.
- **The anchor is deliberately not set inside `_focusGridCard()`.** The card click handler calls `_focusGridCard(sid)` on line 420, immediately *before* the `ev.shiftKey && _lastSelectedIdx >= 0` branch reads the anchor on line 421. Putting the assignment in the shared helper would overwrite the anchor just before it is used and break Shift+Click entirely.

## Testing

**Verified by code inspection only — no automated repro.** `scene-grid.js` is a plain script evaluated in the full visualizer page scope (it closes over `sceneGrid`, `selectedSceneIds`, `_visibleSceneOrder`, `openSceneDialog` and others), so exercising it means booting the whole app with a populated scene grid rather than a standalone harness like the one used for `culling.html`. I did not build that, so this PR rests on reading the two code paths rather than on a demonstrated before/after.

Checked: the file parses, and `_visibleSceneOrder.indexOf(...)` is the same idiom the three existing anchor assignments use, over the array built at render time in the same order as the DOM cards `_getVisibleCards()` returns.

Manual repro worth running before merge:

1. Open a folder with a few dozen scenes.
2. Click one scene near the top, close the dialog.
3. Arrow-key down to a scene well below it, opening a couple with Enter along the way.
4. Shift+Click a nearby scene.

Before: the selection stretches back to the scene clicked in step 2. After: it spans only from the arrow-focused card to the clicked one.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tr2P9YYSFTTUS6WW3Y6Tnu)_