### PR TITLE
Cursor/fix culling move safety 554a

### DIFF
--- a/analyzer/api_bridge.py
+++ b/analyzer/api_bridge.py
@@ -6517,7 +6517,7 @@ class Api:
             # would be O(files x dirsize) on a folder that can hold thousands.
             dir_index = self._build_dir_index(root_real)
             for fn in sanitized_filenames:
-                success, moved_files, problems = self._move_file_with_sidecars(
+                _success, moved_files, problems = self._move_file_with_sidecars(
                     root_real, fn, reject_dir, dir_index=dir_index
                 )
                 if moved_files:
@@ -6658,7 +6658,7 @@ class Api:
             # path, over the rejects folder instead of the shoot folder.
             restore_index = self._build_dir_index(reject_dir)
             for fn in sanitized_filenames:
-                success, restored_files, problems = self._restore_file_with_sidecars(
+                _success, restored_files, problems = self._restore_file_with_sidecars(
                     reject_dir, root_real, fn, dir_index=restore_index
                 )
                 if restored_files:

--- a/analyzer/api_bridge.py
+++ b/analyzer/api_bridge.py
@@ -6425,7 +6425,7 @@ class Api:
         every move below is already guarded by ``os.path.exists``, so a stale
         entry degrades to a logged warning rather than an error.
 
-        Returns (success: bool, moved_files: list[str])
+        Returns (success: bool, moved_files: list[str], error: str | None)
         """
         moved_files = []
 
@@ -6433,13 +6433,21 @@ class Api:
         src = os.path.join(root_path, filename)
         dst = os.path.join(reject_dir, filename)
         try:
-            if os.path.exists(src):
-                shutil.move(src, dst)
-                moved_files.append(filename)
-            else:
-                return False, moved_files
-        except Exception:
-            return False, moved_files
+            if not os.path.exists(src):
+                return False, moved_files, 'source not found'
+            if os.path.exists(dst):
+                # Never overwrite a file already in the reject folder.
+                # shutil.move() falls through to os.rename(), which on POSIX
+                # (Linux/macOS) silently replaces the destination -- so a stale
+                # reject with a recurring camera filename (common after an
+                # SD-card reformat, e.g. a second IMG_0001.CR3) would be
+                # destroyed with no warning. Refuse rather than lose data.
+                warn(f'[reject] destination already exists, not overwriting: {dst}')
+                return False, moved_files, 'a file with this name already exists in the reject folder'
+            shutil.move(src, dst)
+            moved_files.append(filename)
+        except Exception as e:
+            return False, moved_files, str(e)
 
         companion_files = self._find_companion_files(root_path, filename, dir_index=dir_index)
         if companion_files:
@@ -6447,18 +6455,22 @@ class Api:
                 companion_src = os.path.join(root_path, companion)
                 companion_dst = os.path.join(reject_dir, companion)
                 try:
-                    if os.path.exists(companion_src):
-                        shutil.move(companion_src, companion_dst)
-                        moved_files.append(companion)
-                    else:
+                    if not os.path.exists(companion_src):
                         warn(f'[reject] companion detected but not found at: {companion_src}')
+                        continue
+                    if os.path.exists(companion_dst):
+                        # Same no-overwrite rule for companions (e.g. IMG_0001.JPG).
+                        warn(f'[reject] companion destination already exists, not overwriting: {companion_dst}')
+                        continue
+                    shutil.move(companion_src, companion_dst)
+                    moved_files.append(companion)
                 except Exception as e:
                     # Log warning but don't fail the main move if a companion fails
                     warn(f'[reject] Failed to move {companion}: {e}')
         else:
             debug(f'[reject] No companion sidecars found for: {filename}')
 
-        return True, moved_files
+        return True, moved_files, None
 
     def move_rejects_to_folder(self, root_path: str, filenames):
         """Move original photo files and sidecars into _KESTREL_Rejects subfolder."""
@@ -6498,13 +6510,13 @@ class Api:
             # would be O(files x dirsize) on a folder that can hold thousands.
             dir_index = self._build_dir_index(root_real)
             for fn in sanitized_filenames:
-                success, moved_files = self._move_file_with_sidecars(
+                success, moved_files, move_err = self._move_file_with_sidecars(
                     root_real, fn, reject_dir, dir_index=dir_index
                 )
                 if success:
                     moved.extend(moved_files)
                 else:
-                    errors.append(f'{fn}: move failed')
+                    errors.append(f'{fn}: {move_err or "move failed"}')
             info(f'[reject] moved {len(moved)} file(s) (including sidecars), errors {len(errors)}')
             return {'success': True, 'moved': len(moved), 'errors': errors, 'reject_folder': reject_real}
         except Exception as e:

--- a/analyzer/api_bridge.py
+++ b/analyzer/api_bridge.py
@@ -398,6 +398,25 @@ _REJECT_DEST_EXISTS_REASON = 'a file with this name already exists in the reject
 _SHOOT_DEST_EXISTS_REASON = 'a file with this name already exists in the shoot folder'
 
 
+def _unlink_src_or_rollback(src: str, dst: str) -> None:
+    """Unlink ``src`` after ``dst`` was created; drop ``dst`` if that unlink fails.
+
+    The no-overwrite guard treats an existing ``dst`` as a permanent conflict.
+    If we created ``dst`` (hard link or exclusive copy) and then fail to remove
+    ``src``, the caller reports failure while ``dst`` still exists — a retry
+    for the same name is then refused forever. Rolling back ``dst`` restores
+    the pre-move state so a later attempt can succeed.
+    """
+    try:
+        os.unlink(src)
+    except OSError:
+        try:
+            os.unlink(dst)
+        except OSError:
+            pass
+        raise
+
+
 def _move_no_overwrite(src: str, dst: str) -> None:
     """Move ``src`` to ``dst`` without replacing an existing destination.
 
@@ -405,7 +424,8 @@ def _move_no_overwrite(src: str, dst: str) -> None:
     hard link (``os.link`` raises ``FileExistsError`` if ``dst`` already exists)
     then unlink the source. When linking is unsupported (cross-device, some
     Windows setups), copy via ``O_CREAT|O_EXCL`` then unlink the source.
-    Never falls through to ``shutil.move``.
+    Never falls through to ``shutil.move``. If unlinking ``src`` fails after
+    ``dst`` exists, ``dst`` is removed so a retry is not blocked.
     """
     src = os.fspath(src)
     dst = os.fspath(dst)
@@ -439,9 +459,9 @@ def _move_no_overwrite(src: str, dst: str) -> None:
             except OSError:
                 pass
             raise
-        os.unlink(src)
+        _unlink_src_or_rollback(src, dst)
         return
-    os.unlink(src)
+    _unlink_src_or_rollback(src, dst)
 
 
 class Api:

--- a/analyzer/api_bridge.py
+++ b/analyzer/api_bridge.py
@@ -6461,6 +6461,7 @@ class Api:
                 try:
                     if not os.path.exists(companion_src):
                         warn(f'[reject] companion detected but not found at: {companion_src}')
+                        skipped.append({'filename': companion, 'reason': 'companion not found on disk'})
                         continue
                     if os.path.exists(companion_dst):
                         # Same no-overwrite rule for companions (e.g. IMG_0001.JPG):
@@ -6509,13 +6510,16 @@ class Api:
 
         - ``success``: False on hard failures (bad root, exception) and when
           at least one main file was requested but **none** of those mains
-          moved (all conflicts / missing). True for a successful no-op
-          (empty list) and for partial batches.
+          moved (all conflicts, missing, or invalid names). True for a
+          successful no-op (empty list) and for partial batches.
         - ``all_moved``: True iff every requested *main* file is in
-          ``moved_filenames``. Companion skips do not clear this flag.
-        - ``moved_filenames`` / ``skipped``: the source of truth for which
-          requested names actually moved. The culling UI filters state from
-          ``moved_filenames``, not from the request list.
+          ``moved_filenames``. Invalid names and unmoved mains clear this.
+          Companion skips do not.
+        - ``moved_filenames``: every file that actually moved (requested mains
+          **and** companions). The culling UI intersects this with the request
+          list to recover which mains moved.
+        - ``skipped``: mains and companions that did not move (conflict,
+          missing, invalid name, or error).
         """
         try:
             root_real, err = self._validate_root_dir(root_path, context='move_rejects_to_folder', require_exists=True)
@@ -6542,11 +6546,14 @@ class Api:
             else:
                 raw_filenames = []
             sanitized_filenames = []
+            requested_mains = []
             for raw in raw_filenames:
                 clean = self._sanitize_plain_filename(raw, context='move_rejects_to_folder')
                 if clean:
                     sanitized_filenames.append(clean)
+                    requested_mains.append(clean)
                 else:
+                    requested_mains.append(str(raw))
                     skipped.append({'filename': str(raw), 'reason': 'invalid filename'})
                     errors.append(f'{raw}: invalid filename')
 
@@ -6567,7 +6574,7 @@ class Api:
                     skipped.append(s)
                     errors.append(f"{s['filename']}: {s['reason']}")
             info(f'[reject] moved {len(moved)} file(s) (including sidecars), skipped {len(skipped)}')
-            all_moved, success = self._requested_mains_outcome(sanitized_filenames, moved)
+            all_moved, success = self._requested_mains_outcome(requested_mains, moved)
             result = {
                 'success': success,
                 'all_moved': all_moved,
@@ -6580,7 +6587,7 @@ class Api:
             if not success:
                 result['error'] = (
                     'none of the requested files could be moved '
-                    '(name conflicts or missing files; see skipped)'
+                    '(name conflicts, missing files, or invalid filenames; see skipped)'
                 )
             return result
         except Exception as e:
@@ -6661,6 +6668,7 @@ class Api:
                 try:
                     if not os.path.exists(companion_src):
                         warn(f'[reject-undo] companion detected but not found at: {companion_src}')
+                        skipped.append({'filename': companion, 'reason': 'companion not found on disk'})
                         continue
                     if os.path.exists(companion_dst):
                         warn(f'[reject-undo] companion destination already exists, not overwriting: {companion_dst}')
@@ -6680,9 +6688,11 @@ class Api:
         """Move files and their sidecars back from _KESTREL_Rejects to the root folder.
 
         Return contract mirrors ``move_rejects_to_folder``: ``success`` is
-        False when requested mains all failed to restore; ``all_restored``
-        is True iff every requested main is in ``restored_filenames``.
-        Callers must reconcile UI state from ``restored_filenames`` / ``skipped``.
+        False when requested mains all failed to restore (including an
+        all-invalid-name request); ``all_restored`` is True iff every requested
+        main is in ``restored_filenames``. ``restored_filenames`` includes
+        companions. Callers must reconcile UI state from
+        ``restored_filenames`` / ``skipped``.
         """
         try:
             root_real, err = self._validate_root_dir(root_path, context='undo_reject_move', require_exists=True)
@@ -6711,11 +6721,14 @@ class Api:
             else:
                 raw_filenames = []
             sanitized_filenames = []
+            requested_mains = []
             for raw in raw_filenames:
                 clean = self._sanitize_plain_filename(raw, context='undo_reject_move')
                 if clean:
                     sanitized_filenames.append(clean)
+                    requested_mains.append(clean)
                 else:
+                    requested_mains.append(str(raw))
                     skipped.append({'filename': str(raw), 'reason': 'invalid filename'})
                     errors.append(f'{raw}: invalid filename')
 
@@ -6732,7 +6745,7 @@ class Api:
                     skipped.append(s)
                     errors.append(f"{s['filename']}: {s['reason']}")
             info(f"[reject-undo] restored {len(restored)} file(s) (including sidecars), skipped {len(skipped)}")
-            all_restored, success = self._requested_mains_outcome(sanitized_filenames, restored)
+            all_restored, success = self._requested_mains_outcome(requested_mains, restored)
             result = {
                 "success": success,
                 "all_restored": all_restored,
@@ -6744,7 +6757,7 @@ class Api:
             if not success:
                 result["error"] = (
                     "none of the requested files could be restored "
-                    "(name conflicts or missing files; see skipped)"
+                    "(name conflicts, missing files, or invalid filenames; see skipped)"
                 )
             return result
         except Exception as e:

--- a/analyzer/api_bridge.py
+++ b/analyzer/api_bridge.py
@@ -6479,8 +6479,44 @@ class Api:
 
         return True, moved_files, skipped
 
+    @staticmethod
+    def _requested_mains_outcome(requested_mains, completed_filenames):
+        """Flags for a reject/undo batch keyed on the *requested main* files.
+
+        Companions are not requested; they may appear in ``completed_filenames``
+        and ``skipped`` but they do not affect these flags.
+
+        ``all_done`` is True iff every requested main file is in
+        ``completed_filenames``. ``success`` is False only when the caller
+        asked to process at least one main file and none of those mains
+        actually completed -- so callers that gate only on ``success`` cannot
+        drop UI state for files that never left disk. An empty request is a
+        successful no-op. Partial batches keep ``success`` True and set
+        ``all_done`` False; callers must reconcile via moved_filenames /
+        restored_filenames and skipped.
+        """
+        completed = set(completed_filenames)
+        all_done = all(fn in completed for fn in requested_mains)
+        any_done = any(fn in completed for fn in requested_mains)
+        success = (not requested_mains) or any_done
+        return all_done, success
+
     def move_rejects_to_folder(self, root_path: str, filenames):
-        """Move original photo files and sidecars into _KESTREL_Rejects subfolder."""
+        """Move original photo files and sidecars into _KESTREL_Rejects subfolder.
+
+        Return contract (callers must reconcile, not assume every requested
+        file moved just because ``success`` is True):
+
+        - ``success``: False on hard failures (bad root, exception) and when
+          at least one main file was requested but **none** of those mains
+          moved (all conflicts / missing). True for a successful no-op
+          (empty list) and for partial batches.
+        - ``all_moved``: True iff every requested *main* file is in
+          ``moved_filenames``. Companion skips do not clear this flag.
+        - ``moved_filenames`` / ``skipped``: the source of truth for which
+          requested names actually moved. The culling UI filters state from
+          ``moved_filenames``, not from the request list.
+        """
         try:
             root_real, err = self._validate_root_dir(root_path, context='move_rejects_to_folder', require_exists=True)
             if err:
@@ -6531,14 +6567,22 @@ class Api:
                     skipped.append(s)
                     errors.append(f"{s['filename']}: {s['reason']}")
             info(f'[reject] moved {len(moved)} file(s) (including sidecars), skipped {len(skipped)}')
-            return {
-                'success': True,
+            all_moved, success = self._requested_mains_outcome(sanitized_filenames, moved)
+            result = {
+                'success': success,
+                'all_moved': all_moved,
                 'moved': len(moved),
                 'moved_filenames': moved,
                 'skipped': skipped,
                 'errors': errors,
                 'reject_folder': reject_real,
             }
+            if not success:
+                result['error'] = (
+                    'none of the requested files could be moved '
+                    '(name conflicts or missing files; see skipped)'
+                )
+            return result
         except Exception as e:
             error(f'[API] move_rejects_to_folder error: {e}')
             return {'success': False, 'error': str(e)}
@@ -6633,7 +6677,13 @@ class Api:
         return True, restored_files, skipped
 
     def undo_reject_move(self, root_path: str, filenames):
-        """Move files and their sidecars back from _KESTREL_Rejects to the root folder."""
+        """Move files and their sidecars back from _KESTREL_Rejects to the root folder.
+
+        Return contract mirrors ``move_rejects_to_folder``: ``success`` is
+        False when requested mains all failed to restore; ``all_restored``
+        is True iff every requested main is in ``restored_filenames``.
+        Callers must reconcile UI state from ``restored_filenames`` / ``skipped``.
+        """
         try:
             root_real, err = self._validate_root_dir(root_path, context='undo_reject_move', require_exists=True)
             if err:
@@ -6682,13 +6732,21 @@ class Api:
                     skipped.append(s)
                     errors.append(f"{s['filename']}: {s['reason']}")
             info(f"[reject-undo] restored {len(restored)} file(s) (including sidecars), skipped {len(skipped)}")
-            return {
-                "success": True,
+            all_restored, success = self._requested_mains_outcome(sanitized_filenames, restored)
+            result = {
+                "success": success,
+                "all_restored": all_restored,
                 "restored": len(restored),
                 "restored_filenames": restored,
                 "skipped": skipped,
                 "errors": errors,
             }
+            if not success:
+                result["error"] = (
+                    "none of the requested files could be restored "
+                    "(name conflicts or missing files; see skipped)"
+                )
+            return result
         except Exception as e:
             error(f"[API] undo_reject_move error: {e}")
             return {"success": False, "error": str(e)}

--- a/analyzer/api_bridge.py
+++ b/analyzer/api_bridge.py
@@ -6425,20 +6425,20 @@ class Api:
         every move below is already guarded by ``os.path.exists``, so a stale
         entry degrades to a logged warning rather than an error.
 
-        Returns (success: bool, moved_files: list[str], problems: list[str]).
-        ``problems`` holds pre-formatted per-file messages (main file and/or
-        companions) so the caller can surface every conflict in the API result,
-        not just the main-file one.
+        Returns (success: bool, moved_files: list[str], skipped: list[dict]).
+        ``skipped`` holds ``{'filename': str, 'reason': str}`` entries for the
+        main file and/or companions that were NOT moved (conflict, missing, or
+        error), so the caller can report exactly which files stayed behind.
         """
         moved_files = []
-        problems: list[str] = []
+        skipped: list[dict] = []
 
         # Move main file
         src = os.path.join(root_path, filename)
         dst = os.path.join(reject_dir, filename)
         try:
             if not os.path.exists(src):
-                return False, moved_files, [f'{filename}: source not found']
+                return False, moved_files, [{'filename': filename, 'reason': 'source not found'}]
             if os.path.exists(dst):
                 # Never overwrite a file already in the reject folder.
                 # shutil.move() falls through to os.rename(), which on POSIX
@@ -6447,11 +6447,11 @@ class Api:
                 # SD-card reformat, e.g. a second IMG_0001.CR3) would be
                 # destroyed with no warning. Refuse rather than lose data.
                 warn(f'[reject] destination already exists, not overwriting: {dst}')
-                return False, moved_files, [f'{filename}: a file with this name already exists in the reject folder']
+                return False, moved_files, [{'filename': filename, 'reason': 'a file with this name already exists in the reject folder'}]
             shutil.move(src, dst)
             moved_files.append(filename)
         except Exception as e:
-            return False, moved_files, [f'{filename}: {e}']
+            return False, moved_files, [{'filename': filename, 'reason': str(e)}]
 
         companion_files = self._find_companion_files(root_path, filename, dir_index=dir_index)
         if companion_files:
@@ -6466,18 +6466,18 @@ class Api:
                         # Same no-overwrite rule for companions (e.g. IMG_0001.JPG):
                         # surface the conflict instead of silently leaving it behind.
                         warn(f'[reject] companion destination already exists, not overwriting: {companion_dst}')
-                        problems.append(f'{companion}: a file with this name already exists in the reject folder')
+                        skipped.append({'filename': companion, 'reason': 'a file with this name already exists in the reject folder'})
                         continue
                     shutil.move(companion_src, companion_dst)
                     moved_files.append(companion)
                 except Exception as e:
                     # Don't fail the (already moved) main file, but surface it.
                     warn(f'[reject] Failed to move {companion}: {e}')
-                    problems.append(f'{companion}: {e}')
+                    skipped.append({'filename': companion, 'reason': str(e)})
         else:
             debug(f'[reject] No companion sidecars found for: {filename}')
 
-        return True, moved_files, problems
+        return True, moved_files, skipped
 
     def move_rejects_to_folder(self, root_path: str, filenames):
         """Move original photo files and sidecars into _KESTREL_Rejects subfolder."""
@@ -6493,8 +6493,9 @@ class Api:
                 return {'success': False, 'error': 'Invalid reject folder path'}
 
             os.makedirs(reject_dir, exist_ok=True)
-            moved = []
-            errors = []
+            moved = []             # every file actually moved (main + companions)
+            skipped = []           # [{'filename', 'reason'}] for anything not moved
+            errors = []            # same info as formatted strings (back-compat)
 
             if isinstance(filenames, list):
                 raw_filenames = filenames
@@ -6510,6 +6511,7 @@ class Api:
                 if clean:
                     sanitized_filenames.append(clean)
                 else:
+                    skipped.append({'filename': str(raw), 'reason': 'invalid filename'})
                     errors.append(f'{raw}: invalid filename')
 
             # One listing for the whole batch: every file here lives in
@@ -6517,16 +6519,26 @@ class Api:
             # would be O(files x dirsize) on a folder that can hold thousands.
             dir_index = self._build_dir_index(root_real)
             for fn in sanitized_filenames:
-                _success, moved_files, problems = self._move_file_with_sidecars(
+                _success, moved_files, file_skipped = self._move_file_with_sidecars(
                     root_real, fn, reject_dir, dir_index=dir_index
                 )
                 if moved_files:
                     moved.extend(moved_files)
-                # Surface every conflict (main file and/or companions), not just
-                # the main-file failure, so the UI can tell the user what stayed.
-                errors.extend(problems)
-            info(f'[reject] moved {len(moved)} file(s) (including sidecars), errors {len(errors)}')
-            return {'success': True, 'moved': len(moved), 'errors': errors, 'reject_folder': reject_real}
+                # Surface every conflict (main file and/or companions) both as a
+                # structured entry (so callers can reconcile moved vs skipped by
+                # filename) and as a formatted string (backward compatible).
+                for s in file_skipped:
+                    skipped.append(s)
+                    errors.append(f"{s['filename']}: {s['reason']}")
+            info(f'[reject] moved {len(moved)} file(s) (including sidecars), skipped {len(skipped)}')
+            return {
+                'success': True,
+                'moved': len(moved),
+                'moved_filenames': moved,
+                'skipped': skipped,
+                'errors': errors,
+                'reject_folder': reject_real,
+            }
         except Exception as e:
             error(f'[API] move_rejects_to_folder error: {e}')
             return {'success': False, 'error': str(e)}
@@ -6573,28 +6585,29 @@ class Api:
         ``dir_index`` is an optional pre-built listing of ``reject_dir`` shared
         across a batch; see ``_move_file_with_sidecars`` on staleness.
 
-        Returns (success: bool, restored_files: list[str], problems: list[str]).
-        ``problems`` holds pre-formatted per-file messages so companion conflicts
-        are surfaced to the caller, not just logged.
+        Returns (success: bool, restored_files: list[str], skipped: list[dict]).
+        ``skipped`` holds ``{'filename': str, 'reason': str}`` entries so the
+        main file and companion conflicts are surfaced to the caller structured,
+        not just logged.
         """
         restored_files = []
-        problems: list[str] = []
+        skipped: list[dict] = []
 
         # Restore main file
         src = os.path.join(reject_dir, filename)
         dst = os.path.join(root_path, filename)
         try:
             if not os.path.exists(src):
-                return False, restored_files, [f'{filename}: not found in rejects']
+                return False, restored_files, [{'filename': filename, 'reason': 'not found in rejects'}]
             if os.path.exists(dst):
                 # Don't overwrite a file the user re-added to the shoot folder;
                 # shutil.move would silently replace it on POSIX. Refuse instead.
                 warn(f'[reject-undo] destination already exists, not overwriting: {dst}')
-                return False, restored_files, [f'{filename}: a file with this name already exists in the folder']
+                return False, restored_files, [{'filename': filename, 'reason': 'a file with this name already exists in the folder'}]
             shutil.move(src, dst)
             restored_files.append(filename)
         except Exception as e:
-            return False, restored_files, [f'{filename}: {e}']
+            return False, restored_files, [{'filename': filename, 'reason': str(e)}]
 
         companion_files = self._find_companion_files(reject_dir, filename, dir_index=dir_index)
         if companion_files:
@@ -6607,17 +6620,17 @@ class Api:
                         continue
                     if os.path.exists(companion_dst):
                         warn(f'[reject-undo] companion destination already exists, not overwriting: {companion_dst}')
-                        problems.append(f'{companion}: a file with this name already exists in the folder')
+                        skipped.append({'filename': companion, 'reason': 'a file with this name already exists in the folder'})
                         continue
                     shutil.move(companion_src, companion_dst)
                     restored_files.append(companion)
                 except Exception as e:
                     warn(f'[reject-undo] Failed to restore {companion}: {e}')
-                    problems.append(f'{companion}: {e}')
+                    skipped.append({'filename': companion, 'reason': str(e)})
         else:
             debug(f'[reject-undo] No companion sidecars found for: {filename}')
 
-        return True, restored_files, problems
+        return True, restored_files, skipped
 
     def undo_reject_move(self, root_path: str, filenames):
         """Move files and their sidecars back from _KESTREL_Rejects to the root folder."""
@@ -6635,8 +6648,9 @@ class Api:
                 self._log_security_reject('undo_reject_move', 'Reject folder escapes root', root=root_real, reject=reject_real)
                 return {'success': False, 'error': 'Invalid reject folder path'}
 
-            restored = []
-            errors = []
+            restored = []          # every file actually restored (main + companions)
+            skipped = []           # [{'filename', 'reason'}] for anything not restored
+            errors = []            # same info as formatted strings (back-compat)
 
             if isinstance(filenames, list):
                 raw_filenames = filenames
@@ -6652,20 +6666,29 @@ class Api:
                 if clean:
                     sanitized_filenames.append(clean)
                 else:
+                    skipped.append({'filename': str(raw), 'reason': 'invalid filename'})
                     errors.append(f'{raw}: invalid filename')
 
             # One listing for the whole batch — same reasoning as the reject
             # path, over the rejects folder instead of the shoot folder.
             restore_index = self._build_dir_index(reject_dir)
             for fn in sanitized_filenames:
-                _success, restored_files, problems = self._restore_file_with_sidecars(
+                _success, restored_files, file_skipped = self._restore_file_with_sidecars(
                     reject_dir, root_real, fn, dir_index=restore_index
                 )
                 if restored_files:
                     restored.extend(restored_files)
-                errors.extend(problems)
-            info(f"[reject-undo] restored {len(restored)} file(s) (including sidecars), errors {len(errors)}")
-            return {"success": True, "restored": len(restored), "errors": errors}
+                for s in file_skipped:
+                    skipped.append(s)
+                    errors.append(f"{s['filename']}: {s['reason']}")
+            info(f"[reject-undo] restored {len(restored)} file(s) (including sidecars), skipped {len(skipped)}")
+            return {
+                "success": True,
+                "restored": len(restored),
+                "restored_filenames": restored,
+                "skipped": skipped,
+                "errors": errors,
+            }
         except Exception as e:
             error(f"[API] undo_reject_move error: {e}")
             return {"success": False, "error": str(e)}

--- a/analyzer/api_bridge.py
+++ b/analyzer/api_bridge.py
@@ -394,6 +394,55 @@ _CULLING_PRIMARY_IMAGE_EXTENSIONS = set(
     _normalize_extensions([*(_RAW_EXTENSIONS or []), *(_JPEG_EXTENSIONS or [])])
 )
 
+_REJECT_DEST_EXISTS_REASON = 'a file with this name already exists in the reject folder'
+_SHOOT_DEST_EXISTS_REASON = 'a file with this name already exists in the shoot folder'
+
+
+def _move_no_overwrite(src: str, dst: str) -> None:
+    """Move ``src`` to ``dst`` without replacing an existing destination.
+
+    ``os.rename`` / ``shutil.move`` overwrite on POSIX. Prefer a same-filesystem
+    hard link (``os.link`` raises ``FileExistsError`` if ``dst`` already exists)
+    then unlink the source. When linking is unsupported (cross-device, some
+    Windows setups), copy via ``O_CREAT|O_EXCL`` then unlink the source.
+    Never falls through to ``shutil.move``.
+    """
+    src = os.fspath(src)
+    dst = os.fspath(dst)
+    parent = os.path.dirname(dst)
+    if parent:
+        os.makedirs(parent, exist_ok=True)
+    try:
+        os.link(src, dst)
+    except FileExistsError:
+        raise
+    except OSError:
+        flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+        if hasattr(os, 'O_BINARY'):
+            flags |= os.O_BINARY
+        fd = os.open(dst, flags)
+        try:
+            with os.fdopen(fd, 'wb') as dest_fh:
+                fd = -1
+                with open(src, 'rb') as src_fh:
+                    shutil.copyfileobj(src_fh, dest_fh)
+                dest_fh.flush()
+                os.fsync(dest_fh.fileno())
+        except Exception:
+            if fd >= 0:
+                try:
+                    os.close(fd)
+                except OSError:
+                    pass
+            try:
+                os.unlink(dst)
+            except OSError:
+                pass
+            raise
+        os.unlink(src)
+        return
+    os.unlink(src)
+
 
 class Api:
     """JavaScript API exposed to webview for native file/folder operations."""
@@ -6447,11 +6496,16 @@ class Api:
                 # SD-card reformat, e.g. a second IMG_0001.CR3) would be
                 # destroyed with no warning. Refuse rather than lose data.
                 warn(f'[reject] destination already exists, not overwriting: {dst}')
-                return False, moved_files, [{'filename': filename, 'reason': 'a file with this name already exists in the reject folder'}]
-            shutil.move(src, dst)
+                return False, moved_files, [{'filename': filename, 'reason': _REJECT_DEST_EXISTS_REASON}]
+            _move_no_overwrite(src, dst)
             moved_files.append(filename)
+        except FileExistsError:
+            # Dest appeared between the exists() check and the exclusive create.
+            warn(f'[reject] destination already exists, not overwriting: {dst}')
+            return False, moved_files, [{'filename': filename, 'reason': _REJECT_DEST_EXISTS_REASON}]
         except Exception as e:
-            return False, moved_files, [{'filename': filename, 'reason': str(e)}]
+            warn(f'[reject] Failed to move {filename}: {e}')
+            return False, moved_files, [{'filename': filename, 'reason': type(e).__name__}]
 
         companion_files = self._find_companion_files(root_path, filename, dir_index=dir_index)
         if companion_files:
@@ -6467,14 +6521,17 @@ class Api:
                         # Same no-overwrite rule for companions (e.g. IMG_0001.JPG):
                         # surface the conflict instead of silently leaving it behind.
                         warn(f'[reject] companion destination already exists, not overwriting: {companion_dst}')
-                        skipped.append({'filename': companion, 'reason': 'a file with this name already exists in the reject folder'})
+                        skipped.append({'filename': companion, 'reason': _REJECT_DEST_EXISTS_REASON})
                         continue
-                    shutil.move(companion_src, companion_dst)
+                    _move_no_overwrite(companion_src, companion_dst)
                     moved_files.append(companion)
+                except FileExistsError:
+                    warn(f'[reject] companion destination already exists, not overwriting: {companion_dst}')
+                    skipped.append({'filename': companion, 'reason': _REJECT_DEST_EXISTS_REASON})
                 except Exception as e:
                     # Don't fail the (already moved) main file, but surface it.
                     warn(f'[reject] Failed to move {companion}: {e}')
-                    skipped.append({'filename': companion, 'reason': str(e)})
+                    skipped.append({'filename': companion, 'reason': type(e).__name__})
         else:
             debug(f'[reject] No companion sidecars found for: {filename}')
 
@@ -6493,14 +6550,31 @@ class Api:
         actually completed -- so callers that gate only on ``success`` cannot
         drop UI state for files that never left disk. An empty request is a
         successful no-op. Partial batches keep ``success`` True and set
-        ``all_done`` False; callers must reconcile via moved_filenames /
-        restored_filenames and skipped.
+        ``all_done`` False; callers must reconcile via moved_requested /
+        restored_requested (and the back-compat moved_filenames /
+        restored_filenames plus skipped).
         """
         completed = set(completed_filenames)
         all_done = all(fn in completed for fn in requested_mains)
         any_done = any(fn in completed for fn in requested_mains)
         success = (not requested_mains) or any_done
         return all_done, success
+
+    @staticmethod
+    def _requested_filename_lists(requested_mains, completed_filenames, skipped):
+        """Split a batch result into requested-main moved/skipped lists.
+
+        Companions may appear in ``completed_filenames`` and ``skipped``; they
+        are omitted from these lists so callers can reconcile UI state without
+        intersecting against the original request.
+        """
+        completed = set(completed_filenames)
+        requested_set = set(requested_mains)
+        completed_requested = [fn for fn in requested_mains if fn in completed]
+        skipped_requested = [
+            item for item in skipped if item.get('filename') in requested_set
+        ]
+        return completed_requested, skipped_requested
 
     def move_rejects_to_folder(self, root_path: str, filenames):
         """Move original photo files and sidecars into _KESTREL_Rejects subfolder.
@@ -6517,9 +6591,13 @@ class Api:
           Companion skips do not.
         - ``moved_filenames``: every file that actually moved (requested mains
           **and** companions). The culling UI intersects this with the request
-          list to recover which mains moved.
+          list to recover which mains moved when ``moved_requested`` is absent.
+        - ``moved_requested``: requested main filenames that actually moved
+          (no companions). Prefer this over intersecting ``moved_filenames``.
         - ``skipped``: mains and companions that did not move (conflict,
           missing, invalid name, or error).
+        - ``skipped_requested``: ``skipped`` entries whose filename is a
+          requested main (no companions).
         """
         try:
             root_real, err = self._validate_root_dir(root_path, context='move_rejects_to_folder', require_exists=True)
@@ -6575,12 +6653,17 @@ class Api:
                     errors.append(f"{s['filename']}: {s['reason']}")
             info(f'[reject] moved {len(moved)} file(s) (including sidecars), skipped {len(skipped)}')
             all_moved, success = self._requested_mains_outcome(requested_mains, moved)
+            moved_requested, skipped_requested = self._requested_filename_lists(
+                requested_mains, moved, skipped
+            )
             result = {
                 'success': success,
                 'all_moved': all_moved,
                 'moved': len(moved),
                 'moved_filenames': moved,
+                'moved_requested': moved_requested,
                 'skipped': skipped,
+                'skipped_requested': skipped_requested,
                 'errors': errors,
                 'reject_folder': reject_real,
             }
@@ -6654,11 +6737,15 @@ class Api:
                 # Don't overwrite a file the user re-added to the shoot folder;
                 # shutil.move would silently replace it on POSIX. Refuse instead.
                 warn(f'[reject-undo] destination already exists, not overwriting: {dst}')
-                return False, restored_files, [{'filename': filename, 'reason': 'a file with this name already exists in the folder'}]
-            shutil.move(src, dst)
+                return False, restored_files, [{'filename': filename, 'reason': _SHOOT_DEST_EXISTS_REASON}]
+            _move_no_overwrite(src, dst)
             restored_files.append(filename)
+        except FileExistsError:
+            warn(f'[reject-undo] destination already exists, not overwriting: {dst}')
+            return False, restored_files, [{'filename': filename, 'reason': _SHOOT_DEST_EXISTS_REASON}]
         except Exception as e:
-            return False, restored_files, [{'filename': filename, 'reason': str(e)}]
+            warn(f'[reject-undo] Failed to restore {filename}: {e}')
+            return False, restored_files, [{'filename': filename, 'reason': type(e).__name__}]
 
         companion_files = self._find_companion_files(reject_dir, filename, dir_index=dir_index)
         if companion_files:
@@ -6672,13 +6759,16 @@ class Api:
                         continue
                     if os.path.exists(companion_dst):
                         warn(f'[reject-undo] companion destination already exists, not overwriting: {companion_dst}')
-                        skipped.append({'filename': companion, 'reason': 'a file with this name already exists in the folder'})
+                        skipped.append({'filename': companion, 'reason': _SHOOT_DEST_EXISTS_REASON})
                         continue
-                    shutil.move(companion_src, companion_dst)
+                    _move_no_overwrite(companion_src, companion_dst)
                     restored_files.append(companion)
+                except FileExistsError:
+                    warn(f'[reject-undo] companion destination already exists, not overwriting: {companion_dst}')
+                    skipped.append({'filename': companion, 'reason': _SHOOT_DEST_EXISTS_REASON})
                 except Exception as e:
                     warn(f'[reject-undo] Failed to restore {companion}: {e}')
-                    skipped.append({'filename': companion, 'reason': str(e)})
+                    skipped.append({'filename': companion, 'reason': type(e).__name__})
         else:
             debug(f'[reject-undo] No companion sidecars found for: {filename}')
 
@@ -6691,8 +6781,9 @@ class Api:
         False when requested mains all failed to restore (including an
         all-invalid-name request); ``all_restored`` is True iff every requested
         main is in ``restored_filenames``. ``restored_filenames`` includes
-        companions. Callers must reconcile UI state from
-        ``restored_filenames`` / ``skipped``.
+        companions. ``restored_requested`` / ``skipped_requested`` are the
+        requested-main subsets. Callers must reconcile UI state from those
+        lists (or ``restored_filenames`` / ``skipped``).
         """
         try:
             root_real, err = self._validate_root_dir(root_path, context='undo_reject_move', require_exists=True)
@@ -6746,12 +6837,17 @@ class Api:
                     errors.append(f"{s['filename']}: {s['reason']}")
             info(f"[reject-undo] restored {len(restored)} file(s) (including sidecars), skipped {len(skipped)}")
             all_restored, success = self._requested_mains_outcome(requested_mains, restored)
+            restored_requested, skipped_requested = self._requested_filename_lists(
+                requested_mains, restored, skipped
+            )
             result = {
                 "success": success,
                 "all_restored": all_restored,
                 "restored": len(restored),
                 "restored_filenames": restored,
+                "restored_requested": restored_requested,
                 "skipped": skipped,
+                "skipped_requested": skipped_requested,
                 "errors": errors,
             }
             if not success:

--- a/analyzer/api_bridge.py
+++ b/analyzer/api_bridge.py
@@ -6425,16 +6425,20 @@ class Api:
         every move below is already guarded by ``os.path.exists``, so a stale
         entry degrades to a logged warning rather than an error.
 
-        Returns (success: bool, moved_files: list[str], error: str | None)
+        Returns (success: bool, moved_files: list[str], problems: list[str]).
+        ``problems`` holds pre-formatted per-file messages (main file and/or
+        companions) so the caller can surface every conflict in the API result,
+        not just the main-file one.
         """
         moved_files = []
+        problems: list[str] = []
 
         # Move main file
         src = os.path.join(root_path, filename)
         dst = os.path.join(reject_dir, filename)
         try:
             if not os.path.exists(src):
-                return False, moved_files, 'source not found'
+                return False, moved_files, [f'{filename}: source not found']
             if os.path.exists(dst):
                 # Never overwrite a file already in the reject folder.
                 # shutil.move() falls through to os.rename(), which on POSIX
@@ -6443,11 +6447,11 @@ class Api:
                 # SD-card reformat, e.g. a second IMG_0001.CR3) would be
                 # destroyed with no warning. Refuse rather than lose data.
                 warn(f'[reject] destination already exists, not overwriting: {dst}')
-                return False, moved_files, 'a file with this name already exists in the reject folder'
+                return False, moved_files, [f'{filename}: a file with this name already exists in the reject folder']
             shutil.move(src, dst)
             moved_files.append(filename)
         except Exception as e:
-            return False, moved_files, str(e)
+            return False, moved_files, [f'{filename}: {e}']
 
         companion_files = self._find_companion_files(root_path, filename, dir_index=dir_index)
         if companion_files:
@@ -6459,18 +6463,21 @@ class Api:
                         warn(f'[reject] companion detected but not found at: {companion_src}')
                         continue
                     if os.path.exists(companion_dst):
-                        # Same no-overwrite rule for companions (e.g. IMG_0001.JPG).
+                        # Same no-overwrite rule for companions (e.g. IMG_0001.JPG):
+                        # surface the conflict instead of silently leaving it behind.
                         warn(f'[reject] companion destination already exists, not overwriting: {companion_dst}')
+                        problems.append(f'{companion}: a file with this name already exists in the reject folder')
                         continue
                     shutil.move(companion_src, companion_dst)
                     moved_files.append(companion)
                 except Exception as e:
-                    # Log warning but don't fail the main move if a companion fails
+                    # Don't fail the (already moved) main file, but surface it.
                     warn(f'[reject] Failed to move {companion}: {e}')
+                    problems.append(f'{companion}: {e}')
         else:
             debug(f'[reject] No companion sidecars found for: {filename}')
 
-        return True, moved_files, None
+        return True, moved_files, problems
 
     def move_rejects_to_folder(self, root_path: str, filenames):
         """Move original photo files and sidecars into _KESTREL_Rejects subfolder."""
@@ -6510,13 +6517,14 @@ class Api:
             # would be O(files x dirsize) on a folder that can hold thousands.
             dir_index = self._build_dir_index(root_real)
             for fn in sanitized_filenames:
-                success, moved_files, move_err = self._move_file_with_sidecars(
+                success, moved_files, problems = self._move_file_with_sidecars(
                     root_real, fn, reject_dir, dir_index=dir_index
                 )
-                if success:
+                if moved_files:
                     moved.extend(moved_files)
-                else:
-                    errors.append(f'{fn}: {move_err or "move failed"}')
+                # Surface every conflict (main file and/or companions), not just
+                # the main-file failure, so the UI can tell the user what stayed.
+                errors.extend(problems)
             info(f'[reject] moved {len(moved)} file(s) (including sidecars), errors {len(errors)}')
             return {'success': True, 'moved': len(moved), 'errors': errors, 'reject_folder': reject_real}
         except Exception as e:
@@ -6565,21 +6573,28 @@ class Api:
         ``dir_index`` is an optional pre-built listing of ``reject_dir`` shared
         across a batch; see ``_move_file_with_sidecars`` on staleness.
 
-        Returns (success: bool, restored_files: list[str])
+        Returns (success: bool, restored_files: list[str], problems: list[str]).
+        ``problems`` holds pre-formatted per-file messages so companion conflicts
+        are surfaced to the caller, not just logged.
         """
         restored_files = []
+        problems: list[str] = []
 
         # Restore main file
         src = os.path.join(reject_dir, filename)
         dst = os.path.join(root_path, filename)
         try:
-            if os.path.exists(src):
-                shutil.move(src, dst)
-                restored_files.append(filename)
-            else:
-                return False, restored_files
-        except Exception:
-            return False, restored_files
+            if not os.path.exists(src):
+                return False, restored_files, [f'{filename}: not found in rejects']
+            if os.path.exists(dst):
+                # Don't overwrite a file the user re-added to the shoot folder;
+                # shutil.move would silently replace it on POSIX. Refuse instead.
+                warn(f'[reject-undo] destination already exists, not overwriting: {dst}')
+                return False, restored_files, [f'{filename}: a file with this name already exists in the folder']
+            shutil.move(src, dst)
+            restored_files.append(filename)
+        except Exception as e:
+            return False, restored_files, [f'{filename}: {e}']
 
         companion_files = self._find_companion_files(reject_dir, filename, dir_index=dir_index)
         if companion_files:
@@ -6587,15 +6602,22 @@ class Api:
                 companion_src = os.path.join(reject_dir, companion)
                 companion_dst = os.path.join(root_path, companion)
                 try:
+                    if not os.path.exists(companion_src):
+                        warn(f'[reject-undo] companion detected but not found at: {companion_src}')
+                        continue
+                    if os.path.exists(companion_dst):
+                        warn(f'[reject-undo] companion destination already exists, not overwriting: {companion_dst}')
+                        problems.append(f'{companion}: a file with this name already exists in the folder')
+                        continue
                     shutil.move(companion_src, companion_dst)
                     restored_files.append(companion)
                 except Exception as e:
-                    # Log warning but don't fail if companion restore fails
                     warn(f'[reject-undo] Failed to restore {companion}: {e}')
+                    problems.append(f'{companion}: {e}')
         else:
             debug(f'[reject-undo] No companion sidecars found for: {filename}')
 
-        return True, restored_files
+        return True, restored_files, problems
 
     def undo_reject_move(self, root_path: str, filenames):
         """Move files and their sidecars back from _KESTREL_Rejects to the root folder."""
@@ -6636,13 +6658,12 @@ class Api:
             # path, over the rejects folder instead of the shoot folder.
             restore_index = self._build_dir_index(reject_dir)
             for fn in sanitized_filenames:
-                success, restored_files = self._restore_file_with_sidecars(
+                success, restored_files, problems = self._restore_file_with_sidecars(
                     reject_dir, root_real, fn, dir_index=restore_index
                 )
-                if success:
+                if restored_files:
                     restored.extend(restored_files)
-                else:
-                    errors.append(f"{fn}: not found in rejects")
+                errors.extend(problems)
             info(f"[reject-undo] restored {len(restored)} file(s) (including sidecars), errors {len(errors)}")
             return {"success": True, "restored": len(restored), "errors": errors}
         except Exception as e:

--- a/analyzer/culling.html
+++ b/analyzer/culling.html
@@ -2801,10 +2801,12 @@
           }
           // Reconcile against what actually left the shoot folder. success can
           // be True for a partial batch; stripping the request list would drop
-          // files that never moved (name conflicts).
-          const movedSet = new Set(moveRes.moved_filenames || []);
-          const movedMains = rejectFilenames.filter(fn => movedSet.has(fn));
-          const skippedMains = rejectFilenames.filter(fn => !movedSet.has(fn));
+          // files that never moved (name conflicts). Prefer moved_requested
+          // (requested mains only); fall back to intersecting moved_filenames.
+          const movedMains = Array.isArray(moveRes.moved_requested)
+            ? moveRes.moved_requested.slice()
+            : rejectFilenames.filter(fn => new Set(moveRes.moved_filenames || []).has(fn));
+          const skippedMains = rejectFilenames.filter(fn => !new Set(movedMains).has(fn));
           const skipNote = skippedMains.length
             ? `, ${skippedMains.length} skipped`
             : '';

--- a/analyzer/culling.html
+++ b/analyzer/culling.html
@@ -2799,27 +2799,39 @@
             setStep('move', 'failed', moveRes.error || '');
             throw new Error('Move failed: ' + (moveRes.error || ''));
           }
-          setStep('move', 'done', `${moveRes.moved} file${moveRes.moved === 1 ? '' : 's'} moved`);
+          // Reconcile against what actually left the shoot folder. success can
+          // be True for a partial batch; stripping the request list would drop
+          // files that never moved (name conflicts).
+          const movedSet = new Set(moveRes.moved_filenames || []);
+          const movedMains = rejectFilenames.filter(fn => movedSet.has(fn));
+          const skippedMains = rejectFilenames.filter(fn => !movedSet.has(fn));
+          const skipNote = skippedMains.length
+            ? `, ${skippedMains.length} skipped`
+            : '';
+          setStep('move', 'done', `${moveRes.moved} file${moveRes.moved === 1 ? '' : 's'} moved${skipNote}`);
 
-          // Post-move: strip rejects from working data
-          const rejectSet = new Set(rejectFilenames);
-          rows = rows.filter(r => !rejectSet.has(r.filename));
-          for (const fn of rejectSet) cullingState.delete(fn);
-          cleanupScenedataForRejects(rejectSet);
+          const movedMainSet = new Set(movedMains);
+          rows = rows.filter(r => !movedMainSet.has(r.filename));
+          for (const fn of movedMains) cullingState.delete(fn);
+          cleanupScenedataForRejects(movedMainSet);
           await saveCullingState();
 
           try { await window.pywebview.api.open_reject_folder(rootPath); } catch (_) {}
           try { await window.pywebview.api.notify_main_window_refresh(); } catch (_) {}
 
-          moveCompleted = true;
-          const undoBtn = el('#undoBtn');
-          undoBtn.style.display = '';
-          undoBtn.disabled = false;
+          if (movedMains.length) {
+            moveCompleted = true;
+            rejectFilenames = movedMains;
+            const undoBtn = el('#undoBtn');
+            undoBtn.style.display = '';
+            undoBtn.disabled = false;
+          }
           scenes = aggregateScenes();
           renderAllScenes();
           updateStats();
           el('#statusLabel').textContent =
-            `Done! ${moveRes.moved} reject${moveRes.moved === 1 ? '' : 's'} moved. Click \u201cUndo Move\u201d to revert.`;
+            `Done! ${moveRes.moved} reject${moveRes.moved === 1 ? '' : 's'} moved${skipNote}.`
+            + (movedMains.length ? ' Click \u201cUndo Move\u201d to revert.' : '');
         } else {
           try { await window.pywebview.api.notify_main_window_refresh(); } catch (_) {}
           el('#statusLabel').textContent = 'Done!';

--- a/analyzer/culling.html
+++ b/analyzer/culling.html
@@ -2808,7 +2808,7 @@
           const skipNote = skippedMains.length
             ? `, ${skippedMains.length} skipped`
             : '';
-          setStep('move', 'done', `${moveRes.moved} file${moveRes.moved === 1 ? '' : 's'} moved${skipNote}`);
+          setStep('move', 'done', `${movedMains.length} reject${movedMains.length === 1 ? '' : 's'} moved${skipNote}`);
 
           const movedMainSet = new Set(movedMains);
           rows = rows.filter(r => !movedMainSet.has(r.filename));
@@ -2830,7 +2830,7 @@
           renderAllScenes();
           updateStats();
           el('#statusLabel').textContent =
-            `Done! ${moveRes.moved} reject${moveRes.moved === 1 ? '' : 's'} moved${skipNote}.`
+            `Done! ${movedMains.length} reject${movedMains.length === 1 ? '' : 's'} moved${skipNote}.`
             + (movedMains.length ? ' Click \u201cUndo Move\u201d to revert.' : '');
         } else {
           try { await window.pywebview.api.notify_main_window_refresh(); } catch (_) {}
@@ -2843,7 +2843,7 @@
         const parts = [];
         if (doXmp && !anyFailed)  parts.push('XMP files written');
         if (doXmp &&  anyFailed)  parts.push('XMP had errors \u2014 check above');
-        if (doMove) parts.push('Undo available via the bottom bar');
+        if (doMove && moveCompleted) parts.push('Undo available via the bottom bar');
         el('#dlgProgressSubtitle').textContent = parts.join(' \u00b7 ');
         el('#dlgProgressActions').style.display = 'flex';
 

--- a/analyzer/tests/unit/test_reject_move.py
+++ b/analyzer/tests/unit/test_reject_move.py
@@ -427,4 +427,33 @@ class TestRejectNoOverwrite:
         assert (reject_dir / "IMG_0004.JPG").read_bytes() == b"REJECTED-JPG"
         assert any("IMG_0004.JPG" in e for e in result["errors"]), result["errors"]
         assert "IMG_0004.CR3" in result["restored_filenames"]
+        assert result["success"] is True
+        assert result["all_restored"] is True
         assert any(s["filename"] == "IMG_0004.JPG" for s in result["skipped"]), result["skipped"]
+
+    def test_partial_batch_keeps_success_but_clears_all_moved(self, api, tmp_path):
+        """A mixed batch: one main moves, one conflicts.
+
+        Callers that gate only on success must still look at all_moved /
+        moved_filenames so they do not drop the conflicted file from UI state.
+        """
+        workdir = tmp_path / "workdir"
+        workdir.mkdir()
+        reject_dir = workdir / "_KESTREL_Rejects"
+        reject_dir.mkdir()
+        (reject_dir / "IMG_0005.CR3").write_bytes(b"OLD-RAW")
+        (workdir / "IMG_0005.CR3").write_bytes(b"NEW-CONFLICT")
+        (workdir / "IMG_0006.CR3").write_bytes(b"NEW-FREE")
+
+        result = api.move_rejects_to_folder(
+            str(workdir), ["IMG_0005.CR3", "IMG_0006.CR3"]
+        )
+
+        assert result["success"] is True
+        assert result["all_moved"] is False
+        assert "IMG_0006.CR3" in result["moved_filenames"]
+        assert "IMG_0005.CR3" not in result["moved_filenames"]
+        assert any(s["filename"] == "IMG_0005.CR3" for s in result["skipped"])
+        assert (workdir / "IMG_0005.CR3").read_bytes() == b"NEW-CONFLICT"
+        assert (reject_dir / "IMG_0006.CR3").exists()
+        assert not (workdir / "IMG_0006.CR3").exists()

--- a/analyzer/tests/unit/test_reject_move.py
+++ b/analyzer/tests/unit/test_reject_move.py
@@ -218,10 +218,6 @@ class TestCompanionCaseInsensitivity:
     Linux job in CI, so nothing caught it.
     """
 
-    @pytest.fixture
-    def api(self):
-        return api_bridge.Api()
-
     def _shoot(self, tmp_path, raw_name, companion_name):
         workdir = tmp_path / "workdir"
         workdir.mkdir()
@@ -323,10 +319,6 @@ class TestRejectNoOverwrite:
     the destination -- permanently destroying the older RAW while the API
     reported success. The move must refuse and surface an error instead.
     """
-
-    @pytest.fixture
-    def api(self):
-        return api_bridge.Api()
 
     def test_existing_reject_is_not_overwritten(self, api, tmp_path):
         workdir = tmp_path / "workdir"

--- a/analyzer/tests/unit/test_reject_move.py
+++ b/analyzer/tests/unit/test_reject_move.py
@@ -50,6 +50,7 @@ class TestMoveRejects:
         result = api.move_rejects_to_folder(str(workdir_with_files), ['IMG_001.CR3'])
 
         assert result['success'] == True
+        assert result['all_moved'] is True
         # Reject folder should exist
         reject_dir = workdir_with_files / '_KESTREL_Rejects'
         assert reject_dir.is_dir()
@@ -117,6 +118,7 @@ class TestMoveRejects:
         result = api.move_rejects_to_folder(str(workdir_with_files), [])
         # Should succeed but move nothing
         assert result['success'] == True
+        assert result['all_moved'] is True
         # Original files still in place
         assert (workdir_with_files / 'IMG_001.CR3').exists()
 
@@ -347,6 +349,8 @@ class TestRejectNoOverwrite:
         assert (workdir / "IMG_0001.CR3").read_bytes() == b"NEW-PHOTO-TODAY"
         # And the conflict must be reported, not swallowed as success.
         assert result["moved"] == 0
+        assert result["success"] is False
+        assert result["all_moved"] is False
         assert result["errors"], "expected a conflict error, got none"
         # Structured result lets the UI reconcile which files were skipped.
         assert result["moved_filenames"] == []
@@ -368,6 +372,7 @@ class TestRejectNoOverwrite:
         # The RAW moves (its destination was free)...
         assert (reject_dir / "IMG_0002.CR3").exists()
         assert result["success"] is True
+        assert result["all_moved"] is True
         # ...but the pre-existing companion JPG is preserved, not clobbered.
         assert (reject_dir / "IMG_0002.JPG").read_bytes() == b"OLD-JPG"
         assert (workdir / "IMG_0002.JPG").read_bytes() == b"NEW-JPG"
@@ -395,6 +400,8 @@ class TestRejectNoOverwrite:
         assert (workdir / "IMG_0003.CR3").read_bytes() == b"CURRENT-IN-FOLDER"
         assert (reject_dir / "IMG_0003.CR3").read_bytes() == b"REJECTED-COPY"
         assert result["restored"] == 0
+        assert result["success"] is False
+        assert result["all_restored"] is False
         assert any("IMG_0003.CR3" in e for e in result["errors"]), result["errors"]
         assert result["restored_filenames"] == []
         assert any(s["filename"] == "IMG_0003.CR3" for s in result["skipped"]), result["skipped"]

--- a/analyzer/tests/unit/test_reject_move.py
+++ b/analyzer/tests/unit/test_reject_move.py
@@ -313,3 +313,58 @@ class TestCompanionCaseInsensitivity:
         reject_dir = workdir / "_KESTREL_Rejects"
         for i in range(10):
             assert (reject_dir / f"IMG_8{i:03d}.JPG").exists()
+
+
+class TestRejectNoOverwrite:
+    """A reject must never overwrite a file already in the reject folder.
+
+    Camera filename counters recur (e.g. after an SD-card reformat), so a stale
+    IMG_0001.CR3 from an earlier session can already sit in _KESTREL_Rejects.
+    shutil.move() falls through to os.rename(), which on POSIX silently replaces
+    the destination -- permanently destroying the older RAW while the API
+    reported success. The move must refuse and surface an error instead.
+    """
+
+    @pytest.fixture
+    def api(self):
+        return api_bridge.Api()
+
+    def test_existing_reject_is_not_overwritten(self, api, tmp_path):
+        workdir = tmp_path / "workdir"
+        workdir.mkdir()
+        reject_dir = workdir / "_KESTREL_Rejects"
+        reject_dir.mkdir()
+        # An older, irreplaceable RAW already rejected in a previous session.
+        (reject_dir / "IMG_0001.CR3").write_bytes(b"OLD-IRREPLACEABLE-RAW")
+        # Today's brand-new photo happens to reuse the same camera filename.
+        (workdir / "IMG_0001.CR3").write_bytes(b"NEW-PHOTO-TODAY")
+
+        result = api.move_rejects_to_folder(str(workdir), ["IMG_0001.CR3"])
+
+        # The old reject content must survive untouched.
+        assert (reject_dir / "IMG_0001.CR3").read_bytes() == b"OLD-IRREPLACEABLE-RAW"
+        # The new file must NOT have been silently destroyed; it stays put.
+        assert (workdir / "IMG_0001.CR3").read_bytes() == b"NEW-PHOTO-TODAY"
+        # And the conflict must be reported, not swallowed as success.
+        assert result["moved"] == 0
+        assert result["errors"], "expected a conflict error, got none"
+
+    def test_existing_companion_reject_is_not_overwritten(self, api, tmp_path):
+        """The same no-overwrite rule applies to companion files (e.g. the JPG)."""
+        workdir = tmp_path / "workdir"
+        workdir.mkdir()
+        reject_dir = workdir / "_KESTREL_Rejects"
+        reject_dir.mkdir()
+        # Stale companion JPG already in the reject folder; no stale RAW.
+        (reject_dir / "IMG_0002.JPG").write_bytes(b"OLD-JPG")
+        (workdir / "IMG_0002.CR3").write_bytes(b"NEW-RAW")
+        (workdir / "IMG_0002.JPG").write_bytes(b"NEW-JPG")
+
+        result = api.move_rejects_to_folder(str(workdir), ["IMG_0002.CR3"])
+
+        # The RAW moves (its destination was free)...
+        assert (reject_dir / "IMG_0002.CR3").exists()
+        assert result["success"] is True
+        # ...but the pre-existing companion JPG is preserved, not clobbered.
+        assert (reject_dir / "IMG_0002.JPG").read_bytes() == b"OLD-JPG"
+        assert (workdir / "IMG_0002.JPG").read_bytes() == b"NEW-JPG"

--- a/analyzer/tests/unit/test_reject_move.py
+++ b/analyzer/tests/unit/test_reject_move.py
@@ -568,3 +568,56 @@ class TestMoveNoOverwrite:
         api_bridge._move_no_overwrite(str(src), str(dst))
         assert not src.exists()
         assert dst.read_bytes() == b"PAYLOAD"
+
+    def test_unlink_src_failure_rolls_back_dest(self, tmp_path, monkeypatch):
+        """If unlink(src) fails after dest is created, dest must not remain.
+
+        Otherwise the no-overwrite guard treats dest as a permanent conflict
+        and a retry of the same name can never succeed.
+        """
+        src = tmp_path / "src.bin"
+        dst = tmp_path / "dst.bin"
+        src.write_bytes(b"PAYLOAD")
+        real_unlink = api_bridge.os.unlink
+        src_path = os.fspath(src)
+
+        def boom_src_once(path):
+            if os.fspath(path) == src_path:
+                raise OSError("unlink busy")
+            return real_unlink(path)
+
+        monkeypatch.setattr(api_bridge.os, "unlink", boom_src_once)
+        with pytest.raises(OSError, match="unlink busy"):
+            api_bridge._move_no_overwrite(str(src), str(dst))
+        monkeypatch.undo()
+        assert src.read_bytes() == b"PAYLOAD"
+        assert not dst.exists()
+        api_bridge._move_no_overwrite(str(src), str(dst))
+        assert not src.exists()
+        assert dst.read_bytes() == b"PAYLOAD"
+
+    def test_copy_fallback_unlink_src_failure_rolls_back_dest(self, tmp_path, monkeypatch):
+        src = tmp_path / "src.bin"
+        dst = tmp_path / "dst.bin"
+        src.write_bytes(b"PAYLOAD")
+        real_unlink = api_bridge.os.unlink
+        src_path = os.fspath(src)
+
+        def boom_link(_src, _dst):
+            raise OSError("link unsupported")
+
+        def boom_src_once(path):
+            if os.fspath(path) == src_path:
+                raise OSError("unlink busy")
+            return real_unlink(path)
+
+        monkeypatch.setattr(api_bridge.os, "link", boom_link)
+        monkeypatch.setattr(api_bridge.os, "unlink", boom_src_once)
+        with pytest.raises(OSError, match="unlink busy"):
+            api_bridge._move_no_overwrite(str(src), str(dst))
+        monkeypatch.undo()
+        assert src.read_bytes() == b"PAYLOAD"
+        assert not dst.exists()
+        api_bridge._move_no_overwrite(str(src), str(dst))
+        assert not src.exists()
+        assert dst.read_bytes() == b"PAYLOAD"

--- a/analyzer/tests/unit/test_reject_move.py
+++ b/analyzer/tests/unit/test_reject_move.py
@@ -95,6 +95,8 @@ class TestMoveRejects:
         result = api.move_rejects_to_folder(str(workdir_with_files), ['IMG_001.CR3'])
         # Should be at least 2 (CR3 + JPG companion)
         assert result['moved'] >= 2
+        assert result['moved_requested'] == ['IMG_001.CR3']
+        assert result['skipped_requested'] == []
 
     def test_invalid_path_returns_error(self, api):
         """Invalid root path → error response."""
@@ -343,7 +345,9 @@ class TestRejectNoOverwrite:
         assert result["errors"], "expected a conflict error, got none"
         # Structured result lets the UI reconcile which files were skipped.
         assert result["moved_filenames"] == []
+        assert result["moved_requested"] == []
         assert any(s["filename"] == "IMG_0001.CR3" for s in result["skipped"]), result["skipped"]
+        assert any(s["filename"] == "IMG_0001.CR3" for s in result["skipped_requested"]), result["skipped_requested"]
 
     def test_existing_companion_reject_is_not_overwritten(self, api, tmp_path):
         """The same no-overwrite rule applies to companion files (e.g. the JPG)."""
@@ -370,7 +374,9 @@ class TestRejectNoOverwrite:
         assert any("IMG_0002.JPG" in e for e in result["errors"]), result["errors"]
         # Structured result: RAW is in moved_filenames, JPG is in skipped.
         assert "IMG_0002.CR3" in result["moved_filenames"]
+        assert result["moved_requested"] == ["IMG_0002.CR3"]
         assert any(s["filename"] == "IMG_0002.JPG" for s in result["skipped"]), result["skipped"]
+        assert result["skipped_requested"] == []
 
     def test_undo_does_not_overwrite_existing_file(self, api, tmp_path):
         """Undo/restore must not clobber a file the user re-added to the shoot."""
@@ -393,7 +399,12 @@ class TestRejectNoOverwrite:
         assert result["all_restored"] is False
         assert any("IMG_0003.CR3" in e for e in result["errors"]), result["errors"]
         assert result["restored_filenames"] == []
+        assert result["restored_requested"] == []
         assert any(s["filename"] == "IMG_0003.CR3" for s in result["skipped"]), result["skipped"]
+        assert any(
+            s["filename"] == "IMG_0003.CR3" and "shoot folder" in s["reason"]
+            for s in result["skipped_requested"]
+        ), result["skipped_requested"]
 
     def test_undo_companion_conflict_is_surfaced(self, api, tmp_path):
         """A companion conflict on undo is surfaced, not silently skipped."""
@@ -416,9 +427,12 @@ class TestRejectNoOverwrite:
         assert (reject_dir / "IMG_0004.JPG").read_bytes() == b"REJECTED-JPG"
         assert any("IMG_0004.JPG" in e for e in result["errors"]), result["errors"]
         assert "IMG_0004.CR3" in result["restored_filenames"]
+        assert result["restored_requested"] == ["IMG_0004.CR3"]
         assert result["success"] is True
         assert result["all_restored"] is True
         assert any(s["filename"] == "IMG_0004.JPG" for s in result["skipped"]), result["skipped"]
+        assert result["skipped_requested"] == []
+        assert any("shoot folder" in (s.get("reason") or "") for s in result["skipped"])
 
     def test_partial_batch_keeps_success_but_clears_all_moved(self, api, tmp_path):
         """A mixed batch: one main moves, one conflicts.
@@ -442,7 +456,9 @@ class TestRejectNoOverwrite:
         assert result["all_moved"] is False
         assert "IMG_0006.CR3" in result["moved_filenames"]
         assert "IMG_0005.CR3" not in result["moved_filenames"]
+        assert result["moved_requested"] == ["IMG_0006.CR3"]
         assert any(s["filename"] == "IMG_0005.CR3" for s in result["skipped"])
+        assert [s["filename"] for s in result["skipped_requested"]] == ["IMG_0005.CR3"]
         assert (workdir / "IMG_0005.CR3").read_bytes() == b"NEW-CONFLICT"
         assert (reject_dir / "IMG_0006.CR3").exists()
         assert not (workdir / "IMG_0006.CR3").exists()
@@ -455,12 +471,16 @@ class TestRejectNoOverwrite:
         assert result["success"] is False
         assert result["all_moved"] is False
         assert result["moved_filenames"] == []
+        assert result["moved_requested"] == []
         assert any("invalid filename" in (s.get("reason") or "") for s in result["skipped"])
+        assert len(result["skipped_requested"]) == 2
         assert (workdir_with_files / "IMG_001.CR3").exists()
 
         undo = api.undo_reject_move(str(workdir_with_files), ["../escape.CR3"])
         assert undo["success"] is False
         assert undo["all_restored"] is False
+        assert undo["restored_requested"] == []
+        assert len(undo["skipped_requested"]) == 1
 
     def test_missing_companion_is_in_skipped(self, api, tmp_path, monkeypatch):
         """A companion the index named but that is gone from disk is skipped."""
@@ -478,3 +498,73 @@ class TestRejectNoOverwrite:
             s["filename"] == "IMG_0007.JPG" and "not found" in s["reason"]
             for s in result["skipped"]
         ), result["skipped"]
+        assert result["moved_requested"] == ["IMG_0007.CR3"]
+        assert result["skipped_requested"] == []
+
+    def test_move_failure_reason_is_exception_type(self, api, tmp_path, monkeypatch):
+        """Generic move errors return the exception type, not str(e) paths."""
+        workdir = tmp_path / "workdir"
+        workdir.mkdir()
+        (workdir / "IMG_0008.CR3").write_bytes(b"RAW")
+
+        def boom(_src, _dst):
+            raise PermissionError("/secret/path leaked")
+
+        monkeypatch.setattr(api_bridge, "_move_no_overwrite", boom)
+        result = api.move_rejects_to_folder(str(workdir), ["IMG_0008.CR3"])
+        assert any(
+            s["filename"] == "IMG_0008.CR3" and s["reason"] == "PermissionError"
+            for s in result["skipped"]
+        ), result["skipped"]
+        assert not any("/secret/path" in (s.get("reason") or "") for s in result["skipped"])
+        assert not any("/secret/path" in e for e in result["errors"])
+
+
+class TestMoveNoOverwrite:
+    """Direct tests for the exclusive dest-create move helper."""
+
+    def test_refuses_existing_dest(self, tmp_path):
+        src = tmp_path / "src.bin"
+        dst = tmp_path / "dst.bin"
+        src.write_bytes(b"NEW")
+        dst.write_bytes(b"OLD")
+        with pytest.raises(FileExistsError):
+            api_bridge._move_no_overwrite(str(src), str(dst))
+        assert dst.read_bytes() == b"OLD"
+        assert src.read_bytes() == b"NEW"
+
+    def test_moves_when_dest_is_free(self, tmp_path):
+        src = tmp_path / "src.bin"
+        dst = tmp_path / "dst.bin"
+        src.write_bytes(b"PAYLOAD")
+        api_bridge._move_no_overwrite(str(src), str(dst))
+        assert not src.exists()
+        assert dst.read_bytes() == b"PAYLOAD"
+
+    def test_copy_fallback_refuses_existing_dest(self, tmp_path, monkeypatch):
+        src = tmp_path / "src.bin"
+        dst = tmp_path / "dst.bin"
+        src.write_bytes(b"NEW")
+        dst.write_bytes(b"OLD")
+
+        def boom(_src, _dst):
+            raise OSError("link unsupported")
+
+        monkeypatch.setattr(api_bridge.os, "link", boom)
+        with pytest.raises(FileExistsError):
+            api_bridge._move_no_overwrite(str(src), str(dst))
+        assert dst.read_bytes() == b"OLD"
+        assert src.read_bytes() == b"NEW"
+
+    def test_copy_fallback_moves_when_dest_is_free(self, tmp_path, monkeypatch):
+        src = tmp_path / "src.bin"
+        dst = tmp_path / "dst.bin"
+        src.write_bytes(b"PAYLOAD")
+
+        def boom(_src, _dst):
+            raise OSError("link unsupported")
+
+        monkeypatch.setattr(api_bridge.os, "link", boom)
+        api_bridge._move_no_overwrite(str(src), str(dst))
+        assert not src.exists()
+        assert dst.read_bytes() == b"PAYLOAD"

--- a/analyzer/tests/unit/test_reject_move.py
+++ b/analyzer/tests/unit/test_reject_move.py
@@ -368,3 +368,6 @@ class TestRejectNoOverwrite:
         # ...but the pre-existing companion JPG is preserved, not clobbered.
         assert (reject_dir / "IMG_0002.JPG").read_bytes() == b"OLD-JPG"
         assert (workdir / "IMG_0002.JPG").read_bytes() == b"NEW-JPG"
+        # ...and the companion conflict is surfaced in the API result, not just
+        # logged, so the UI can tell the user the JPG stayed behind.
+        assert any("IMG_0002.JPG" in e for e in result["errors"]), result["errors"]

--- a/analyzer/tests/unit/test_reject_move.py
+++ b/analyzer/tests/unit/test_reject_move.py
@@ -371,3 +371,43 @@ class TestRejectNoOverwrite:
         # ...and the companion conflict is surfaced in the API result, not just
         # logged, so the UI can tell the user the JPG stayed behind.
         assert any("IMG_0002.JPG" in e for e in result["errors"]), result["errors"]
+
+    def test_undo_does_not_overwrite_existing_file(self, api, tmp_path):
+        """Undo/restore must not clobber a file the user re-added to the shoot."""
+        workdir = tmp_path / "workdir"
+        workdir.mkdir()
+        reject_dir = workdir / "_KESTREL_Rejects"
+        reject_dir.mkdir()
+        # A rejected copy sits in the reject folder...
+        (reject_dir / "IMG_0003.CR3").write_bytes(b"REJECTED-COPY")
+        # ...but the user re-added a different file with the same name.
+        (workdir / "IMG_0003.CR3").write_bytes(b"CURRENT-IN-FOLDER")
+
+        result = api.undo_reject_move(str(workdir), ["IMG_0003.CR3"])
+
+        # The current file is preserved; the rejected copy stays put.
+        assert (workdir / "IMG_0003.CR3").read_bytes() == b"CURRENT-IN-FOLDER"
+        assert (reject_dir / "IMG_0003.CR3").read_bytes() == b"REJECTED-COPY"
+        assert result["restored"] == 0
+        assert any("IMG_0003.CR3" in e for e in result["errors"]), result["errors"]
+
+    def test_undo_companion_conflict_is_surfaced(self, api, tmp_path):
+        """A companion conflict on undo is surfaced, not silently skipped."""
+        workdir = tmp_path / "workdir"
+        workdir.mkdir()
+        reject_dir = workdir / "_KESTREL_Rejects"
+        reject_dir.mkdir()
+        # RAW + JPG both previously rejected.
+        (reject_dir / "IMG_0004.CR3").write_bytes(b"REJECTED-RAW")
+        (reject_dir / "IMG_0004.JPG").write_bytes(b"REJECTED-JPG")
+        # The JPG already exists back in the shoot folder; the RAW does not.
+        (workdir / "IMG_0004.JPG").write_bytes(b"CURRENT-JPG")
+
+        result = api.undo_reject_move(str(workdir), ["IMG_0004.CR3"])
+
+        # The RAW restores (its destination was free)...
+        assert (workdir / "IMG_0004.CR3").exists()
+        # ...but the existing JPG is preserved and the conflict surfaced.
+        assert (workdir / "IMG_0004.JPG").read_bytes() == b"CURRENT-JPG"
+        assert (reject_dir / "IMG_0004.JPG").read_bytes() == b"REJECTED-JPG"
+        assert any("IMG_0004.JPG" in e for e in result["errors"]), result["errors"]

--- a/analyzer/tests/unit/test_reject_move.py
+++ b/analyzer/tests/unit/test_reject_move.py
@@ -105,13 +105,10 @@ class TestMoveRejects:
     def test_traversal_filename_rejected(self, api, workdir_with_files):
         """Filename with traversal → rejected, not moved."""
         result = api.move_rejects_to_folder(str(workdir_with_files), ['../../../etc/passwd'])
-        # Either the request succeeds with errors for the bad filename, or it fails entirely
-        # In either case, no file should be written outside the root
-        # And the existing files should not be affected
+        assert result['success'] is False
+        assert result['all_moved'] is False
+        assert result.get('errors')
         assert (workdir_with_files / 'IMG_001.CR3').exists()
-        # Look for error in result
-        if result.get('success'):
-            assert len(result.get('errors', [])) > 0
 
     def test_empty_filename_list_no_op(self, api, workdir_with_files):
         """Empty filename list → no-op, no errors."""
@@ -457,3 +454,35 @@ class TestRejectNoOverwrite:
         assert (workdir / "IMG_0005.CR3").read_bytes() == b"NEW-CONFLICT"
         assert (reject_dir / "IMG_0006.CR3").exists()
         assert not (workdir / "IMG_0006.CR3").exists()
+
+    def test_all_invalid_filenames_are_not_success(self, api, workdir_with_files):
+        """A non-empty request of only unsanitary names is not a successful no-op."""
+        result = api.move_rejects_to_folder(
+            str(workdir_with_files), ["../escape.CR3", ""]
+        )
+        assert result["success"] is False
+        assert result["all_moved"] is False
+        assert result["moved_filenames"] == []
+        assert any("invalid filename" in (s.get("reason") or "") for s in result["skipped"])
+        assert (workdir_with_files / "IMG_001.CR3").exists()
+
+        undo = api.undo_reject_move(str(workdir_with_files), ["../escape.CR3"])
+        assert undo["success"] is False
+        assert undo["all_restored"] is False
+
+    def test_missing_companion_is_in_skipped(self, api, tmp_path, monkeypatch):
+        """A companion the index named but that is gone from disk is skipped."""
+        workdir = tmp_path / "workdir"
+        workdir.mkdir()
+        (workdir / "IMG_0007.CR3").write_bytes(b"RAW")
+
+        monkeypatch.setattr(
+            api, "_find_companion_files", lambda *_a, **_k: ["IMG_0007.JPG"]
+        )
+        result = api.move_rejects_to_folder(str(workdir), ["IMG_0007.CR3"])
+        assert result["success"] is True
+        assert "IMG_0007.CR3" in result["moved_filenames"]
+        assert any(
+            s["filename"] == "IMG_0007.JPG" and "not found" in s["reason"]
+            for s in result["skipped"]
+        ), result["skipped"]

--- a/analyzer/tests/unit/test_reject_move.py
+++ b/analyzer/tests/unit/test_reject_move.py
@@ -348,6 +348,9 @@ class TestRejectNoOverwrite:
         # And the conflict must be reported, not swallowed as success.
         assert result["moved"] == 0
         assert result["errors"], "expected a conflict error, got none"
+        # Structured result lets the UI reconcile which files were skipped.
+        assert result["moved_filenames"] == []
+        assert any(s["filename"] == "IMG_0001.CR3" for s in result["skipped"]), result["skipped"]
 
     def test_existing_companion_reject_is_not_overwritten(self, api, tmp_path):
         """The same no-overwrite rule applies to companion files (e.g. the JPG)."""
@@ -371,6 +374,9 @@ class TestRejectNoOverwrite:
         # ...and the companion conflict is surfaced in the API result, not just
         # logged, so the UI can tell the user the JPG stayed behind.
         assert any("IMG_0002.JPG" in e for e in result["errors"]), result["errors"]
+        # Structured result: RAW is in moved_filenames, JPG is in skipped.
+        assert "IMG_0002.CR3" in result["moved_filenames"]
+        assert any(s["filename"] == "IMG_0002.JPG" for s in result["skipped"]), result["skipped"]
 
     def test_undo_does_not_overwrite_existing_file(self, api, tmp_path):
         """Undo/restore must not clobber a file the user re-added to the shoot."""
@@ -390,6 +396,8 @@ class TestRejectNoOverwrite:
         assert (reject_dir / "IMG_0003.CR3").read_bytes() == b"REJECTED-COPY"
         assert result["restored"] == 0
         assert any("IMG_0003.CR3" in e for e in result["errors"]), result["errors"]
+        assert result["restored_filenames"] == []
+        assert any(s["filename"] == "IMG_0003.CR3" for s in result["skipped"]), result["skipped"]
 
     def test_undo_companion_conflict_is_surfaced(self, api, tmp_path):
         """A companion conflict on undo is surfaced, not silently skipped."""
@@ -411,3 +419,5 @@ class TestRejectNoOverwrite:
         assert (workdir / "IMG_0004.JPG").read_bytes() == b"CURRENT-JPG"
         assert (reject_dir / "IMG_0004.JPG").read_bytes() == b"REJECTED-JPG"
         assert any("IMG_0004.JPG" in e for e in result["errors"]), result["errors"]
+        assert "IMG_0004.CR3" in result["restored_filenames"]
+        assert any(s["filename"] == "IMG_0004.JPG" for s in result["skipped"]), result["skipped"]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

`Api.move_rejects_to_folder` / `_move_file_with_sidecars` in `analyzer/api_bridge.py` used `shutil.move()`, which falls through to `os.rename()`. On POSIX (Linux/macOS) that **silently replaces** an existing destination. Camera filename counters recur (e.g. after an SD-card reformat), so a stale `IMG_0001.CR3` already sitting in `_KESTREL_Rejects` from an earlier session is permanently destroyed when a new same-named file is rejected — and the API still returns `{'success': True, 'errors': []}`. (On Windows `os.rename` would instead raise, so the behavior was also platform-inconsistent.)

## Fix

Guard both the main-file and companion moves with an `os.path.exists(dst)` check: refuse the move and surface a clear per-file error instead of overwriting. `_move_file_with_sidecars` now returns `(success, moved_files, error)` so the conflict reason reaches the caller/UI. No data is ever silently replaced.

## Testing

- New regression tests in `analyzer/tests/unit/test_reject_move.py`:
  - `test_existing_reject_is_not_overwritten` — a stale reject with a recurring filename is preserved, the new file stays put, and the conflict is reported (`moved == 0`, non-empty `errors`).
  - `test_existing_companion_reject_is_not_overwritten` — the same rule for companion files (e.g. the JPG).
- Full `test_reject_move.py` suite passes (21 passed), including the existing case-insensitivity tests.

## Note

This is one of several P1 data-loss fixes from a review of the analyzer. The companion case-sensitivity and CSV atomic-write findings from that review are already fixed on current `main`; this PR covers the still-present reject-overwrite case.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c5090e64-798b-45af-8972-8263f4d5554a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c5090e64-798b-45af-8972-8263f4d5554a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

