### PR TITLE
Represent the user's decisions in the scene grid

### DIFF
--- a/analyzer/js/csv-init.js
+++ b/analyzer/js/csv-init.js
@@ -92,13 +92,30 @@
     if (zoomInBtn) zoomInBtn.addEventListener('click', () => { uiZoom = Math.min(1.4, uiZoom + 0.1); applyZoom(); });
     if (zoomOutBtn) zoomOutBtn.addEventListener('click', () => { uiZoom = Math.max(0.7, uiZoom - 0.1); applyZoom(); });
 
-    // Initialize toolbar toggle for scene-level manual-reviewed filter
-    (function initScenesManualFilter() {
-      const t = document.getElementById('filterScenesManualRated');
+    // Initialize the scene-level review-state filter (all / reviewed / unreviewed).
+    (function initSceneReviewStateFilter() {
+      const t = document.getElementById('filterSceneReviewState');
       if (!t) return;
-      try { t.checked = !!getSetting('onlyManualRatedScenes', false); } catch { }
+      const VALID = ['all', 'reviewed', 'unreviewed'];
+      try {
+        let mode = getSetting('sceneReviewFilter', null);
+        // Migrate the superseded boolean. This used to be a single
+        // "Only manually reviewed scenes" checkbox; an existing install that
+        // had it ticked should land on 'reviewed' rather than silently
+        // reverting to showing everything.
+        if (!VALID.includes(mode)) {
+          mode = getSetting('onlyManualRatedScenes', false) ? 'reviewed' : 'all';
+        }
+        t.value = mode;
+      } catch { t.value = 'all'; }
       t.addEventListener('change', () => {
-        const s = loadSettings(); s.onlyManualRatedScenes = !!t.checked; saveSettings(s);
+        const mode = VALID.includes(t.value) ? t.value : 'all';
+        const s = loadSettings();
+        s.sceneReviewFilter = mode;
+        // Keep the legacy key consistent so an older build reading these
+        // settings still behaves sensibly.
+        s.onlyManualRatedScenes = (mode === 'reviewed');
+        saveSettings(s);
         renderScenes();
       });
     })();

--- a/analyzer/js/scene-dialog.js
+++ b/analyzer/js/scene-dialog.js
@@ -6,6 +6,10 @@
       for (const r of rows) { if (r.culled === undefined) r.culled = ''; }
     }
 
+    // Set whenever a cull decision changes while the scene dialog is open;
+    // consumed once on close to refresh the grid behind it.
+    let _sceneCullDecisionsChanged = false;
+
     function getCullStatus(row) {
       const raw = (row.culled === 'accept' || row.culled === 'reject') ? row.culled : '';
       if (!raw) return '';
@@ -24,6 +28,12 @@
       row.culled = status || ''; // 'accept', 'reject', or ''
       row.culled_origin = status ? 'manual' : '';
       markDirty(row);
+      // The grid thumbnail is chosen from the user's accept/reject decisions
+      // (see _pickSceneRepresentative), so the card behind this dialog is now
+      // potentially stale. Re-rendering per keystroke would be far too costly
+      // on a large folder, so just record that the grid owes a refresh and let
+      // the dialog-close handler do it once.
+      _sceneCullDecisionsChanged = true;
     }
 
     async function _blobUrlToBlob(url) {
@@ -516,6 +526,20 @@
         _showSceneCropOverlay(r, cropState.activeIndex, 1000);
       }
     }
+
+    // Repaint the grid once, on close, if cull decisions changed while the
+    // dialog was open. Navigating between scenes with the dialog still open
+    // closes and reopens it, so the flag is only cleared once the dialog is
+    // actually gone.
+    sceneDlg?.addEventListener('close', () => {
+      if (!_sceneCullDecisionsChanged) return;
+      // Scene-to-scene navigation closes and immediately reopens the dialog.
+      // The close event is queued, so by the time it runs the next scene may
+      // already be showing -- leave the flag set and refresh on the real close.
+      if (sceneDlg.open) return;
+      _sceneCullDecisionsChanged = false;
+      renderScenes();
+    });
 
     // Allow other code to refresh the scene images when filter or ratings change
     window.refreshSceneFilter = function () {

--- a/analyzer/js/scene-grid.js
+++ b/analyzer/js/scene-grid.js
@@ -69,7 +69,8 @@
       const minC = parseFloat(el('#speciesConf').value) || 0;
       const search = el('#search').value;
       const sortBy = el('#sortBy').value;
-      const onlyReviewedScenes = !!document.getElementById('filterScenesManualRated')?.checked;
+      const reviewStateFilter = document.getElementById('filterSceneReviewState')?.value
+        || getSetting('sceneReviewFilter', 'all');
       const groupByFolder = document.getElementById('groupByFolder')?.checked ?? getSetting('groupByFolder', true);
       const groupByTime = document.getElementById('groupByTime')?.checked ?? getSetting('groupByTime', true);
       const showBirdThumbs = document.getElementById('showBirdThumbs')?.checked ?? getSetting('showBirdThumbs', false);
@@ -90,12 +91,17 @@
         if (refreshed) _currentScene = refreshed;
       }
 
-      // Apply scene-level manual-reviewed filter without mutating global scenes.
+      // Apply the scene-level review-state filter without mutating global scenes.
       // Reviewed means any of:
       //  - scene tags finalized by user, or scene renamed by user
       //  - manual/verified accept-reject culling decision on any image
       //  - manual star rating on any image
-      const visibleScenes = onlyReviewedScenes ? scenes.filter(isManuallyReviewedScene) : scenes;
+      // 'unreviewed' is the exact complement: scenes carrying no user-assigned
+      // trait at all, i.e. the ones that still need work.
+      const visibleScenes =
+        reviewStateFilter === 'reviewed' ? scenes.filter(isManuallyReviewedScene)
+        : reviewStateFilter === 'unreviewed' ? scenes.filter(s => !isManuallyReviewedScene(s))
+        : scenes;
 
       // Batched hydration of bird-catalog records for every species pill we're
       // about to paint when the show-scientific-names toggle is on. Collect
@@ -409,6 +415,14 @@
         const countEl = document.createElement('span');
         countEl.className = 'meta-count';
         countEl.textContent = `📸 ${s.imageCount}`;
+        // Break the count down on hover rather than on the tile: the split is
+        // useful when triaging but not worth the visual weight on every card.
+        if (s.cullCounts) {
+          const { accepted, rejected, undecided } = s.cullCounts;
+          countEl.title = accepted || rejected
+            ? `${accepted} accepted · ${undecided} undecided · ${rejected} rejected`
+            : `${s.imageCount} image${s.imageCount === 1 ? '' : 's'}, none decided yet`;
+        }
         meta.appendChild(countEl);
         metaRow.appendChild(meta);
 

--- a/analyzer/js/scenes.js
+++ b/analyzer/js/scenes.js
@@ -18,6 +18,44 @@
         && scene.images.some(r => isManualRated(r) || isManualCullDecision(r));
     }
 
+    /** Highest-quality row in ``pool``; ties keep the earliest, as before. */
+    function _bestByQuality(pool) {
+      let best = null;
+      for (const r of pool) {
+        if (best === null || parseNumber(r.quality) > parseNumber(best.quality)) best = r;
+      }
+      return best;
+    }
+
+    /** Count manual accept / reject / undecided decisions across a scene's rows. */
+    function _cullCounts(arr) {
+      let accepted = 0, rejected = 0;
+      for (const r of arr) {
+        const status = getCullStatus(r);
+        if (status === 'accept') accepted++;
+        else if (status === 'reject') rejected++;
+      }
+      return { accepted, rejected, undecided: arr.length - accepted - rejected };
+    }
+
+    /**
+     * Pick the scene thumbnail so it reflects the user's decisions, not just
+     * raw quality. In order: the best accepted photo; else the best photo the
+     * user has not rejected; else -- every photo was rejected -- the best of
+     * those.
+     *
+     * Only manual decisions count. getCullStatus() already returns '' for
+     * auto-culled rows, so a scene the user has not touched picks exactly the
+     * representative it always did.
+     */
+    function _pickSceneRepresentative(arr) {
+      const accepted = arr.filter(r => getCullStatus(r) === 'accept');
+      if (accepted.length) return _bestByQuality(accepted);
+      const notRejected = arr.filter(r => getCullStatus(r) !== 'reject');
+      if (notRejected.length) return _bestByQuality(notRejected);
+      return _bestByQuality(arr) || arr[0];
+    }
+
     function aggregateScenes(minSpeciesConf, searchTerm, sortBy, includeSecondary, includeFamilies) {
       const groups = new Map();
       for (const r of rows) {
@@ -29,9 +67,10 @@
 
       const list = [];
       for (const [sceneId, arr] of groups) {
-        // representative by max quality
-        let rep = arr[0];
-        for (const r of arr) if (parseNumber(r.quality) > parseNumber(rep.quality)) rep = r;
+        // Representative: best accepted, else best non-rejected, else best
+        // overall. See _pickSceneRepresentative.
+        const rep = _pickSceneRepresentative(arr);
+        const cullCounts = _cullCounts(arr);
 
         const computedTags = _computeSceneTagsFromRows(arr, minSpeciesConf, includeSecondary, includeFamilies);
         let species = computedTags.species.slice().sort();
@@ -56,6 +95,7 @@
           images: arr.slice().sort((a, b) => parseNumber(b.quality) - parseNumber(a.quality)),
           representative: rep,
           imageCount: arr.length,
+          cullCounts,
           species,
           families,
           maxQuality: maxQ,

--- a/analyzer/tests/unit/test_scene_review_state.py
+++ b/analyzer/tests/unit/test_scene_review_state.py
@@ -1,0 +1,152 @@
+"""Tests for scene review state: thumbnail choice and the review-state filter.
+
+The scene thumbnail is picked from the user's own accept/reject decisions
+(best accepted, else best non-rejected, else best overall) rather than from raw
+quality alone, and the grid can be filtered to reviewed or unreviewed scenes.
+
+Both halves live in ``analyzer/js`` and the repo has no JS test runner, so these
+are source-level lints in the spirit of ``test_raw_warn_banner.py`` and
+``test_culling_quality_cutoff.py``. Behavioural coverage — the full tier
+priority table, auto-cull rows being ignored, tie-breaking, the cull counts and
+the reviewed/unreviewed predicate — was verified by evaluating the real
+``scenes.js`` source in a Node harness; see the PR description.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+_THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+_ANALYZER_DIR = os.path.dirname(os.path.dirname(_THIS_DIR))
+
+_SCENES_JS = os.path.join(_ANALYZER_DIR, 'js', 'scenes.js')
+_SCENE_GRID_JS = os.path.join(_ANALYZER_DIR, 'js', 'scene-grid.js')
+_CSV_INIT_JS = os.path.join(_ANALYZER_DIR, 'js', 'csv-init.js')
+_VISUALIZER_HTML = os.path.join(_ANALYZER_DIR, 'visualizer.html')
+
+
+def _read(path: str) -> str:
+    with open(path, 'r', encoding='utf-8') as fh:
+        return fh.read()
+
+
+class TestRepresentativeSelection(unittest.TestCase):
+    """The thumbnail must reflect the user's decisions, in priority order."""
+
+    def setUp(self):
+        self.src = _read(_SCENES_JS)
+
+    def test_helper_exists_and_is_used_by_aggregate(self):
+        self.assertIn('function _pickSceneRepresentative', self.src)
+        self.assertIn('_pickSceneRepresentative(arr)', self.src)
+
+    def test_no_longer_picks_purely_by_quality(self):
+        # The superseded implementation walked every row comparing quality and
+        # ignored cull state entirely.
+        self.assertNotIn(
+            "for (const r of arr) if (parseNumber(r.quality) > parseNumber(rep.quality)) rep = r;",
+            self.src,
+        )
+
+    def test_tiers_are_ordered_accepted_then_non_rejected(self):
+        body = self.src.split('function _pickSceneRepresentative', 1)[1]
+        body = body.split('\n    }', 1)[0]
+        accept_at = body.find("=== 'accept'")
+        reject_at = body.find("!== 'reject'")
+        self.assertGreater(accept_at, -1, 'no accepted tier')
+        self.assertGreater(reject_at, -1, 'no non-rejected tier')
+        self.assertLess(
+            accept_at, reject_at,
+            'accepted photos must be preferred over merely non-rejected ones',
+        )
+
+    def test_uses_manual_only_cull_status(self):
+        # getCullStatus() returns '' for auto-culled rows, so an untouched
+        # scene keeps the representative it always had. Using the raw column
+        # would let the auto-culler change thumbnails behind the user's back.
+        body = self.src.split('function _pickSceneRepresentative', 1)[1]
+        body = body.split('\n    }', 1)[0]
+        self.assertIn('getCullStatus(r)', body)
+        self.assertNotIn('getRawCullStatus', body)
+        self.assertNotIn('r.culled ===', body)
+
+    def test_scene_exposes_cull_counts(self):
+        self.assertIn('function _cullCounts', self.src)
+        self.assertIn('cullCounts,', self.src)
+
+
+class TestReviewStateFilter(unittest.TestCase):
+    """All / reviewed / unreviewed, with the legacy boolean migrated."""
+
+    def test_markup_offers_three_states(self):
+        html = _read(_VISUALIZER_HTML)
+        self.assertIn('id="filterSceneReviewState"', html)
+        for value in ('"all"', '"reviewed"', '"unreviewed"'):
+            self.assertIn(f'<option value={value}', html)
+
+    def test_superseded_checkbox_is_gone(self):
+        html = _read(_VISUALIZER_HTML)
+        self.assertNotIn('id="filterScenesManualRated"', html)
+        # ...and nothing still reads it.
+        self.assertNotIn('filterScenesManualRated', _read(_SCENE_GRID_JS))
+        self.assertNotIn('filterScenesManualRated', _read(_CSV_INIT_JS))
+
+    def test_grid_filters_both_directions(self):
+        src = _read(_SCENE_GRID_JS)
+        self.assertIn("=== 'reviewed' ? scenes.filter(isManuallyReviewedScene)", src)
+        self.assertIn("=== 'unreviewed' ? scenes.filter(s => !isManuallyReviewedScene(s))", src)
+
+    def test_unreviewed_is_the_exact_complement(self):
+        """Both branches must go through the same predicate.
+
+        'Unreviewed' means no user-assigned trait anywhere on the scene --
+        across its photos and its scene tags. Reimplementing that test instead
+        of negating isManuallyReviewedScene would let the two drift apart.
+        """
+        src = _read(_SCENE_GRID_JS)
+        self.assertEqual(2, src.count('isManuallyReviewedScene'))
+
+    def test_legacy_setting_is_migrated(self):
+        src = _read(_CSV_INIT_JS)
+        self.assertIn('sceneReviewFilter', src)
+        # An install that had the old checkbox ticked must land on 'reviewed'.
+        self.assertIn("getSetting('onlyManualRatedScenes', false) ? 'reviewed' : 'all'", src)
+
+    def test_filter_value_is_validated_before_use(self):
+        src = _read(_CSV_INIT_JS)
+        self.assertIn("VALID = ['all', 'reviewed', 'unreviewed']", src)
+        self.assertIn('VALID.includes(t.value)', src)
+
+
+class TestGridRefreshAfterCullChange(unittest.TestCase):
+    """A cull decision now changes the thumbnail, so the grid owes a repaint."""
+
+    def test_close_handler_repaints_once(self):
+        src = _read(os.path.join(_ANALYZER_DIR, 'js', 'scene-dialog.js'))
+        self.assertIn('_sceneCullDecisionsChanged = true;', src)
+        self.assertIn("sceneDlg?.addEventListener('close'", src)
+
+    def test_navigation_between_scenes_does_not_drop_the_refresh(self):
+        """close fires on scene-to-scene navigation too; the flag must survive.
+
+        The guard has to return BEFORE clearing the flag, or navigating away
+        from a scene you just culled would swallow the pending repaint.
+        """
+        src = _read(os.path.join(_ANALYZER_DIR, 'js', 'scene-dialog.js'))
+        handler = src.split("sceneDlg?.addEventListener('close'", 1)[1]
+        handler = handler.split('});', 1)[0]
+        open_guard = handler.find('if (sceneDlg.open) return;')
+        clear = handler.find('_sceneCullDecisionsChanged = false;')
+        self.assertGreater(open_guard, -1, 'no reopen guard')
+        self.assertGreater(clear, -1, 'flag is never cleared')
+        self.assertLess(open_guard, clear, 'flag cleared before the reopen guard')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/analyzer/visualizer.html
+++ b/analyzer/visualizer.html
@@ -183,9 +183,13 @@
         <div class="tfb-more-wrap">
           <button id="tfbMoreBtn" type="button" class="tfb-more-btn" aria-haspopup="true" aria-expanded="false" title="More filter and grouping options">⚙ More ▾</button>
           <div id="tfbMorePopover" class="tfb-more-popover hidden" role="menu" aria-label="Additional options">
-            <label class="tfb-popover-row" title="Only show scenes you've manually reviewed: user star ratings, user accept/reject culling decisions, reviewed scene tags, or renamed scene names.">
-              <input id="filterScenesManualRated" type="checkbox" />
-              <span>Only manually reviewed scenes</span>
+            <label class="tfb-popover-row" title="Filter by review state. A scene counts as reviewed once you have given it any user star rating, any accept/reject culling decision, reviewed scene tags, or a scene name. Unreviewed scenes are the ones that still need work.">
+              <span>Review state</span>
+              <select id="filterSceneReviewState">
+                <option value="all">All scenes</option>
+                <option value="reviewed">Reviewed only</option>
+                <option value="unreviewed">Unreviewed only</option>
+              </select>
             </label>
             <label class="tfb-popover-row">
               <input id="includeSecondarySpecies" type="checkbox" />


### PR DESCRIPTION
## Context

From a user suggestion (feedback 21):

> It could be helpful to provide more representation of the user's current choices for the scene:
> 1) Instead of using the photo with the highest quality score as the scene thumbnail, use the one with the highest quality score in either (in this order): Accepted photos / Non-rejected photos (if none were accepted) / Rejected photos (if all were rejected)
> 2) Show which scenes need more work by either or both methods: a filter to show only scenes that still need work … or break the scene photo count to accepted, undecided and rejected

Both parts are implemented. The filter predicate follows the owner's definition: a scene with no user-assigned traits, across both its photos and its scene tags, counts as unreviewed.

## 1. Thumbnail follows the user's decisions

`aggregateScenes` picked the representative purely by quality:

```js
let rep = arr[0];
for (const r of arr) if (parseNumber(r.quality) > parseNumber(rep.quality)) rep = r;
```

So a scene could keep advertising a photo the user had already rejected. Now `_pickSceneRepresentative` walks the requested tiers: best accepted → best non-rejected → best overall.

**Only manual decisions count.** It goes through `getCullStatus()`, which already returns `''` for auto-culled rows. Two consequences worth stating, both deliberate:

- A scene the user has never touched picks **exactly** the representative it always did — this is a no-op for untouched libraries.
- The auto-culler cannot change thumbnails behind the user's back.

Quality ties still keep the earliest row, matching the previous `>` comparison.

## 2. Three-way review-state filter

The "Only manually reviewed scenes" checkbox becomes a select: **All scenes / Reviewed only / Unreviewed only**.

`unreviewed` is the exact complement of the existing `isManuallyReviewedScene` predicate rather than a reimplementation — both branches call the one function, so they cannot drift apart (there is a test pinning that). That predicate already means: finalized scene tags, a user-set scene name, a manual accept/reject on any image, or a manual star rating on any image.

**Settings migration:** an install with the old checkbox ticked lands on `reviewed`, not silently back on "show everything". The legacy `onlyManualRatedScenes` key is kept in sync so an older build reading the same settings still behaves.

## 3. Count breakdown

The accept/undecided/reject split is on the image count's tooltip rather than on the tile. The suggestion asked for this "if possible without overloading the display" — a hover keeps it available when triaging without adding weight to every card. Easy to promote onto the tile if you'd rather see it inline.

## 4. Grid repaint after a cull decision

The thumbnail now depends on cull state, so a decision made inside the scene dialog leaves the card behind it stale. Re-rendering per keystroke would be far too costly on a large folder, so `setCullStatus` records that the grid owes a repaint and the dialog's `close` handler does it once.

One subtlety, tested: scene-to-scene navigation *also* closes the dialog (`sceneDlg.close()` then `openSceneDialog(next)`), and the `close` event is queued, so it can run after the next scene is already showing. The handler returns **before** clearing the flag in that case, so a pending refresh survives navigation instead of being swallowed.

## Testing

`analyzer/tests/unit/test_scene_review_state.py` — 13 source-level lints, following the convention documented in `test_culling_quality_cutoff.py` and `test_raw_warn_banner.py` (no JS runner in this repo): tier ordering, manual-only cull status, the superseded checkbox being fully removed from all three consumers, both filter directions, the complement invariant, settings migration and validation, and the close-handler ordering above.

Behavioural coverage was done by evaluating the **real `scenes.js` source** in a Node harness with the surrounding globals stubbed (including the true `getCullStatus` semantics from `scene-dialog.js`). All 18 cases pass:

| case | expected |
|---|---|
| untouched scene | highest quality (unchanged behaviour) ✓ |
| one accepted, lower quality than an undecided | the accepted one ✓ |
| several accepted | best accepted ✓ |
| none accepted, a better rejected exists | best non-rejected ✓ |
| all rejected | best rejected ✓ |
| auto-reject present | ignored — auto row still eligible ✓ |
| auto-accept vs better undecided | undecided wins ✓ |
| quality tie | earliest row ✓ |
| single-image scene | that image ✓ |
| cull counts with an auto row | auto counts as undecided ✓ |
| unreviewed predicate | no decisions → unreviewed; manual cull / approved tags / scene name / manual star → reviewed; auto cull alone → still unreviewed ✓ |

Full unit suite: 641 passed, 3 skipped, 69 subtests. All four touched JS files parse clean.

## Note

Part 2 of the suggestion offered three possible filter predicates and the user was explicit they were unsure which was right. This implements the one you specified. If "unreviewed" should instead mean *"nothing assigned **and** more than one photo"* — the user's own alternative — that is a one-line change to `isManuallyReviewedScene`'s call site.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tr2P9YYSFTTUS6WW3Y6Tnu)_