### PR TITLE
fix(database): don't drop manual ratings with a blank rating_origin on migration

### DIFF
--- a/analyzer/kestrel_analyzer/database.py
+++ b/analyzer/kestrel_analyzer/database.py
@@ -180,7 +180,14 @@ def _build_scenedata_from_legacy_db(database: pd.DataFrame) -> dict:
             filename = str(row.get("filename", ""))
             if not filename:
                 continue
-            origin = str(row.get("rating_origin", "")).lower() if has_origin else ""
+            if has_origin:
+                raw_origin = row.get("rating_origin", "")
+                # A blank field is read by pd.read_csv as NaN, so str(NaN) would
+                # be 'nan' rather than ''. Normalize NaN/None/whitespace to ''
+                # so a blank origin is treated as "no explicit origin".
+                origin = "" if pd.isna(raw_origin) else str(raw_origin).strip().lower()
+            else:
+                origin = ""
             rating_val = row.get("rating", None)
             try:
                 r = int(float(rating_val))

--- a/analyzer/kestrel_analyzer/database.py
+++ b/analyzer/kestrel_analyzer/database.py
@@ -186,10 +186,14 @@ def _build_scenedata_from_legacy_db(database: pd.DataFrame) -> dict:
                 r = int(float(rating_val))
             except (TypeError, ValueError):
                 continue
-            # Save if explicitly manual, or if non-zero with no origin (implies user intent)
-            if origin == "manual" or (not has_origin and 1 <= r <= 5):
-                if 1 <= r <= 5:
-                    scenedata["image_ratings"][filename] = r
+            # Preserve a real 1-5 rating unless it is explicitly an auto rating.
+            # A blank origin is treated like "no origin column": a rating with no
+            # explicit 'auto' marker is assumed to be user intent, so it is not
+            # dropped during migration. (Previously, when a rating_origin column
+            # existed but was blank for a manually-rated row, the rating was
+            # silently lost.) Explicit 'auto' ratings are left for recomputation.
+            if 1 <= r <= 5 and origin in ("", "manual"):
+                scenedata["image_ratings"][filename] = r
 
     # Build scenes from scene_count grouping
     if "scene_count" in database.columns:

--- a/analyzer/tests/unit/test_legacy_rating_migration.py
+++ b/analyzer/tests/unit/test_legacy_rating_migration.py
@@ -8,6 +8,7 @@ now treated like "no origin column" (assumed user intent); explicit ``auto``
 ratings are still left for recomputation.
 """
 
+import io
 import sys
 from pathlib import Path
 
@@ -21,17 +22,35 @@ from kestrel_analyzer.database import _build_scenedata_from_legacy_db
 pytestmark = pytest.mark.unit
 
 
-def test_blank_origin_rating_is_preserved_not_dropped():
-    df = pd.DataFrame({
-        "filename": ["A.CR3", "B.CR3", "C.CR3"],
-        "rating": [4, 5, 3],
-        "rating_origin": ["", "manual", "auto"],   # blank / manual / auto
-        "scene_count": [1, 1, 2],
-    })
+def test_blank_origin_via_read_csv_is_preserved_not_dropped():
+    """Reproduces the real path: a blank CSV field becomes NaN via pd.read_csv."""
+    csv_text = (
+        "filename,rating,rating_origin,scene_count\n"
+        "A.CR3,4,,1\n"          # blank rating_origin -> NaN
+        "B.CR3,5,manual,1\n"
+        "C.CR3,3,auto,2\n"
+    )
+    df = pd.read_csv(io.StringIO(csv_text))
+    # Sanity: the blank field really is NaN, not '' (this is what broke the fix).
+    assert pd.isna(df.loc[0, "rating_origin"])
+
     ratings = _build_scenedata_from_legacy_db(df)["image_ratings"]
-    assert ratings.get("A.CR3") == 4, "blank-origin rating must be preserved"
+    assert ratings.get("A.CR3") == 4, "blank/NaN-origin rating must be preserved"
     assert ratings.get("B.CR3") == 5, "manual rating must be preserved"
     assert "C.CR3" not in ratings, "explicit 'auto' rating must not be migrated"
+
+
+def test_blank_and_nan_origins_preserved_directly():
+    """Both an empty string and a real NaN origin count as user intent."""
+    df = pd.DataFrame({
+        "filename": ["A.CR3", "B.CR3"],
+        "rating": [4, 2],
+        "rating_origin": ["", float("nan")],
+        "scene_count": [1, 1],
+    })
+    ratings = _build_scenedata_from_legacy_db(df)["image_ratings"]
+    assert ratings.get("A.CR3") == 4
+    assert ratings.get("B.CR3") == 2
 
 
 def test_no_origin_column_preserves_nonzero_ratings():

--- a/analyzer/tests/unit/test_legacy_rating_migration.py
+++ b/analyzer/tests/unit/test_legacy_rating_migration.py
@@ -1,0 +1,45 @@
+"""Regression test for legacy rating -> scenedata migration.
+
+When a legacy CSV had a ``rating_origin`` column that was blank for a
+manually-rated row, the migration dropped the rating: the condition required
+``origin == "manual"`` OR ``(no origin column AND 1<=r<=5)``, so a blank origin
+with a real rating fell through both branches and was lost. A blank origin is
+now treated like "no origin column" (assumed user intent); explicit ``auto``
+ratings are still left for recomputation.
+"""
+
+import sys
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from kestrel_analyzer.database import _build_scenedata_from_legacy_db
+
+pytestmark = pytest.mark.unit
+
+
+def test_blank_origin_rating_is_preserved_not_dropped():
+    df = pd.DataFrame({
+        "filename": ["A.CR3", "B.CR3", "C.CR3"],
+        "rating": [4, 5, 3],
+        "rating_origin": ["", "manual", "auto"],   # blank / manual / auto
+        "scene_count": [1, 1, 2],
+    })
+    ratings = _build_scenedata_from_legacy_db(df)["image_ratings"]
+    assert ratings.get("A.CR3") == 4, "blank-origin rating must be preserved"
+    assert ratings.get("B.CR3") == 5, "manual rating must be preserved"
+    assert "C.CR3" not in ratings, "explicit 'auto' rating must not be migrated"
+
+
+def test_no_origin_column_preserves_nonzero_ratings():
+    df = pd.DataFrame({
+        "filename": ["A.CR3", "B.CR3"],
+        "rating": [3, 0],
+        "scene_count": [1, 1],
+    })
+    ratings = _build_scenedata_from_legacy_db(df)["image_ratings"]
+    assert ratings.get("A.CR3") == 3
+    assert "B.CR3" not in ratings   # a 0 rating is "unrated", not migrated


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

`_build_scenedata_from_legacy_db` (the one-time legacy CSV -> `kestrel_scenedata.json` upgrade) migrated a row's rating only when `origin == "manual"` **or** `(no rating_origin column AND 1 <= r <= 5)`. A legacy CSV that *had* a `rating_origin` column but left it **blank** for a manually-rated row fell through both branches, so that rating was silently lost during the upgrade.

## Fix

Treat a blank origin like "no origin column": a real 1–5 rating with no explicit `auto` marker is assumed to be user intent and preserved. Explicit `auto` ratings are still left for recomputation.

```python
if 1 <= r <= 5 and origin in ("", "manual"):
    scenedata["image_ratings"][filename] = r
```

## Testing

`analyzer/tests/unit/test_legacy_rating_migration.py`:
- blank origin -> preserved; `manual` -> preserved; `auto` -> not migrated.
- no `rating_origin` column: non-zero ratings preserved, 0 (unrated) not migrated.

Existing `compat/test_database_migration.py` still passes (15 passed, 6 skipped).

## Note

Re-verified as still present on current `main`. This is a low-likelihood edge (depends on a transitional CSV schema with a blank-but-present `rating_origin`), but it is silent user-data loss during a one-time upgrade, so worth closing.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c5090e64-798b-45af-8972-8263f4d5554a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c5090e64-798b-45af-8972-8263f4d5554a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

