### PR TITLE
fix(io): restore DB/scenedata backups atomically

### DIFF
--- a/analyzer/api_bridge.py
+++ b/analyzer/api_bridge.py
@@ -6784,13 +6784,21 @@ class Api:
             if not os.path.exists(csv_backup):
                 return {"success": False, "error": "kestrel_database_old.csv not found"}
 
+            # Atomic restore: overwrite the live files via temp-file + os.replace
+            # so an interrupted restore can't leave the live database/scenedata
+            # half-written. (This path runs right after a risky reject-and-move.)
+            try:
+                from kestrel_analyzer.database import copy_file_atomic
+            except ImportError:
+                from analyzer.kestrel_analyzer.database import copy_file_atomic  # type: ignore[no-redef]
+
             # Restore CSV
-            shutil.copy2(csv_backup, csv_path)
+            copy_file_atomic(csv_backup, csv_path)
             info(f"[backup] CSV restored from {csv_backup}")
 
             # Restore scenedata if backup exists
             if os.path.exists(scenedata_backup):
-                shutil.copy2(scenedata_backup, scenedata_path)
+                copy_file_atomic(scenedata_backup, scenedata_path)
                 info(f"[backup] Scenedata restored from {scenedata_backup}")
 
             return {"success": True, "error": ""}

--- a/analyzer/kestrel_analyzer/database.py
+++ b/analyzer/kestrel_analyzer/database.py
@@ -1,5 +1,6 @@
 import json
 import os
+import shutil
 import tempfile
 import time
 from datetime import datetime
@@ -466,6 +467,32 @@ def _to_csv_atomic(database: pd.DataFrame, db_path: str) -> None:
     except BaseException:
         # Do NOT fall back to a direct write — that is the partial-read path
         # this function exists to close. Leave the previous file intact.
+        try:
+            os.remove(tmp)
+        except OSError:
+            pass
+        raise
+
+
+def copy_file_atomic(src_path: str, dst_path: str) -> None:
+    """Copy ``src_path`` onto ``dst_path`` atomically (temp file + os.replace).
+
+    Used by the backup-restore path: ``shutil.copy2`` writes the destination in
+    place, so an interrupted restore (this runs right after a risky operation
+    like reject-and-move, exactly when a crash is plausible) could leave the
+    live database/scenedata half-overwritten and corrupt. Copying raw bytes to a
+    temp file in the same directory and ``os.replace``-ing it in gives readers /
+    a crash an all-or-nothing view, and preserves the file's exact encoding/BOM.
+    """
+    directory = os.path.dirname(dst_path) or "."
+    os.makedirs(directory, exist_ok=True)
+
+    tmp_fd, tmp = tempfile.mkstemp(prefix=".kestrel_atomic_", suffix=".tmp", dir=directory)
+    try:
+        os.close(tmp_fd)
+        shutil.copyfile(src_path, tmp)
+        retry_on_file_lock(lambda: os.replace(tmp, dst_path))
+    except BaseException:
         try:
             os.remove(tmp)
         except OSError:

--- a/analyzer/kestrel_analyzer/database.py
+++ b/analyzer/kestrel_analyzer/database.py
@@ -499,15 +499,24 @@ def copy_file_atomic(src_path: str, dst_path: str) -> None:
         except BaseException:
             os.close(tmp_fd)
             raise
-        with dst_f, open(src_path, "rb") as src_f:
-            shutil.copyfileobj(src_f, dst_f)
-            dst_f.flush()
-            try:
-                os.fsync(dst_f.fileno())
-            except OSError:
-                # fsync can legitimately fail on some network filesystems; the
-                # replace below still gives readers an all-or-nothing view.
-                pass
+        # Close dst_f in a finally rather than relying on the with-statement's
+        # ordering: if opening the source (or the copy) raises, the destination
+        # handle must still be released. A leaked handle on Windows can block
+        # the os.replace below and strand the .tmp file. close() on an
+        # already-closed handle is a harmless no-op.
+        try:
+            with open(src_path, "rb") as src_f:
+                shutil.copyfileobj(src_f, dst_f)
+                dst_f.flush()
+                try:
+                    os.fsync(dst_f.fileno())
+                except OSError:
+                    # fsync can legitimately fail on some network filesystems;
+                    # the replace below still gives readers an all-or-nothing
+                    # view.
+                    pass
+        finally:
+            dst_f.close()
         # Preserve mode/mtime as the previous shutil.copy2 did (best-effort).
         try:
             shutil.copystat(src_path, tmp)

--- a/analyzer/kestrel_analyzer/database.py
+++ b/analyzer/kestrel_analyzer/database.py
@@ -483,14 +483,36 @@ def copy_file_atomic(src_path: str, dst_path: str) -> None:
     live database/scenedata half-overwritten and corrupt. Copying raw bytes to a
     temp file in the same directory and ``os.replace``-ing it in gives readers /
     a crash an all-or-nothing view, and preserves the file's exact encoding/BOM.
+    Content is flushed+fsync'd before the replace (matching ``_to_csv_atomic``'s
+    durability), and file metadata (mode/mtime) is preserved like the previous
+    ``shutil.copy2``.
     """
     directory = os.path.dirname(dst_path) or "."
     os.makedirs(directory, exist_ok=True)
 
     tmp_fd, tmp = tempfile.mkstemp(prefix=".kestrel_atomic_", suffix=".tmp", dir=directory)
     try:
-        os.close(tmp_fd)
-        shutil.copyfile(src_path, tmp)
+        # If fdopen raises it hasn't taken ownership of the descriptor; close it
+        # explicitly so it can't leak.
+        try:
+            dst_f = os.fdopen(tmp_fd, "wb")
+        except BaseException:
+            os.close(tmp_fd)
+            raise
+        with dst_f, open(src_path, "rb") as src_f:
+            shutil.copyfileobj(src_f, dst_f)
+            dst_f.flush()
+            try:
+                os.fsync(dst_f.fileno())
+            except OSError:
+                # fsync can legitimately fail on some network filesystems; the
+                # replace below still gives readers an all-or-nothing view.
+                pass
+        # Preserve mode/mtime as the previous shutil.copy2 did (best-effort).
+        try:
+            shutil.copystat(src_path, tmp)
+        except OSError:
+            pass
         retry_on_file_lock(lambda: os.replace(tmp, dst_path))
     except BaseException:
         try:

--- a/analyzer/tests/unit/test_backup_restore_atomic.py
+++ b/analyzer/tests/unit/test_backup_restore_atomic.py
@@ -1,0 +1,68 @@
+"""Regression tests for atomic backup restore.
+
+``restore_kestrel_db_backup`` used ``shutil.copy2`` to overwrite the live
+kestrel_database.csv / kestrel_scenedata.json in place. An interrupted restore
+(this runs right after a risky reject-and-move) could leave the live file
+half-written and corrupt. It now copies through a temp file + os.replace via
+``copy_file_atomic``.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+import api_bridge
+import kestrel_analyzer.database as _dbmod
+from kestrel_analyzer.database import copy_file_atomic
+
+pytestmark = pytest.mark.unit
+
+
+def test_copy_file_atomic_is_byte_exact_and_leaves_no_temp(tmp_path):
+    # Include a UTF-8 BOM to prove the raw bytes (encoding) are preserved.
+    src = tmp_path / "src.csv"
+    src.write_bytes(b"\xef\xbb\xbffilename,rating\nA.CR3,5\n")
+    dst = tmp_path / "kestrel_database.csv"
+    dst.write_bytes(b"OLD CONTENT")
+
+    copy_file_atomic(str(src), str(dst))
+
+    assert dst.read_bytes() == src.read_bytes()
+    assert sorted(p.name for p in tmp_path.iterdir()) == ["kestrel_database.csv", "src.csv"]
+
+
+def test_existing_dst_survives_a_failed_replace(tmp_path, monkeypatch):
+    src = tmp_path / "src"
+    src.write_bytes(b"NEW")
+    dst = tmp_path / "live"
+    dst.write_bytes(b"GOOD")
+
+    def boom(*_a, **_k):
+        raise OSError("simulated crash during replace")
+
+    monkeypatch.setattr(_dbmod.os, "replace", boom)
+    with pytest.raises(OSError):
+        copy_file_atomic(str(src), str(dst))
+
+    assert dst.read_bytes() == b"GOOD", "live file must be untouched on failure"
+    assert sorted(p.name for p in tmp_path.iterdir()) == ["live", "src"]
+
+
+def test_restore_kestrel_db_backup_roundtrips_without_temp_leftovers(tmp_path):
+    api = api_bridge.Api()
+    kdir = tmp_path / ".kestrel"
+    kdir.mkdir()
+    (kdir / "kestrel_database.csv").write_text("live-csv", encoding="utf-8")
+    (kdir / "kestrel_database_old.csv").write_text("backup-csv", encoding="utf-8")
+    (kdir / "kestrel_scenedata.json").write_text("{}", encoding="utf-8")
+    (kdir / "kestrel_scenedata_old.json").write_text('{"version": "2.0"}', encoding="utf-8")
+
+    res = api.restore_kestrel_db_backup(str(tmp_path))
+
+    assert res["success"] is True, res
+    assert (kdir / "kestrel_database.csv").read_text(encoding="utf-8") == "backup-csv"
+    assert (kdir / "kestrel_scenedata.json").read_text(encoding="utf-8") == '{"version": "2.0"}'
+    assert [p.name for p in kdir.iterdir() if p.name.endswith(".tmp")] == []

--- a/analyzer/tests/unit/test_backup_restore_atomic.py
+++ b/analyzer/tests/unit/test_backup_restore_atomic.py
@@ -51,6 +51,23 @@ def test_existing_dst_survives_a_failed_replace(tmp_path, monkeypatch):
     assert sorted(p.name for p in tmp_path.iterdir()) == ["live", "src"]
 
 
+def test_missing_source_raises_and_leaves_no_temp(tmp_path):
+    """If opening the source fails, the pre-created temp handle must still be
+    closed and the .tmp removed. A leaked destination handle would otherwise
+    strand the .tmp (and on Windows block later replaces)."""
+    src = tmp_path / "does_not_exist"
+    dst = tmp_path / "live"
+    dst.write_bytes(b"GOOD")
+
+    with pytest.raises((FileNotFoundError, OSError)):
+        copy_file_atomic(str(src), str(dst))
+
+    assert dst.read_bytes() == b"GOOD", "live file must be untouched"
+    # No stranded temp file -> the destination handle was released so cleanup
+    # could remove it.
+    assert sorted(p.name for p in tmp_path.iterdir()) == ["live"]
+
+
 def test_restore_kestrel_db_backup_roundtrips_without_temp_leftovers(tmp_path):
     api = api_bridge.Api()
     kdir = tmp_path / ".kestrel"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

`Api.restore_kestrel_db_backup` overwrote the live `kestrel_database.csv` / `kestrel_scenedata.json` in place with `shutil.copy2`. This runs right after a risky reject-and-move (exactly when a crash is plausible), so an interrupted restore could leave the live file half-written and corrupt — feeding the same partial-file read path the CSV atomic-save already guards against.

## Fix

Add `kestrel_analyzer/database.copy_file_atomic(src, dst)` — copies raw bytes to a temp file in the destination directory and `os.replace`s it into place (via the existing `retry_on_file_lock` for the Windows rename window). Raw byte copy preserves the file's exact encoding/BOM. Route both restore copies through it.

## Testing

`analyzer/tests/unit/test_backup_restore_atomic.py`:
- byte-exact copy (incl. a UTF-8 BOM) with no temp-file leftovers;
- the live file survives a failed `os.replace` (injected `OSError`), no temp left behind;
- end-to-end `restore_kestrel_db_backup` round-trip restores CSV + scenedata and leaves no `.tmp` files.

Existing `test_database_atomic_save.py` still passes (8 total).

## Note

Re-verified as still present on current `main`. Complements the earlier CSV/scenedata atomic-write PR; this closes the remaining non-atomic overwrite on the restore path.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c5090e64-798b-45af-8972-8263f4d5554a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c5090e64-798b-45af-8972-8263f4d5554a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

