### PR TITLE
Cursor/fix queue error and decode leak 554a

### DIFF
--- a/analyzer/kestrel_analyzer/pipeline.py
+++ b/analyzer/kestrel_analyzer/pipeline.py
@@ -268,6 +268,7 @@ class AnalysisPipeline:
         max_buffered = max_workers + 1
         semaphore = threading.Semaphore(max_buffered)
         futures_q: queue.Queue = queue.Queue()
+        stop_event = threading.Event()
 
         # Fixed cadence (every 10 images) rather than a percentage of total so
         # long runs remain observable in real time. First 3 images always
@@ -289,7 +290,14 @@ class AnalysisPipeline:
             nonlocal submitted, peak_inflight
             with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
                 for raw_file in file_list:
+                    if stop_event.is_set():
+                        break
                     semaphore.acquire()
+                    if stop_event.is_set():
+                        # Consumer abandoned the generator (cancel / fatal error)
+                        # while we waited for a free buffer slot; stop submitting
+                        # so the pool can drain and shut down.
+                        break
                     future = executor.submit(
                         _decode_and_time,
                         os.path.join(folder, raw_file),
@@ -312,33 +320,44 @@ class AnalysisPipeline:
             f"buffer={max_buffered}"
         )
 
-        while True:
-            future = futures_q.get()
-            if future is None:
-                break
-            t_wait = time.monotonic()
-            decoded = future.result()
-            wait_ms = (time.monotonic() - t_wait) * 1000.0
-            with metrics_lock:
-                total_wait_ms += wait_ms
-                snap_submitted = submitted
-                snap_completed = completed
-            idx += 1
+        try:
+            while True:
+                future = futures_q.get()
+                if future is None:
+                    break
+                t_wait = time.monotonic()
+                decoded = future.result()
+                wait_ms = (time.monotonic() - t_wait) * 1000.0
+                with metrics_lock:
+                    total_wait_ms += wait_ms
+                    snap_submitted = submitted
+                    snap_completed = completed
+                idx += 1
 
-            # Print for the first 3 images (warm-up visibility), then every
-            # ~10% of the run, and always on the last image.
-            if idx <= 3 or idx % log_every_n == 0 or idx == total:
-                decode_ms = decoded.get("_decode_ms")
-                decode_ms_str = f"{decode_ms:.0f}" if decode_ms is not None else "?"
-                inflight_now = max(0, snap_submitted - snap_completed)
-                ahead = max(0, snap_submitted - idx)
-                _debug(
-                    f"[decode-queue] idx={idx}/{total} "
-                    f"inflight={inflight_now} ahead={ahead} "
-                    f"decode_ms={decode_ms_str} wait_ms={wait_ms:.0f}"
-                )
+                # Print for the first 3 images (warm-up visibility), then every
+                # ~10% of the run, and always on the last image.
+                if idx <= 3 or idx % log_every_n == 0 or idx == total:
+                    decode_ms = decoded.get("_decode_ms")
+                    decode_ms_str = f"{decode_ms:.0f}" if decode_ms is not None else "?"
+                    inflight_now = max(0, snap_submitted - snap_completed)
+                    ahead = max(0, snap_submitted - idx)
+                    _debug(
+                        f"[decode-queue] idx={idx}/{total} "
+                        f"inflight={inflight_now} ahead={ahead} "
+                        f"decode_ms={decode_ms_str} wait_ms={wait_ms:.0f}"
+                    )
 
-            yield decoded
+                yield decoded
+                semaphore.release()
+        finally:
+            # If the consumer abandons this generator early -- an outer cancel or
+            # a fatal error makes process_folder return, which raises
+            # GeneratorExit at the yield above -- the loop stops releasing the
+            # semaphore. Signal the producer to stop and free one slot so it
+            # unblocks from semaphore.acquire(), lets its ThreadPoolExecutor
+            # drain, and exits. Without this the decode-worker threads (and their
+            # buffered full-res images) leak for the rest of the process.
+            stop_event.set()
             semaphore.release()
 
         submit_thread.join()

--- a/analyzer/queue_manager.py
+++ b/analyzer/queue_manager.py
@@ -619,7 +619,11 @@ class QueueManager:
                         # without raising; surface it as an errored folder rather
                         # than a false 'done'.
                         item.status = 'error'
-                        item.error = str(fatal_error['exc'])
+                        # Some exceptions stringify to '' (e.g. RuntimeError());
+                        # fall back to the type name so the UI never shows a
+                        # blank error for a failed folder.
+                        _exc = fatal_error['exc']
+                        item.error = str(_exc) or type(_exc).__name__
                         item.end_time = _time_mod.time()
                     else:
                         item.status = 'done'

--- a/analyzer/queue_manager.py
+++ b/analyzer/queue_manager.py
@@ -486,6 +486,15 @@ class QueueManager:
                 pass
 
             try:
+                # process_folder() logs a fatal error (e.g. a failed model load
+                # or DB read) and returns normally instead of raising, so capture
+                # it here; otherwise a folder that never analyzed is marked 'done'.
+                fatal_error = {'exc': None}
+
+                def _on_error(kind, exc, _fatal=fatal_error):
+                    if kind == 'fatal':
+                        _fatal['exc'] = exc
+
                 def _on_progress(processed, total, _it=item):
                     with self._lock:
                         if _it.initial_processed == 0 and processed > 0 and _it.processed == 0:
@@ -589,6 +598,7 @@ class QueueManager:
                         'on_crops': _on_crops,
                         'on_quality': _on_quality,
                         'on_species': _on_species,
+                        'on_error': _on_error,
                     },
                     analyzer_name='visualizer-queue',
                     wildlife_enabled=self._wildlife_enabled,
@@ -603,6 +613,13 @@ class QueueManager:
                 with self._lock:
                     if self._cancel_event.is_set():
                         item.status = 'cancelled'
+                        item.end_time = _time_mod.time()
+                    elif fatal_error['exc'] is not None:
+                        # process_folder() caught a fatal error and returned
+                        # without raising; surface it as an errored folder rather
+                        # than a false 'done'.
+                        item.status = 'error'
+                        item.error = str(fatal_error['exc'])
                         item.end_time = _time_mod.time()
                     else:
                         item.status = 'done'

--- a/analyzer/queue_manager.py
+++ b/analyzer/queue_manager.py
@@ -637,7 +637,7 @@ class QueueManager:
                 with self._lock:
                     item.status = 'error'
                     item.end_time = _time_mod.time()
-                    item.error = str(exc)
+                    item.error = str(exc) or type(exc).__name__
                 self._persist_recovery_state()
                 self._send_folder_analytics(item)
 

--- a/analyzer/tests/unit/test_decode_generator_leak.py
+++ b/analyzer/tests/unit/test_decode_generator_leak.py
@@ -42,7 +42,11 @@ def test_decode_generator_releases_threads_on_early_close(tmp_path):
 
     pipeline = AnalysisPipeline(use_gpu=False)
 
-    assert _decode_threads() == []
+    # Record a baseline rather than asserting a globally-empty set: another test
+    # or library in the same pytest process may legitimately keep a
+    # ThreadPoolExecutor thread alive. We only care that THIS generator adds no
+    # surviving threads.
+    baseline = set(_decode_threads())
 
     gen = pipeline._iter_decoded(names, str(tmp_path), max_workers=3)
     next(gen)          # start the producer thread + pool, consume one item
@@ -51,8 +55,8 @@ def test_decode_generator_releases_threads_on_early_close(tmp_path):
     # The producer must unblock, drain its pool and exit; poll briefly because
     # the executor waits for in-flight decodes before shutting down.
     deadline = time.time() + 10
-    while time.time() < deadline and _decode_threads():
+    while time.time() < deadline and (set(_decode_threads()) - baseline):
         time.sleep(0.05)
 
-    leftover = _decode_threads()
+    leftover = sorted(set(_decode_threads()) - baseline)
     assert leftover == [], f"decode threads leaked after early close: {leftover}"

--- a/analyzer/tests/unit/test_decode_generator_leak.py
+++ b/analyzer/tests/unit/test_decode_generator_leak.py
@@ -1,0 +1,58 @@
+"""Regression test: the decode generator must not leak threads on early close.
+
+``AnalysisPipeline._iter_decoded`` runs a producer thread that owns a
+ThreadPoolExecutor and is bounded by a semaphore the consumer releases after
+each yield. If the consumer abandons the generator early (an outer cancel or a
+fatal error makes ``process_folder`` return, raising GeneratorExit at the
+yield), the release never happened, so the producer stayed parked on
+``semaphore.acquire()`` forever and its decode-worker threads leaked for the
+process lifetime.
+"""
+
+import sys
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from kestrel_analyzer.pipeline import AnalysisPipeline
+
+pytestmark = pytest.mark.unit
+
+
+def _decode_threads():
+    return [
+        t.name for t in threading.enumerate()
+        if '_submit_all' in t.name or 'ThreadPoolExecutor' in t.name
+    ]
+
+
+def test_decode_generator_releases_threads_on_early_close(tmp_path):
+    # A handful of files so the threaded path (max_workers > 1) is exercised.
+    names = []
+    for i in range(6):
+        p = tmp_path / f"img_{i}.jpg"
+        # Not a real JPEG: _decode_image catches the failure and returns an
+        # error dict, which is still yielded -- enough to drive the generator.
+        p.write_bytes(b"\xff\xd8\xff\xe0not-a-real-jpeg")
+        names.append(p.name)
+
+    pipeline = AnalysisPipeline(use_gpu=False)
+
+    assert _decode_threads() == []
+
+    gen = pipeline._iter_decoded(names, str(tmp_path), max_workers=3)
+    next(gen)          # start the producer thread + pool, consume one item
+    gen.close()        # GeneratorExit at the yield, like process_folder's return
+
+    # The producer must unblock, drain its pool and exit; poll briefly because
+    # the executor waits for in-flight decodes before shutting down.
+    deadline = time.time() + 10
+    while time.time() < deadline and _decode_threads():
+        time.sleep(0.05)
+
+    leftover = _decode_threads()
+    assert leftover == [], f"decode threads leaked after early close: {leftover}"

--- a/analyzer/tests/unit/test_queue_fatal_error.py
+++ b/analyzer/tests/unit/test_queue_fatal_error.py
@@ -1,0 +1,48 @@
+"""Regression test: a fatal pipeline error must not be reported as a done folder.
+
+``AnalysisPipeline.process_folder`` catches a fatal error (e.g. a failed model
+load or DB read), logs it, calls ``on_error('fatal', exc)`` and returns
+normally rather than raising. The queue therefore saw no exception and used to
+mark the folder ``done`` with 0 images processed -- a silent false success.
+Wiring ``on_error`` lets the queue surface it as ``error`` instead.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+import queue_manager
+
+pytestmark = pytest.mark.unit
+
+
+class _FatalPipeline:
+    """Stub mirroring the real pipeline's swallow-fatal-and-return behavior."""
+
+    detector_name = None
+    use_gpu = False
+
+    def process_folder(self, path, pause_event=None, cancel_event=None,
+                        callbacks=None, **kwargs):
+        cb = (callbacks or {}).get('on_error')
+        if cb:
+            cb('fatal', RuntimeError('simulated model load failure'))
+        # Returns normally, exactly like process_folder after its outer except.
+
+
+def test_fatal_pipeline_error_marks_folder_error(tmp_path):
+    mgr = queue_manager.QueueManager()
+    # Pre-seed the cached pipeline so _run reuses the stub instead of building
+    # a real AnalysisPipeline.
+    mgr._pipeline = _FatalPipeline()
+
+    folder = str(tmp_path)
+    mgr.enqueue([folder], use_gpu=False)
+    assert mgr.join_worker(timeout=30) is True
+
+    item = mgr._items[0]
+    assert item.status == 'error', f"expected 'error', got {item.status!r}"
+    assert item.error, "fatal error message should be surfaced, not empty"

--- a/analyzer/tests/unit/test_queue_fatal_error.py
+++ b/analyzer/tests/unit/test_queue_fatal_error.py
@@ -46,3 +46,47 @@ def test_fatal_pipeline_error_marks_folder_error(tmp_path):
     item = mgr._items[0]
     assert item.status == 'error', f"expected 'error', got {item.status!r}"
     assert item.error, "fatal error message should be surfaced, not empty"
+
+
+class _FatalEmptyPipeline:
+    """Fatal callback with an exception whose str() is empty."""
+
+    detector_name = None
+    use_gpu = False
+
+    def process_folder(self, path, pause_event=None, cancel_event=None,
+                        callbacks=None, **kwargs):
+        cb = (callbacks or {}).get('on_error')
+        if cb:
+            cb('fatal', RuntimeError())
+
+
+class _RaisingEmptyPipeline:
+    """process_folder raises an empty-message exception (outer queue except)."""
+
+    detector_name = None
+    use_gpu = False
+
+    def process_folder(self, path, pause_event=None, cancel_event=None,
+                        callbacks=None, **kwargs):
+        raise RuntimeError()
+
+
+def test_empty_fatal_exception_uses_type_name(tmp_path):
+    mgr = queue_manager.QueueManager()
+    mgr._pipeline = _FatalEmptyPipeline()
+    mgr.enqueue([str(tmp_path)], use_gpu=False)
+    assert mgr.join_worker(timeout=30) is True
+    item = mgr._items[0]
+    assert item.status == 'error'
+    assert item.error == 'RuntimeError'
+
+
+def test_empty_raised_exception_uses_type_name(tmp_path):
+    mgr = queue_manager.QueueManager()
+    mgr._pipeline = _RaisingEmptyPipeline()
+    mgr.enqueue([str(tmp_path)], use_gpu=False)
+    assert mgr.join_worker(timeout=30) is True
+    item = mgr._items[0]
+    assert item.status == 'error'
+    assert item.error == 'RuntimeError'


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Two related robustness fixes from an analyzer review (one commit each).

## 1. `fix(queue)`: a fatal pipeline error was reported as a done folder

`AnalysisPipeline.process_folder` catches a fatal error (e.g. a failed model load or DB read), logs it, calls `on_error('fatal', exc)` and **returns normally** rather than raising. The queue's callbacks dict (`queue_manager._run`) had no `on_error` entry, so the error was invisible and the folder was marked `done` with 0 images processed — a silent false success; the queue then moved on as if the folder had been analyzed.

Fix: wire an `on_error` callback that captures a fatal error and mark the item `error` (with the message) when one occurred, instead of `done`.

## 2. `fix(pipeline)`: decode threads leak when the generator is abandoned

`_iter_decoded` runs a producer thread that owns a `ThreadPoolExecutor` and is bounded by a semaphore the consumer releases after each `yield`. When the consumer abandons the generator early — an outer cancel or a fatal error makes `process_folder` return, raising `GeneratorExit` at the `yield` — the release never ran, so the producer stayed parked on `semaphore.acquire()` forever and its decode-worker threads (and their buffered full-res images) leaked for the rest of the process. Over repeated cancel/retry cycles this accumulates.

Fix: add a `stop_event` the producer checks around its blocking `acquire`, and wrap the consumer loop in `try/finally` so an early exit signals the producer and frees a slot, letting the executor drain and shut down.

## Testing

- `analyzer/tests/unit/test_queue_fatal_error.py` — a stub pipeline that reports a fatal error; asserts the queue item ends `error` (not `done`) with a non-empty message.
- `analyzer/tests/unit/test_decode_generator_leak.py` — starts the decode generator, consumes one item, `gen.close()`s it early, and asserts no `_submit_all` / `ThreadPoolExecutor` threads survive.
- Full unit suite: 616 passed, 1 skipped. The only 2 failures (`test_cli_args` `RecursionError`) are pre-existing and unrelated (a `datetime.utcnow()` deprecation-warning recursion in the pipeline warning hook, not touched here).

## Note

Part of a series of P1 fixes from an analyzer review. Sibling PRs cover the reject-folder overwrite guard and atomic scenedata/CSV writes.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c5090e64-798b-45af-8972-8263f4d5554a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c5090e64-798b-45af-8972-8263f4d5554a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

