### PR TITLE
Cursor/fix atomic scenedata writes 554a

### DIFF
--- a/analyzer/api_bridge.py
+++ b/analyzer/api_bridge.py
@@ -1835,8 +1835,13 @@ class Api:
             csv_path = os.path.join(kestrel_dir, 'kestrel_database.csv')
             if not os.path.exists(csv_path):
                 return {'success': False, 'error': f'CSV not found: {csv_path}'}
-            with open(csv_path, 'w', encoding='utf-8-sig', newline='') as f:
-                f.write(csv_content)
+            # Atomic write: the analysis pipeline / auto-refresh may read this
+            # same file, and a crash mid-write must not truncate the database.
+            try:
+                from kestrel_analyzer.database import write_text_atomic
+            except ImportError:
+                from analyzer.kestrel_analyzer.database import write_text_atomic  # type: ignore[no-redef]
+            write_text_atomic(csv_path, csv_content, encoding='utf-8-sig')
             return {'success': True, 'path': csv_path}
         except Exception as e:
             error(f'[API] write_kestrel_csv({folder_path!r}) error: {e}')
@@ -1984,8 +1989,13 @@ class Api:
             if not isinstance(scenedata, dict):
                 return {'success': False, 'error': 'scenedata must be a dict', 'path': ''}
 
-            with open(scenedata_path, 'w', encoding='utf-8') as f:
-                json.dump(scenedata, f, indent=2)
+            # Atomic write: scenedata holds the user's ratings/tags/cull
+            # decisions; a crash mid-write must not truncate the existing file.
+            try:
+                from kestrel_analyzer.database import write_text_atomic
+            except ImportError:
+                from analyzer.kestrel_analyzer.database import write_text_atomic  # type: ignore[no-redef]
+            write_text_atomic(scenedata_path, json.dumps(scenedata, indent=2))
             return {'success': True, 'path': scenedata_path, 'error': ''}
         except Exception as e:
             error(f'[API] write_kestrel_scenedata({folder_path!r}) error: {e}')

--- a/analyzer/api_bridge.py
+++ b/analyzer/api_bridge.py
@@ -66,8 +66,15 @@ except ImportError:
     try:
         from analyzer.kestrel_analyzer.database import write_json_atomic, write_text_atomic
     except ImportError:
-        write_json_atomic = None  # type: ignore[assignment]
-        write_text_atomic = None  # type: ignore[assignment]
+        def write_json_atomic(*_a, **_k):
+            raise RuntimeError(
+                "kestrel_analyzer.database.write_json_atomic is not importable"
+            )
+
+        def write_text_atomic(*_a, **_k):
+            raise RuntimeError(
+                "kestrel_analyzer.database.write_text_atomic is not importable"
+            )
 
 # Distribution channel ('direct' website build vs 'appstore' sandboxed build),
 # baked at build time. Import-safe everywhere; used by the frontend to branch

--- a/analyzer/api_bridge.py
+++ b/analyzer/api_bridge.py
@@ -60,6 +60,15 @@ except ImportError:
     except ImportError:
         _mac_sandbox = None
 
+try:
+    from kestrel_analyzer.database import write_json_atomic, write_text_atomic
+except ImportError:
+    try:
+        from analyzer.kestrel_analyzer.database import write_json_atomic, write_text_atomic
+    except ImportError:
+        write_json_atomic = None  # type: ignore[assignment]
+        write_text_atomic = None  # type: ignore[assignment]
+
 # Distribution channel ('direct' website build vs 'appstore' sandboxed build),
 # baked at build time. Import-safe everywhere; used by the frontend to branch
 # What's New / cloud-compute CTAs on channel without cutting a new release.
@@ -1837,10 +1846,6 @@ class Api:
                 return {'success': False, 'error': f'CSV not found: {csv_path}'}
             # Atomic write: the analysis pipeline / auto-refresh may read this
             # same file, and a crash mid-write must not truncate the database.
-            try:
-                from kestrel_analyzer.database import write_text_atomic
-            except ImportError:
-                from analyzer.kestrel_analyzer.database import write_text_atomic  # type: ignore[no-redef]
             write_text_atomic(csv_path, csv_content, encoding='utf-8-sig')
             return {'success': True, 'path': csv_path}
         except Exception as e:
@@ -1991,11 +1996,8 @@ class Api:
 
             # Atomic write: scenedata holds the user's ratings/tags/cull
             # decisions; a crash mid-write must not truncate the existing file.
-            try:
-                from kestrel_analyzer.database import write_text_atomic
-            except ImportError:
-                from analyzer.kestrel_analyzer.database import write_text_atomic  # type: ignore[no-redef]
-            write_text_atomic(scenedata_path, json.dumps(scenedata, indent=2))
+            # Stream via json.dump so large payloads don't peak on json.dumps.
+            write_json_atomic(scenedata_path, scenedata, indent=2)
             return {'success': True, 'path': scenedata_path, 'error': ''}
         except Exception as e:
             error(f'[API] write_kestrel_scenedata({folder_path!r}) error: {e}')

--- a/analyzer/kestrel_analyzer/database.py
+++ b/analyzer/kestrel_analyzer/database.py
@@ -458,8 +458,10 @@ def _to_csv_atomic(database: pd.DataFrame, db_path: str) -> None:
     try:
         with os.fdopen(tmp_fd, "w", encoding="utf-8", newline="") as f:
             database.to_csv(f, index=False)
+            # flush() errors (ENOSPC, EIO) must propagate: a partial temp
+            # file must not be os.replace'd over a good destination.
+            f.flush()
             try:
-                f.flush()
                 os.fsync(f.fileno())
             except OSError:
                 # fsync can legitimately fail on some network filesystems

--- a/analyzer/kestrel_analyzer/database.py
+++ b/analyzer/kestrel_analyzer/database.py
@@ -499,8 +499,10 @@ def _write_file_atomic(path: str, write_fn, encoding: str = "utf-8") -> None:
             raise
         with f:
             write_fn(f)
+            # flush() errors (ENOSPC, EIO) must propagate: a partial temp
+            # file must not be os.replace'd over a good destination.
+            f.flush()
             try:
-                f.flush()
                 os.fsync(f.fileno())
             except OSError:
                 # fsync can legitimately fail on some network filesystems; the

--- a/analyzer/kestrel_analyzer/database.py
+++ b/analyzer/kestrel_analyzer/database.py
@@ -322,10 +322,14 @@ def load_scenedata(kestrel_dir: str) -> dict:
 
 
 def save_scenedata(scenedata: dict, kestrel_dir: str) -> None:
-    """Save scenedata dict to kestrel_scenedata.json."""
+    """Save scenedata dict to kestrel_scenedata.json.
+
+    Written atomically: scenedata holds the user's ratings, tags and Accept/
+    Reject decisions, so a partial write from a crash/power loss must never
+    truncate the existing file.
+    """
     scenedata_path = os.path.join(kestrel_dir, SCENEDATA_FILENAME)
-    with open(scenedata_path, "w", encoding="utf-8") as f:
-        json.dump(scenedata, f, indent=2)
+    write_text_atomic(scenedata_path, json.dumps(scenedata, indent=2))
 
 
 def ensure_columns(database: pd.DataFrame) -> pd.DataFrame:
@@ -466,6 +470,42 @@ def _to_csv_atomic(database: pd.DataFrame, db_path: str) -> None:
     except BaseException:
         # Do NOT fall back to a direct write — that is the partial-read path
         # this function exists to close. Leave the previous file intact.
+        try:
+            os.remove(tmp)
+        except OSError:
+            pass
+        raise
+
+
+def write_text_atomic(path: str, text: str, encoding: str = "utf-8") -> None:
+    """Write ``text`` to ``path`` atomically (temp file + ``os.replace``).
+
+    Plain ``open(path, "w")`` truncates the destination and streams into it, so
+    a crash/power loss mid-write leaves a partial file behind. For JSON
+    (kestrel_scenedata.json) that means losing the user's ratings/tags/cull
+    decisions; for the UI's raw-text CSV save it means a truncated database.
+    Writing to a unique temp file in the same directory and ``os.replace``-ing
+    it into place gives readers/crashes an all-or-nothing view. Mirrors
+    ``_to_csv_atomic`` and ``settings_utils.save_settings``.
+    """
+    directory = os.path.dirname(path) or "."
+    os.makedirs(directory, exist_ok=True)
+
+    tmp_fd, tmp = tempfile.mkstemp(prefix=".kestrel_atomic_", suffix=".tmp", dir=directory)
+    try:
+        with os.fdopen(tmp_fd, "w", encoding=encoding, newline="") as f:
+            f.write(text)
+            try:
+                f.flush()
+                os.fsync(f.fileno())
+            except OSError:
+                # fsync can legitimately fail on some network filesystems; the
+                # replace below still gives readers an all-or-nothing view.
+                pass
+        retry_on_file_lock(lambda: os.replace(tmp, path))
+    except BaseException:
+        # Do NOT fall back to a direct write -- that is the partial-write path
+        # this helper exists to close. Leave the previous file intact.
         try:
             os.remove(tmp)
         except OSError:

--- a/analyzer/kestrel_analyzer/database.py
+++ b/analyzer/kestrel_analyzer/database.py
@@ -493,7 +493,15 @@ def write_text_atomic(path: str, text: str, encoding: str = "utf-8") -> None:
 
     tmp_fd, tmp = tempfile.mkstemp(prefix=".kestrel_atomic_", suffix=".tmp", dir=directory)
     try:
-        with os.fdopen(tmp_fd, "w", encoding=encoding, newline="") as f:
+        # If os.fdopen raises, it has NOT taken ownership of tmp_fd, so the
+        # descriptor would leak (and on Windows keep the temp file locked). Close
+        # it explicitly in that case; on success the with-block owns and closes it.
+        try:
+            f = os.fdopen(tmp_fd, "w", encoding=encoding, newline="")
+        except BaseException:
+            os.close(tmp_fd)
+            raise
+        with f:
             f.write(text)
             try:
                 f.flush()

--- a/analyzer/kestrel_analyzer/database.py
+++ b/analyzer/kestrel_analyzer/database.py
@@ -329,7 +329,7 @@ def save_scenedata(scenedata: dict, kestrel_dir: str) -> None:
     truncate the existing file.
     """
     scenedata_path = os.path.join(kestrel_dir, SCENEDATA_FILENAME)
-    write_text_atomic(scenedata_path, json.dumps(scenedata, indent=2))
+    write_json_atomic(scenedata_path, scenedata, indent=2)
 
 
 def ensure_columns(database: pd.DataFrame) -> pd.DataFrame:
@@ -477,16 +477,12 @@ def _to_csv_atomic(database: pd.DataFrame, db_path: str) -> None:
         raise
 
 
-def write_text_atomic(path: str, text: str, encoding: str = "utf-8") -> None:
-    """Write ``text`` to ``path`` atomically (temp file + ``os.replace``).
+def _write_file_atomic(path: str, write_fn, encoding: str = "utf-8") -> None:
+    """Atomically write by calling ``write_fn(file)`` on a temp file, then replace.
 
-    Plain ``open(path, "w")`` truncates the destination and streams into it, so
-    a crash/power loss mid-write leaves a partial file behind. For JSON
-    (kestrel_scenedata.json) that means losing the user's ratings/tags/cull
-    decisions; for the UI's raw-text CSV save it means a truncated database.
-    Writing to a unique temp file in the same directory and ``os.replace``-ing
-    it into place gives readers/crashes an all-or-nothing view. Mirrors
-    ``_to_csv_atomic`` and ``settings_utils.save_settings``.
+    ``write_fn`` receives an open text file (encoding/newline already set) and
+    must write the full payload into it. Shared by ``write_text_atomic`` and
+    ``write_json_atomic``. Mirrors ``_to_csv_atomic`` / ``settings_utils.save_settings``.
     """
     directory = os.path.dirname(path) or "."
     os.makedirs(directory, exist_ok=True)
@@ -502,7 +498,7 @@ def write_text_atomic(path: str, text: str, encoding: str = "utf-8") -> None:
             os.close(tmp_fd)
             raise
         with f:
-            f.write(text)
+            write_fn(f)
             try:
                 f.flush()
                 os.fsync(f.fileno())
@@ -519,6 +515,31 @@ def write_text_atomic(path: str, text: str, encoding: str = "utf-8") -> None:
         except OSError:
             pass
         raise
+
+
+def write_text_atomic(path: str, text: str, encoding: str = "utf-8") -> None:
+    """Write ``text`` to ``path`` atomically (temp file + ``os.replace``).
+
+    Plain ``open(path, "w")`` truncates the destination and streams into it, so
+    a crash/power loss mid-write leaves a partial file behind. For the UI's
+    raw-text CSV save that means a truncated database. Writing to a unique temp
+    file in the same directory and ``os.replace``-ing it into place gives
+    readers/crashes an all-or-nothing view.
+    """
+    _write_file_atomic(path, lambda f: f.write(text), encoding=encoding)
+
+
+def write_json_atomic(path: str, obj, indent: int = 2) -> None:
+    """Serialize ``obj`` to JSON at ``path`` atomically via streaming ``json.dump``.
+
+    Unlike ``write_text_atomic(json.dumps(obj))``, this never materializes the
+    full serialized string in memory -- important for large scenedata payloads
+    (ratings, tags, cull decisions).
+    """
+    def _dump(f):
+        json.dump(obj, f, indent=indent)
+
+    _write_file_atomic(path, _dump)
 
 
 def save_database(database: pd.DataFrame, db_path: str) -> None:

--- a/analyzer/tests/unit/test_database_atomic_save.py
+++ b/analyzer/tests/unit/test_database_atomic_save.py
@@ -7,6 +7,8 @@ destination and streams rows into it, so a concurrent reader can observe a
 partial file and raise ``EmptyDataError`` or ``ParserError``.
 """
 
+import errno
+import json
 import os
 import sys
 import threading
@@ -16,8 +18,6 @@ import pandas as pd
 import pytest
 
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
-
-import json
 
 from kestrel_analyzer.database import (
     _to_csv_atomic,
@@ -181,6 +181,38 @@ class TestAtomicTextWrite:
 
         assert p.read_bytes() == good
         assert sorted(x.name for x in tmp_path.iterdir()) == ["kestrel_database.csv"]
+
+    def test_flush_error_does_not_replace_existing(self, tmp_path, monkeypatch):
+        """ENOSPC on flush must not promote a partial temp over the last good file."""
+        p = tmp_path / "kestrel_database.csv"
+        write_text_atomic(str(p), "filename,quality\n")
+        good = p.read_bytes()
+        real_fdopen = _dbmod.os.fdopen
+
+        def wrapping_fdopen(*a, **k):
+            f = real_fdopen(*a, **k)
+
+            def boom_flush():
+                raise OSError(errno.ENOSPC, "No space left on device")
+
+            f.flush = boom_flush
+            return f
+
+        monkeypatch.setattr(_dbmod.os, "fdopen", wrapping_fdopen)
+        with pytest.raises(OSError):
+            write_text_atomic(str(p), "partial,\n")
+        assert p.read_bytes() == good
+        assert sorted(x.name for x in tmp_path.iterdir()) == ["kestrel_database.csv"]
+
+    def test_fsync_error_still_replaces(self, tmp_path, monkeypatch):
+        """Network-FS fsync failures are ignored; the flushed temp still replaces."""
+        def boom_fsync(_fd):
+            raise OSError(errno.EINVAL, "Operation not supported")
+
+        monkeypatch.setattr(_dbmod.os, "fsync", boom_fsync)
+        p = tmp_path / "kestrel_database.csv"
+        write_text_atomic(str(p), "ok\n")
+        assert p.read_text() == "ok\n"
 
 
 class TestAtomicJsonWrite:

--- a/analyzer/tests/unit/test_database_atomic_save.py
+++ b/analyzer/tests/unit/test_database_atomic_save.py
@@ -17,11 +17,16 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
+import json
+
 from kestrel_analyzer.database import (
     _to_csv_atomic,
     read_database_csv,
     save_database,
+    save_scenedata,
+    write_text_atomic,
 )
+import kestrel_analyzer.database as _dbmod
 
 pytestmark = pytest.mark.unit
 
@@ -149,3 +154,48 @@ class TestAtomicCsvWrite:
 
         assert sorted(os.listdir(tmp_path)) == ["kestrel_database.csv"]
         assert len(pd.read_csv(db_path)) == len(df)
+
+
+class TestAtomicTextWrite:
+    """write_text_atomic backs the scenedata (ratings/tags/cull) + UI CSV writes."""
+
+    def test_writes_content_and_leaves_no_temp(self, tmp_path):
+        p = tmp_path / "kestrel_scenedata.json"
+        write_text_atomic(str(p), '{"a": 1}')
+        assert p.read_text() == '{"a": 1}'
+        assert [x.name for x in tmp_path.iterdir()] == ["kestrel_scenedata.json"]
+
+    def test_existing_file_survives_a_failed_write(self, tmp_path, monkeypatch):
+        """A crash/replace failure mid-write must leave the previous file intact."""
+        p = tmp_path / "kestrel_scenedata.json"
+        write_text_atomic(str(p), json.dumps({"good": True}))
+        good = p.read_bytes()
+
+        def boom(*_a, **_k):
+            raise OSError("simulated crash during replace")
+
+        monkeypatch.setattr(_dbmod.os, "replace", boom)
+        with pytest.raises(OSError):
+            write_text_atomic(str(p), '{"partial": ')  # deliberately truncated
+
+        assert p.read_bytes() == good
+        assert [x.name for x in tmp_path.iterdir()] == ["kestrel_scenedata.json"]
+
+    def test_save_scenedata_is_atomic_and_roundtrips(self, tmp_path, monkeypatch):
+        scenedata = {"version": "2.0", "image_ratings": {"IMG_1.CR3": 5}, "scenes": {}}
+        save_scenedata(scenedata, str(tmp_path))
+        out = tmp_path / "kestrel_scenedata.json"
+        assert json.loads(out.read_text()) == scenedata
+
+        # A failed re-save must not destroy the previously saved decisions.
+        good = out.read_bytes()
+
+        def boom(*_a, **_k):
+            raise OSError("disk full")
+
+        monkeypatch.setattr(_dbmod.os, "replace", boom)
+        with pytest.raises(OSError):
+            save_scenedata({"version": "2.0", "image_ratings": {}, "scenes": {}}, str(tmp_path))
+        assert out.read_bytes() == good
+        # no stray temp files
+        assert sorted(x.name for x in tmp_path.iterdir()) == ["kestrel_scenedata.json"]

--- a/analyzer/tests/unit/test_database_atomic_save.py
+++ b/analyzer/tests/unit/test_database_atomic_save.py
@@ -189,14 +189,33 @@ class TestAtomicTextWrite:
         good = p.read_bytes()
         real_fdopen = _dbmod.os.fdopen
 
-        def wrapping_fdopen(*a, **k):
-            f = real_fdopen(*a, **k)
+        class FlushBoom:
+            """Delegates to the real fdopen file; flush is not assignable on TextIOWrapper."""
 
-            def boom_flush():
+            def __init__(self, real):
+                self._real = real
+
+            def write(self, *a, **k):
+                return self._real.write(*a, **k)
+
+            def flush(self):
                 raise OSError(errno.ENOSPC, "No space left on device")
 
-            f.flush = boom_flush
-            return f
+            def fileno(self):
+                return self._real.fileno()
+
+            def close(self):
+                return self._real.close()
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *exc):
+                self.close()
+                return False
+
+        def wrapping_fdopen(*a, **k):
+            return FlushBoom(real_fdopen(*a, **k))
 
         monkeypatch.setattr(_dbmod.os, "fdopen", wrapping_fdopen)
         with pytest.raises(OSError):

--- a/analyzer/tests/unit/test_database_atomic_save.py
+++ b/analyzer/tests/unit/test_database_atomic_save.py
@@ -161,15 +161,15 @@ class TestAtomicTextWrite:
     """write_text_atomic backs the UI CSV write path."""
 
     def test_writes_content_and_leaves_no_temp(self, tmp_path):
-        p = tmp_path / "kestrel_scenedata.json"
-        write_text_atomic(str(p), '{"a": 1}')
-        assert p.read_text() == '{"a": 1}'
-        assert [x.name for x in tmp_path.iterdir()] == ["kestrel_scenedata.json"]
+        p = tmp_path / "kestrel_database.csv"
+        write_text_atomic(str(p), "filename,quality\n")
+        assert p.read_text() == "filename,quality\n"
+        assert sorted(x.name for x in tmp_path.iterdir()) == ["kestrel_database.csv"]
 
     def test_existing_file_survives_a_failed_write(self, tmp_path, monkeypatch):
         """A crash/replace failure mid-write must leave the previous file intact."""
-        p = tmp_path / "kestrel_scenedata.json"
-        write_text_atomic(str(p), json.dumps({"good": True}))
+        p = tmp_path / "kestrel_database.csv"
+        write_text_atomic(str(p), "filename,quality\nIMG_1.CR3,0.9\n")
         good = p.read_bytes()
 
         def boom(*_a, **_k):
@@ -177,10 +177,10 @@ class TestAtomicTextWrite:
 
         monkeypatch.setattr(_dbmod.os, "replace", boom)
         with pytest.raises(OSError):
-            write_text_atomic(str(p), '{"partial": ')  # deliberately truncated
+            write_text_atomic(str(p), "partial,")  # deliberately truncated
 
         assert p.read_bytes() == good
-        assert [x.name for x in tmp_path.iterdir()] == ["kestrel_scenedata.json"]
+        assert sorted(x.name for x in tmp_path.iterdir()) == ["kestrel_database.csv"]
 
 
 class TestAtomicJsonWrite:
@@ -191,7 +191,7 @@ class TestAtomicJsonWrite:
         obj = {"version": "2.0", "image_ratings": {"IMG_1.CR3": 5}, "scenes": {}}
         write_json_atomic(str(p), obj, indent=2)
         assert json.loads(p.read_text()) == obj
-        assert [x.name for x in tmp_path.iterdir()] == ["kestrel_scenedata.json"]
+        assert sorted(x.name for x in tmp_path.iterdir()) == ["kestrel_scenedata.json"]
 
     def test_streams_via_dump_not_dumps(self, tmp_path, monkeypatch):
         """Peak-memory path: serialize directly into the temp file."""
@@ -227,7 +227,7 @@ class TestAtomicJsonWrite:
             write_json_atomic(str(p), {"partial": True}, indent=2)
 
         assert p.read_bytes() == good
-        assert [x.name for x in tmp_path.iterdir()] == ["kestrel_scenedata.json"]
+        assert sorted(x.name for x in tmp_path.iterdir()) == ["kestrel_scenedata.json"]
 
     def test_save_scenedata_is_atomic_and_roundtrips(self, tmp_path, monkeypatch):
         scenedata = {"version": "2.0", "image_ratings": {"IMG_1.CR3": 5}, "scenes": {}}
@@ -255,3 +255,12 @@ class TestAtomicJsonWrite:
         monkeypatch.setattr(_dbmod.json, "dumps", fail_dumps)
         save_scenedata({"version": "2.0", "image_ratings": {}, "scenes": {}}, str(tmp_path))
         assert (tmp_path / "kestrel_scenedata.json").exists()
+
+
+def test_api_bridge_atomic_writers_are_callable():
+    """Import fallback must not leave write_*_atomic as None (TypeError on save)."""
+    import api_bridge
+
+    assert callable(api_bridge.write_json_atomic)
+    assert callable(api_bridge.write_text_atomic)
+

--- a/analyzer/tests/unit/test_database_atomic_save.py
+++ b/analyzer/tests/unit/test_database_atomic_save.py
@@ -24,6 +24,7 @@ from kestrel_analyzer.database import (
     read_database_csv,
     save_database,
     save_scenedata,
+    write_json_atomic,
     write_text_atomic,
 )
 import kestrel_analyzer.database as _dbmod
@@ -157,7 +158,7 @@ class TestAtomicCsvWrite:
 
 
 class TestAtomicTextWrite:
-    """write_text_atomic backs the scenedata (ratings/tags/cull) + UI CSV writes."""
+    """write_text_atomic backs the UI CSV write path."""
 
     def test_writes_content_and_leaves_no_temp(self, tmp_path):
         p = tmp_path / "kestrel_scenedata.json"
@@ -181,6 +182,53 @@ class TestAtomicTextWrite:
         assert p.read_bytes() == good
         assert [x.name for x in tmp_path.iterdir()] == ["kestrel_scenedata.json"]
 
+
+class TestAtomicJsonWrite:
+    """write_json_atomic streams json.dump into the temp file (no dumps buffer)."""
+
+    def test_roundtrips_and_leaves_no_temp(self, tmp_path):
+        p = tmp_path / "kestrel_scenedata.json"
+        obj = {"version": "2.0", "image_ratings": {"IMG_1.CR3": 5}, "scenes": {}}
+        write_json_atomic(str(p), obj, indent=2)
+        assert json.loads(p.read_text()) == obj
+        assert [x.name for x in tmp_path.iterdir()] == ["kestrel_scenedata.json"]
+
+    def test_streams_via_dump_not_dumps(self, tmp_path, monkeypatch):
+        """Peak-memory path: serialize directly into the temp file."""
+        dumped = {"via": None}
+
+        real_dump = json.dump
+        real_dumps = json.dumps
+
+        def tracking_dump(obj, fp, *a, **k):
+            dumped["via"] = "dump"
+            return real_dump(obj, fp, *a, **k)
+
+        def tracking_dumps(*a, **k):
+            dumped["via"] = "dumps"
+            return real_dumps(*a, **k)
+
+        monkeypatch.setattr(_dbmod.json, "dump", tracking_dump)
+        monkeypatch.setattr(_dbmod.json, "dumps", tracking_dumps)
+
+        write_json_atomic(str(tmp_path / "kestrel_scenedata.json"), {"a": 1}, indent=2)
+        assert dumped["via"] == "dump"
+
+    def test_existing_file_survives_a_failed_write(self, tmp_path, monkeypatch):
+        p = tmp_path / "kestrel_scenedata.json"
+        write_json_atomic(str(p), {"good": True}, indent=2)
+        good = p.read_bytes()
+
+        def boom(*_a, **_k):
+            raise OSError("simulated crash during replace")
+
+        monkeypatch.setattr(_dbmod.os, "replace", boom)
+        with pytest.raises(OSError):
+            write_json_atomic(str(p), {"partial": True}, indent=2)
+
+        assert p.read_bytes() == good
+        assert [x.name for x in tmp_path.iterdir()] == ["kestrel_scenedata.json"]
+
     def test_save_scenedata_is_atomic_and_roundtrips(self, tmp_path, monkeypatch):
         scenedata = {"version": "2.0", "image_ratings": {"IMG_1.CR3": 5}, "scenes": {}}
         save_scenedata(scenedata, str(tmp_path))
@@ -199,3 +247,11 @@ class TestAtomicTextWrite:
         assert out.read_bytes() == good
         # no stray temp files
         assert sorted(x.name for x in tmp_path.iterdir()) == ["kestrel_scenedata.json"]
+
+    def test_save_scenedata_does_not_call_dumps(self, tmp_path, monkeypatch):
+        def fail_dumps(*_a, **_k):
+            raise AssertionError("json.dumps must not be used")
+
+        monkeypatch.setattr(_dbmod.json, "dumps", fail_dumps)
+        save_scenedata({"version": "2.0", "image_ratings": {}, "scenes": {}}, str(tmp_path))
+        assert (tmp_path / "kestrel_scenedata.json").exists()

--- a/analyzer/tests/unit/test_database_atomic_save.py
+++ b/analyzer/tests/unit/test_database_atomic_save.py
@@ -156,6 +156,45 @@ class TestAtomicCsvWrite:
         assert sorted(os.listdir(tmp_path)) == ["kestrel_database.csv"]
         assert len(pd.read_csv(db_path)) == len(df)
 
+    def test_flush_error_does_not_replace_existing(self, tmp_path, monkeypatch):
+        """ENOSPC on flush must not promote a partial CSV temp over the last good file."""
+        db_path = tmp_path / "kestrel_database.csv"
+        _to_csv_atomic(_frame(5), str(db_path))
+        good = db_path.read_bytes()
+        real_fdopen = _dbmod.os.fdopen
+
+        class FlushBoom:
+            def __init__(self, real):
+                self._real = real
+
+            def write(self, *a, **k):
+                return self._real.write(*a, **k)
+
+            def flush(self):
+                raise OSError(errno.ENOSPC, "No space left on device")
+
+            def fileno(self):
+                return self._real.fileno()
+
+            def close(self):
+                return self._real.close()
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *exc):
+                self.close()
+                return False
+
+        def wrapping_fdopen(*a, **k):
+            return FlushBoom(real_fdopen(*a, **k))
+
+        monkeypatch.setattr(_dbmod.os, "fdopen", wrapping_fdopen)
+        with pytest.raises(OSError):
+            _to_csv_atomic(_frame(5), str(db_path))
+        assert db_path.read_bytes() == good
+        assert sorted(x.name for x in tmp_path.iterdir()) == ["kestrel_database.csv"]
+
 
 class TestAtomicTextWrite:
     """write_text_atomic backs the UI CSV write path."""


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

`save_database` already writes atomically (`_to_csv_atomic`: temp file + `os.replace`), but three sibling write paths still used a plain `open('w')` / `json.dump`, which truncates the destination in place. A crash or power loss mid-write leaves a partial/empty file and loses data:

- `kestrel_analyzer/database.py::save_scenedata` — writes `kestrel_scenedata.json`, the **only** home for the user's manual ratings, tags and Accept/Reject decisions.
- `api_bridge.py::write_kestrel_scenedata` — the UI save path for the same file.
- `api_bridge.py::write_kestrel_csv` — the UI save path for `kestrel_database.csv`.

## Fix

Add a shared `write_text_atomic(path, text, encoding)` helper in `database.py` (temp file in the same dir + `flush`/`fsync` + `os.replace` via the existing `retry_on_file_lock`, mirroring `_to_csv_atomic` and `settings_utils.save_settings`) and route all three writes through it. On any failure the temp file is removed and the previous file is left intact — never a partial write.

## Testing

New tests in `analyzer/tests/unit/test_database_atomic_save.py`:
- `write_text_atomic` content round-trip with no temp-file leftovers.
- The previous file survives a failed `os.replace` (injected `OSError`), leaving no temp files.
- `save_scenedata` round-trips and a failed re-save preserves the prior decisions.

Full unit suite: 617 passed, 1 skipped. The only 2 failures (`test_cli_args` `RecursionError`) are pre-existing and unrelated to this change (a `datetime.utcnow()` deprecation-warning recursion in the pipeline warning hook, not touched here).

## Note

Part of a series of P1 data-loss fixes from an analyzer review. The core CSV atomic-write finding is already fixed on `main`; this PR extends the same guarantee to the scenedata and UI write paths that were missed.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c5090e64-798b-45af-8972-8263f4d5554a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c5090e64-798b-45af-8972-8263f4d5554a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

