### PR TITLE
fix(metadata): don't silently overwrite externally-edited XMP sidecars

### DIFF
--- a/analyzer/metadata_writer.py
+++ b/analyzer/metadata_writer.py
@@ -288,7 +288,15 @@ def _load_xmp_fingerprints(root: str) -> dict:
     try:
         with open(_xmp_fingerprint_path(root), 'r', encoding='utf-8') as f:
             data = json.load(f)
-        return data if isinstance(data, dict) else {}
+        if not isinstance(data, dict):
+            return {}
+        # Keep only usable entries. A fingerprint must be a string sha256; a
+        # null or other non-string value (e.g. from an older/corrupt store)
+        # would otherwise behave like "no fingerprint" and silently allow an
+        # overwrite of a file whose fingerprint is actually unknown. Dropping
+        # them makes such a sidecar fall back to legacy handling explicitly.
+        return {k: v for k, v in data.items()
+                if isinstance(k, str) and isinstance(v, str)}
     except Exception:
         return {}
 
@@ -490,15 +498,17 @@ def write_xmp_metadata(
     original in ``root_path``.
 
     Safety rules:
-      - If a ``.xmp`` file already exists and was written by Kestrel
-        (detected by the presence of the Kestrel namespace URI), it is
-        safe to overwrite and will always be updated.
+      - If a ``.xmp`` file already exists and is a Kestrel sidecar that is
+        unchanged since Kestrel last wrote it (its recorded content
+        fingerprint still matches, or it predates fingerprinting), it is
+        safe to overwrite and will be updated.
       - If a ``.xmp`` file already exists but was written by external
-        software (Lightroom, darktable, Capture One, etc.) AND
-        ``overwrite_external`` is False, the file is skipped and its
-        filename is added to ``skipped_conflicts`` in the response so the
-        caller can ask the user for confirmation.
-      - If ``overwrite_external`` is True, external XMP files are also
+        software (Lightroom, darktable, Capture One, etc.), OR is a Kestrel
+        sidecar that was edited externally after Kestrel wrote it (its
+        fingerprint no longer matches), AND ``overwrite_external`` is False,
+        the file is skipped and its filename is added to ``skipped_conflicts``
+        in the response so the caller can ask the user for confirmation.
+      - If ``overwrite_external`` is True, such conflicting files are also
         overwritten.
 
     Args:
@@ -645,8 +655,19 @@ def write_xmp_metadata(
                     f.write(xmp_content)
 
                 # Record the hash of exactly what we just wrote, so a later
-                # external edit is detected on the next write.
-                fingerprints[fp_key] = _file_sha256(xmp_path)
+                # external edit is detected on the next write. Only persist a
+                # real digest: if hashing the just-written file fails,
+                # _file_sha256 returns None, and a stored None reads back as
+                # "no fingerprint" — which _safe_to_overwrite_xmp treats as a
+                # legacy file and silently overwrites, erasing the protection
+                # this feature adds. In that case drop any stale entry instead,
+                # so the sidecar cleanly falls back to legacy no-fingerprint
+                # handling rather than an ambiguous null.
+                _digest = _file_sha256(xmp_path)
+                if _digest is not None:
+                    fingerprints[fp_key] = _digest
+                else:
+                    fingerprints.pop(fp_key, None)
 
                 written += 1
                 info(f'[metadata] write_xmp: wrote {xmp_path}')

--- a/analyzer/metadata_writer.py
+++ b/analyzer/metadata_writer.py
@@ -17,6 +17,7 @@ segment is rewritten), so it is strictly opt-in.
 import hashlib
 import json
 import os
+import re
 import tempfile
 
 # XMP namespace URIs
@@ -262,6 +263,16 @@ def _is_kestrel_xmp(path: str) -> bool:
 # sidecar is only overwritten without confirmation if its hash still matches.
 _XMP_FINGERPRINT_FILE = 'xmp_fingerprints.json'
 
+# A valid fingerprint is exactly what hashlib.sha256().hexdigest() produces:
+# 64 lowercase hex chars. Anything else in the store is corrupt/foreign and is
+# treated as "no fingerprint" (legacy fallback) rather than a hash to compare.
+_SHA256_HEX_RE = re.compile(r'\A[0-9a-f]{64}\Z')
+
+
+def _is_sha256_hex(value) -> bool:
+    """True iff ``value`` is a 64-char lowercase hex sha256 digest string."""
+    return isinstance(value, str) and _SHA256_HEX_RE.match(value) is not None
+
 
 def _file_sha256(path: str) -> str | None:
     """Return the hex sha256 of a file's bytes, or None if unreadable."""
@@ -290,13 +301,15 @@ def _load_xmp_fingerprints(root: str) -> dict:
             data = json.load(f)
         if not isinstance(data, dict):
             return {}
-        # Keep only usable entries. A fingerprint must be a string sha256; a
-        # null or other non-string value (e.g. from an older/corrupt store)
-        # would otherwise behave like "no fingerprint" and silently allow an
-        # overwrite of a file whose fingerprint is actually unknown. Dropping
-        # them makes such a sidecar fall back to legacy handling explicitly.
+        # Keep only usable entries. A fingerprint must be a real sha256 hex
+        # digest. A null/other-typed value (older/corrupt store) or a
+        # non-sha256 string would otherwise be misused: a null behaves like
+        # "no fingerprint" and could silently allow an overwrite, while a
+        # bogus string would never match the file's real hash and wrongly
+        # route an untouched sidecar through the conflict path. Dropping both
+        # makes a corrupt store fall back cleanly to legacy handling.
         return {k: v for k, v in data.items()
-                if isinstance(k, str) and isinstance(v, str)}
+                if isinstance(k, str) and _is_sha256_hex(v)}
     except Exception:
         return {}
 
@@ -543,6 +556,15 @@ def write_xmp_metadata(
         if not root_path or not os.path.isdir(root_path):
             return {'success': False, 'error': 'Invalid root path'}
 
+        # Canonicalize the root once. `_safe_sidecar_path` resolves each sidecar
+        # to an absolute realpath under realpath(root), so the fingerprint key
+        # (and the store location) must be derived from the same canonical root.
+        # Using the raw `root_path` here made keys unstable: a relative root, a
+        # different CWD, or a symlinked path could yield a different relpath
+        # (even with '..' components) for the same file, missing a previously
+        # recorded fingerprint and silently re-enabling overwrites.
+        root_real = os.path.realpath(root_path)
+
         written = 0
         skipped_conflicts = []
         errors = []
@@ -551,7 +573,7 @@ def write_xmp_metadata(
 
         # Hashes of sidecars as Kestrel last wrote them; used to tell "ours and
         # unchanged" (safe to overwrite) from "ours but edited externally".
-        fingerprints = _load_xmp_fingerprints(root_path)
+        fingerprints = _load_xmp_fingerprints(root_real)
 
         for entry in (image_data or []):
             try:
@@ -586,7 +608,7 @@ def write_xmp_metadata(
                 # with traversal segments (``../sensitive``) or an absolute
                 # path would otherwise let the caller write .xmp files
                 # anywhere on disk. See FINDING-02.
-                resolved_image = _safe_sidecar_path(root_path, filename)
+                resolved_image = _safe_sidecar_path(root_real, filename)
                 if resolved_image is None:
                     errors.append(f'{filename}: rejected (unsafe filename)')
                     warn(f'[metadata][security] write_xmp_metadata rejected unsafe filename: {filename!r}')
@@ -594,7 +616,9 @@ def write_xmp_metadata(
                 base, _ext = os.path.splitext(resolved_image)
                 xmp_path = base + '.xmp'
                 xmp_filename = os.path.basename(xmp_path)
-                fp_key = os.path.relpath(xmp_path, root_path)
+                # Key relative to the canonical root -> a stable basename-level
+                # key regardless of how the caller spelled root_path.
+                fp_key = os.path.relpath(xmp_path, root_real)
 
                 # Safety check: if XMP already exists, only overwrite it silently
                 # when it is a Kestrel sidecar that is unchanged since we wrote it
@@ -676,7 +700,7 @@ def write_xmp_metadata(
                 errors.append(f'{entry.get("filename", "?")}: {entry_err}')
 
         if written:
-            _save_xmp_fingerprints(root_path, fingerprints)
+            _save_xmp_fingerprints(root_real, fingerprints)
 
         info(
             f'[metadata] write_xmp_metadata: written={written}, '

--- a/analyzer/metadata_writer.py
+++ b/analyzer/metadata_writer.py
@@ -14,7 +14,10 @@ original file in place (pixel data is left untouched; only the metadata
 segment is rewritten), so it is strictly opt-in.
 """
 
+import hashlib
+import json
 import os
+import tempfile
 
 # XMP namespace URIs
 _KESTREL_NS = 'http://ns.projectkestrel.app/xmp/1.0/'
@@ -250,6 +253,84 @@ def _is_kestrel_xmp(path: str) -> bool:
         return False
 
 
+# ---- Sidecar fingerprinting -------------------------------------------------
+#
+# "Contains the Kestrel namespace" is not enough to decide a sidecar is safe to
+# overwrite: a file Kestrel wrote and the user then edited in Lightroom/darktable
+# still contains the namespace, and was being silently clobbered. We record a
+# content hash of each sidecar as Kestrel last wrote it; on the next write, a
+# sidecar is only overwritten without confirmation if its hash still matches.
+_XMP_FINGERPRINT_FILE = 'xmp_fingerprints.json'
+
+
+def _file_sha256(path: str) -> str | None:
+    """Return the hex sha256 of a file's bytes, or None if unreadable."""
+    try:
+        h = hashlib.sha256()
+        with open(path, 'rb') as f:
+            for chunk in iter(lambda: f.read(65536), b''):
+                h.update(chunk)
+        return h.hexdigest()
+    except Exception:
+        return None
+
+
+def _xmp_fingerprint_path(root: str) -> str:
+    return os.path.join(root, '.kestrel', _XMP_FINGERPRINT_FILE)
+
+
+def _load_xmp_fingerprints(root: str) -> dict:
+    """Load {relative-xmp-path -> sha256 as Kestrel last wrote it}.
+
+    Returns {} on any error, so a missing/corrupt store never blocks writes —
+    callers then fall back to the legacy "namespace substring" behavior.
+    """
+    try:
+        with open(_xmp_fingerprint_path(root), 'r', encoding='utf-8') as f:
+            data = json.load(f)
+        return data if isinstance(data, dict) else {}
+    except Exception:
+        return {}
+
+
+def _save_xmp_fingerprints(root: str, fingerprints: dict) -> None:
+    """Persist the fingerprint map atomically (best-effort; never raises)."""
+    try:
+        kdir = os.path.join(root, '.kestrel')
+        os.makedirs(kdir, exist_ok=True)
+        fd, tmp = tempfile.mkstemp(prefix='.xmp_fp_', suffix='.tmp', dir=kdir)
+        try:
+            with os.fdopen(fd, 'w', encoding='utf-8') as f:
+                json.dump(fingerprints, f, indent=2)
+            os.replace(tmp, _xmp_fingerprint_path(root))
+        except BaseException:
+            try:
+                os.remove(tmp)
+            except OSError:
+                pass
+            raise
+    except Exception as e:
+        warn(f'[metadata] could not save XMP fingerprints: {e}')
+
+
+def _safe_to_overwrite_xmp(xmp_path: str, key: str, fingerprints: dict) -> bool:
+    """Whether Kestrel may overwrite an existing sidecar without confirmation.
+
+    Safe only if the file is a Kestrel sidecar AND unchanged since Kestrel last
+    wrote it (content hash matches the recorded fingerprint). A Kestrel sidecar
+    with no recorded fingerprint is treated as safe (legacy files written before
+    fingerprinting) to avoid flagging every pre-existing sidecar; the next write
+    records a fingerprint, closing the gap going forward. A hash mismatch means
+    the file was edited externally and must go through the conflict path.
+    """
+    if not _is_kestrel_xmp(xmp_path):
+        return False
+    recorded = fingerprints.get(key)
+    if recorded is None:
+        return True
+    return _file_sha256(xmp_path) == recorded
+
+
 def _is_jpeg(filename: str) -> bool:
     """Return True if ``filename`` has a JPEG extension (case-insensitive)."""
     return os.path.splitext(filename)[1].lower() in _JPEG_EXTS
@@ -458,6 +539,10 @@ def write_xmp_metadata(
         embedded = 0
         embed_errors = []
 
+        # Hashes of sidecars as Kestrel last wrote them; used to tell "ours and
+        # unchanged" (safe to overwrite) from "ours but edited externally".
+        fingerprints = _load_xmp_fingerprints(root_path)
+
         for entry in (image_data or []):
             try:
                 filename = str(entry.get('filename', '')).strip()
@@ -499,16 +584,21 @@ def write_xmp_metadata(
                 base, _ext = os.path.splitext(resolved_image)
                 xmp_path = base + '.xmp'
                 xmp_filename = os.path.basename(xmp_path)
+                fp_key = os.path.relpath(xmp_path, root_path)
 
-                # Safety check: if XMP already exists, verify origin
+                # Safety check: if XMP already exists, only overwrite it silently
+                # when it is a Kestrel sidecar that is unchanged since we wrote it
+                # (fingerprint match). External files, or Kestrel sidecars edited
+                # externally afterward, go through the conflict path so the user's
+                # edits are never silently destroyed.
                 if os.path.exists(xmp_path):
-                    if not _is_kestrel_xmp(xmp_path):
+                    if not _safe_to_overwrite_xmp(xmp_path, fp_key, fingerprints):
                         if not overwrite_external:
                             skipped_conflicts.append(xmp_filename)
-                            warn(f'[metadata] write_xmp: skipping external XMP {xmp_path}')
+                            warn(f'[metadata] write_xmp: skipping external/modified XMP {xmp_path}')
                             continue
                         else:
-                            info(f'[metadata] write_xmp: overwriting external XMP {xmp_path} (user confirmed)')
+                            info(f'[metadata] write_xmp: overwriting external/modified XMP {xmp_path} (user confirmed)')
 
                 # Embed XMP directly into JPEG originals when requested. This
                 # merges into the file's own XMP segment (Lightroom ignores
@@ -554,11 +644,18 @@ def write_xmp_metadata(
                 with open(xmp_path, 'w', encoding='utf-8') as f:
                     f.write(xmp_content)
 
+                # Record the hash of exactly what we just wrote, so a later
+                # external edit is detected on the next write.
+                fingerprints[fp_key] = _file_sha256(xmp_path)
+
                 written += 1
                 info(f'[metadata] write_xmp: wrote {xmp_path}')
 
             except Exception as entry_err:
                 errors.append(f'{entry.get("filename", "?")}: {entry_err}')
+
+        if written:
+            _save_xmp_fingerprints(root_path, fingerprints)
 
         info(
             f'[metadata] write_xmp_metadata: written={written}, '

--- a/analyzer/metadata_writer.py
+++ b/analyzer/metadata_writer.py
@@ -274,6 +274,26 @@ def _is_sha256_hex(value) -> bool:
     return isinstance(value, str) and _SHA256_HEX_RE.match(value) is not None
 
 
+def _is_xmp_fp_key(key) -> bool:
+    """True iff ``key`` is a bare ``*.xmp`` basename (no directory components).
+
+    Sidecars are only ever written for jailed basenames, so the store only
+    needs basename keys. Path separators, ``..``, or a non-.xmp suffix are
+    garbage/foreign and must not be persisted back to disk.
+    """
+    if not isinstance(key, str) or not key:
+        return False
+    if not key.lower().endswith('.xmp'):
+        return False
+    if '/' in key or '\\' in key:
+        return False
+    if os.sep in key or (os.altsep and os.altsep in key):
+        return False
+    if key in ('.', '..') or os.path.basename(key) != key:
+        return False
+    return True
+
+
 def _file_sha256(path: str) -> str | None:
     """Return the hex sha256 of a file's bytes, or None if unreadable."""
     try:
@@ -291,7 +311,7 @@ def _xmp_fingerprint_path(root: str) -> str:
 
 
 def _load_xmp_fingerprints(root: str) -> dict:
-    """Load {relative-xmp-path -> sha256 as Kestrel last wrote it}.
+    """Load {basename.xmp -> sha256 as Kestrel last wrote it}.
 
     Returns {} on any error, so a missing/corrupt store never blocks writes —
     callers then fall back to the legacy "namespace substring" behavior.
@@ -302,14 +322,16 @@ def _load_xmp_fingerprints(root: str) -> dict:
         if not isinstance(data, dict):
             return {}
         # Keep only usable entries. A fingerprint must be a real sha256 hex
-        # digest. A null/other-typed value (older/corrupt store) or a
-        # non-sha256 string would otherwise be misused: a null behaves like
-        # "no fingerprint" and could silently allow an overwrite, while a
-        # bogus string would never match the file's real hash and wrongly
-        # route an untouched sidecar through the conflict path. Dropping both
-        # makes a corrupt store fall back cleanly to legacy handling.
+        # digest keyed by a bare ``*.xmp`` basename. A null/other-typed value
+        # (older/corrupt store) or a non-sha256 string would otherwise be
+        # misused: a null behaves like "no fingerprint" and could silently
+        # allow an overwrite, while a bogus string would never match the
+        # file's real hash and wrongly route an untouched sidecar through the
+        # conflict path. Path-shaped keys are never written (sidecars live
+        # next to the image in root) and must not be round-tripped. Dropping
+        # all of the above makes a corrupt store fall back to legacy handling.
         return {k: v for k, v in data.items()
-                if isinstance(k, str) and _is_sha256_hex(v)}
+                if _is_xmp_fp_key(k) and _is_sha256_hex(v)}
     except Exception:
         return {}
 
@@ -628,9 +650,10 @@ def write_xmp_metadata(
                 base, _ext = os.path.splitext(resolved_image)
                 xmp_path = base + '.xmp'
                 xmp_filename = os.path.basename(xmp_path)
-                # Key relative to the canonical root -> a stable basename-level
-                # key regardless of how the caller spelled root_path.
-                fp_key = os.path.relpath(xmp_path, root_real)
+                # Sidecars are jailed to a bare basename in root, so the
+                # fingerprint key is that basename — not a relpath that could
+                # carry separators if a corrupt store or future caller drifted.
+                fp_key = os.path.basename(xmp_path)
 
                 # Safety check: if XMP already exists, only overwrite it silently
                 # when it is a Kestrel sidecar that is unchanged since we wrote it

--- a/analyzer/metadata_writer.py
+++ b/analyzer/metadata_writer.py
@@ -315,13 +315,25 @@ def _load_xmp_fingerprints(root: str) -> dict:
 
 
 def _save_xmp_fingerprints(root: str, fingerprints: dict) -> None:
-    """Persist the fingerprint map atomically (best-effort; never raises)."""
+    """Persist the fingerprint map atomically.
+
+    Best-effort: ordinary errors (I/O, permissions, serialization) are logged
+    and swallowed so a failed persist never breaks a metadata write. Only
+    KeyboardInterrupt/SystemExit are intentionally allowed to propagate.
+    """
     try:
         kdir = os.path.join(root, '.kestrel')
         os.makedirs(kdir, exist_ok=True)
         fd, tmp = tempfile.mkstemp(prefix='.xmp_fp_', suffix='.tmp', dir=kdir)
         try:
-            with os.fdopen(fd, 'w', encoding='utf-8') as f:
+            # os.fdopen takes ownership of fd on success; if it raises, fd
+            # hasn't been wrapped yet and would leak, so close it explicitly.
+            try:
+                f = os.fdopen(fd, 'w', encoding='utf-8')
+            except BaseException:
+                os.close(fd)
+                raise
+            with f:
                 json.dump(fingerprints, f, indent=2)
             os.replace(tmp, _xmp_fingerprint_path(root))
         except BaseException:

--- a/analyzer/metadata_writer.py
+++ b/analyzer/metadata_writer.py
@@ -653,7 +653,7 @@ def write_xmp_metadata(
                 # Sidecars are jailed to a bare basename in root, so the
                 # fingerprint key is that basename — not a relpath that could
                 # carry separators if a corrupt store or future caller drifted.
-                fp_key = os.path.basename(xmp_path)
+                fp_key = xmp_filename
 
                 # Safety check: if XMP already exists, only overwrite it silently
                 # when it is a Kestrel sidecar that is unchanged since we wrote it

--- a/analyzer/tests/unit/test_xmp_overwrite_fingerprint.py
+++ b/analyzer/tests/unit/test_xmp_overwrite_fingerprint.py
@@ -142,6 +142,41 @@ def test_corrupt_nonhex_fingerprint_falls_back_to_legacy_not_conflict(tmp_path):
     assert r['skipped_conflicts'] == []
 
 
+def test_save_fingerprints_closes_fd_when_fdopen_fails(tmp_path, monkeypatch):
+    """If os.fdopen fails, the mkstemp descriptor must be closed (not leaked)
+    and the temp file cleaned up, and the best-effort save must swallow the
+    error rather than propagate it."""
+    import os as _os
+
+    created = {}
+    real_mkstemp = mw.tempfile.mkstemp
+
+    def spy_mkstemp(*a, **k):
+        fd, path = real_mkstemp(*a, **k)
+        created['fd'] = fd
+        created['path'] = path
+        return fd, path
+
+    closed = []
+    real_close = mw.os.close
+
+    def spy_close(fd):
+        closed.append(fd)
+        return real_close(fd)
+
+    monkeypatch.setattr(mw.tempfile, 'mkstemp', spy_mkstemp)
+    monkeypatch.setattr(mw.os, 'close', spy_close)
+    monkeypatch.setattr(mw.os, 'fdopen',
+                        lambda *a, **k: (_ for _ in ()).throw(OSError("boom")))
+
+    # Best-effort: must not raise.
+    mw._save_xmp_fingerprints(str(tmp_path), {'A.xmp': 'a' * 64})
+
+    assert created['fd'] in closed, "mkstemp fd was not closed -> leaked"
+    assert not _os.path.exists(created['path']), "temp file left behind"
+    assert not (tmp_path / '.kestrel' / 'xmp_fingerprints.json').exists()
+
+
 def test_fingerprint_key_is_stable_across_relative_and_symlinked_roots(tmp_path, monkeypatch):
     """The overwrite protection must hold when the same folder is addressed via
     a relative path or a symlink: an externally edited sidecar must still be

--- a/analyzer/tests/unit/test_xmp_overwrite_fingerprint.py
+++ b/analyzer/tests/unit/test_xmp_overwrite_fingerprint.py
@@ -1,0 +1,97 @@
+"""Regression tests for XMP sidecar overwrite protection.
+
+Previously an existing .xmp that merely *contained* the Kestrel namespace was
+treated as "ours" and silently overwritten -- so a sidecar Kestrel wrote and the
+user then edited in Lightroom/darktable lost those edits with no conflict
+reported. Kestrel now records a content hash of each sidecar it writes and only
+overwrites without confirmation when the file is unchanged since (hash match).
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+import metadata_writer as mw
+
+pytestmark = pytest.mark.unit
+
+
+def _entry():
+    return {
+        'filename': 'A.CR3',
+        'rating': 4,
+        'culled': 'accept',
+        'culled_origin': 'manual',
+        'species': 'Chipping Sparrow',
+        'family': 'Sparrow sp.',
+        'quality': 0.5,
+    }
+
+
+def _write(root):
+    (root / "A.CR3").write_bytes(b"raw-placeholder")
+    return mw.write_xmp_metadata(str(root), [_entry()])
+
+
+def test_unchanged_kestrel_sidecar_is_overwritten_silently(tmp_path):
+    r1 = _write(tmp_path)
+    assert r1['success'] and r1['written'] == 1
+    xmp = tmp_path / "A.xmp"
+    assert xmp.exists()
+    assert (tmp_path / ".kestrel" / "xmp_fingerprints.json").exists()
+
+    # Nothing touched the file -> second write overwrites it, no conflict.
+    r2 = mw.write_xmp_metadata(str(tmp_path), [_entry()])
+    assert r2['written'] == 1
+    assert r2['skipped_conflicts'] == []
+
+
+def test_externally_edited_kestrel_sidecar_is_not_clobbered(tmp_path):
+    _write(tmp_path)
+    xmp = tmp_path / "A.xmp"
+
+    # Simulate an external edit that keeps the Kestrel namespace (so the old
+    # substring check would still call it "ours").
+    edited = xmp.read_text(encoding='utf-8') + "\n<!-- edited in Lightroom -->\n"
+    xmp.write_text(edited, encoding='utf-8')
+
+    r = mw.write_xmp_metadata(str(tmp_path), [_entry()])  # overwrite_external=False
+    assert r['written'] == 0
+    assert 'A.xmp' in r['skipped_conflicts']
+    # The user's edit must survive untouched.
+    assert xmp.read_text(encoding='utf-8') == edited
+
+
+def test_overwrite_external_true_forces_write(tmp_path):
+    _write(tmp_path)
+    xmp = tmp_path / "A.xmp"
+    xmp.write_text(xmp.read_text(encoding='utf-8') + "\n<!-- edited -->\n", encoding='utf-8')
+
+    r = mw.write_xmp_metadata(str(tmp_path), [_entry()], overwrite_external=True)
+    assert r['written'] == 1
+    assert 'edited' not in xmp.read_text(encoding='utf-8')
+
+
+def test_legacy_kestrel_sidecar_without_fingerprint_is_overwritten(tmp_path):
+    """A Kestrel sidecar written before fingerprinting (no recorded hash) keeps
+    the prior behavior: treated as ours and overwritten, not flagged."""
+    _write(tmp_path)
+    # Drop the fingerprint store to emulate a pre-fingerprint sidecar.
+    (tmp_path / ".kestrel" / "xmp_fingerprints.json").unlink()
+
+    r = mw.write_xmp_metadata(str(tmp_path), [_entry()])
+    assert r['written'] == 1
+    assert r['skipped_conflicts'] == []
+
+
+def test_non_kestrel_external_xmp_is_skipped(tmp_path):
+    (tmp_path / "A.CR3").write_bytes(b"raw")
+    xmp = tmp_path / "A.xmp"
+    xmp.write_text("<x:xmpmeta xmlns:x='adobe:ns:meta/'></x:xmpmeta>", encoding='utf-8')
+
+    r = mw.write_xmp_metadata(str(tmp_path), [_entry()])
+    assert r['written'] == 0
+    assert 'A.xmp' in r['skipped_conflicts']

--- a/analyzer/tests/unit/test_xmp_overwrite_fingerprint.py
+++ b/analyzer/tests/unit/test_xmp_overwrite_fingerprint.py
@@ -72,7 +72,7 @@ def test_overwrite_external_true_forces_write(tmp_path):
 
     r = mw.write_xmp_metadata(str(tmp_path), [_entry()], overwrite_external=True)
     assert r['written'] == 1
-    assert 'edited' not in xmp.read_text(encoding='utf-8')
+    assert '<!-- edited -->' not in xmp.read_text(encoding='utf-8')
 
 
 def test_legacy_kestrel_sidecar_without_fingerprint_is_overwritten(tmp_path):
@@ -98,9 +98,10 @@ def test_non_kestrel_external_xmp_is_skipped(tmp_path):
 
 
 def test_load_fingerprints_keeps_only_sha256_hex(tmp_path):
-    """A store with null/non-string/non-sha256 values (older or corrupt) must
-    not feed ambiguous entries downstream; only real 64-char hex sha256
-    digests are kept. Everything else falls back to legacy handling."""
+    """A store with null/non-string/non-sha256 values or path-shaped keys
+    (older or corrupt) must not feed ambiguous entries downstream; only real
+    64-char hex sha256 digests keyed by a bare ``*.xmp`` basename are kept.
+    Everything else falls back to legacy handling."""
     import json
 
     good = "a" * 64  # a valid 64-char lowercase hex digest shape
@@ -114,6 +115,9 @@ def test_load_fingerprints_keeps_only_sha256_hex(tmp_path):
             "null.xmp": None,
             "num.xmp": 42,
             "list.xmp": ["x"],
+            "sub/dir.xmp": good,            # path separator — not a basename
+            "../evil.xmp": good,            # traversal-shaped key
+            "notxmp.txt": good,             # wrong suffix
         }),
         encoding='utf-8',
     )

--- a/analyzer/tests/unit/test_xmp_overwrite_fingerprint.py
+++ b/analyzer/tests/unit/test_xmp_overwrite_fingerprint.py
@@ -97,16 +97,20 @@ def test_non_kestrel_external_xmp_is_skipped(tmp_path):
     assert 'A.xmp' in r['skipped_conflicts']
 
 
-def test_load_fingerprints_drops_non_string_values(tmp_path):
-    """A store with null/non-string values (older or corrupt) must not feed
-    ambiguous entries downstream; only hex-string fingerprints are kept."""
+def test_load_fingerprints_keeps_only_sha256_hex(tmp_path):
+    """A store with null/non-string/non-sha256 values (older or corrupt) must
+    not feed ambiguous entries downstream; only real 64-char hex sha256
+    digests are kept. Everything else falls back to legacy handling."""
     import json
 
+    good = "a" * 64  # a valid 64-char lowercase hex digest shape
     kdir = tmp_path / ".kestrel"
     kdir.mkdir()
     (kdir / "xmp_fingerprints.json").write_text(
         json.dumps({
-            "good.xmp": "abc123",
+            "good.xmp": good,
+            "short.xmp": "abc123",          # too short to be sha256
+            "upper.xmp": "A" * 64,          # uppercase -> not hexdigest() output
             "null.xmp": None,
             "num.xmp": 42,
             "list.xmp": ["x"],
@@ -115,7 +119,64 @@ def test_load_fingerprints_drops_non_string_values(tmp_path):
     )
 
     fps = mw._load_xmp_fingerprints(str(tmp_path))
-    assert fps == {"good.xmp": "abc123"}
+    assert fps == {"good.xmp": good}
+
+
+def test_corrupt_nonhex_fingerprint_falls_back_to_legacy_not_conflict(tmp_path):
+    """A corrupt store holding a non-sha256 string for an existing Kestrel
+    sidecar must be ignored (legacy overwrite), NOT routed through the conflict
+    path -- otherwise an untouched sidecar would be wrongly flagged."""
+    import json
+
+    _write(tmp_path)  # creates A.xmp + a valid fingerprint
+    store = tmp_path / ".kestrel" / "xmp_fingerprints.json"
+    data = json.loads(store.read_text(encoding='utf-8'))
+    key = next(iter(data))
+    data[key] = "not-a-real-sha256"  # corrupt the recorded value
+    store.write_text(json.dumps(data), encoding='utf-8')
+
+    # The sidecar itself was NOT edited; with the bogus fingerprint dropped it
+    # is treated as a legacy Kestrel sidecar and overwritten, not a conflict.
+    r = mw.write_xmp_metadata(str(tmp_path), [_entry()])
+    assert r['written'] == 1
+    assert r['skipped_conflicts'] == []
+
+
+def test_fingerprint_key_is_stable_across_relative_and_symlinked_roots(tmp_path, monkeypatch):
+    """The overwrite protection must hold when the same folder is addressed via
+    a relative path or a symlink: an externally edited sidecar must still be
+    detected as a conflict, not silently overwritten due to an unstable key."""
+    shoot = tmp_path / "shoot"
+    shoot.mkdir()
+    (shoot / "A.CR3").write_bytes(b"raw-placeholder")
+
+    # First write via an absolute root records the fingerprint.
+    assert mw.write_xmp_metadata(str(shoot), [_entry()])['written'] == 1
+
+    # Simulate an external edit that keeps the Kestrel namespace.
+    xmp = shoot / "A.xmp"
+    edited = xmp.read_text(encoding='utf-8') + "\n<!-- edited elsewhere -->\n"
+    xmp.write_text(edited, encoding='utf-8')
+
+    # Address the SAME folder via a relative path (different CWD) ...
+    monkeypatch.chdir(tmp_path)
+    r_rel = mw.write_xmp_metadata("shoot", [_entry()])
+    assert r_rel['written'] == 0
+    assert 'A.xmp' in r_rel['skipped_conflicts']
+    assert xmp.read_text(encoding='utf-8') == edited
+
+    # ... and via a symlink to it. Both must resolve to the same key and keep
+    # protecting the edit. (Symlink support is universal on POSIX; skip if the
+    # platform/filesystem can't create one.)
+    link = tmp_path / "link_to_shoot"
+    try:
+        link.symlink_to(shoot, target_is_directory=True)
+    except (OSError, NotImplementedError):
+        pytest.skip("symlinks not supported here")
+    r_link = mw.write_xmp_metadata(str(link), [_entry()])
+    assert r_link['written'] == 0
+    assert 'A.xmp' in r_link['skipped_conflicts']
+    assert xmp.read_text(encoding='utf-8') == edited
 
 
 def test_failed_post_write_hash_is_not_persisted_as_null(tmp_path, monkeypatch):

--- a/analyzer/tests/unit/test_xmp_overwrite_fingerprint.py
+++ b/analyzer/tests/unit/test_xmp_overwrite_fingerprint.py
@@ -95,3 +95,51 @@ def test_non_kestrel_external_xmp_is_skipped(tmp_path):
     r = mw.write_xmp_metadata(str(tmp_path), [_entry()])
     assert r['written'] == 0
     assert 'A.xmp' in r['skipped_conflicts']
+
+
+def test_load_fingerprints_drops_non_string_values(tmp_path):
+    """A store with null/non-string values (older or corrupt) must not feed
+    ambiguous entries downstream; only hex-string fingerprints are kept."""
+    import json
+
+    kdir = tmp_path / ".kestrel"
+    kdir.mkdir()
+    (kdir / "xmp_fingerprints.json").write_text(
+        json.dumps({
+            "good.xmp": "abc123",
+            "null.xmp": None,
+            "num.xmp": 42,
+            "list.xmp": ["x"],
+        }),
+        encoding='utf-8',
+    )
+
+    fps = mw._load_xmp_fingerprints(str(tmp_path))
+    assert fps == {"good.xmp": "abc123"}
+
+
+def test_failed_post_write_hash_is_not_persisted_as_null(tmp_path, monkeypatch):
+    """If hashing the just-written sidecar fails, we must not persist a null
+    fingerprint (which reads back as "no fingerprint" and silently re-enables
+    overwrites). The stale entry is dropped instead, and the store never
+    contains a null value."""
+    import json
+
+    # First write records a real fingerprint for A.xmp.
+    _write(tmp_path)
+    store = tmp_path / ".kestrel" / "xmp_fingerprints.json"
+    fp_key = next(iter(json.loads(store.read_text(encoding='utf-8'))))
+
+    # Second write, but hashing fails (e.g. transient I/O). With _file_sha256
+    # returning None the pre-write conflict check can't confirm the file is
+    # unchanged, so force the write through with overwrite_external=True; the
+    # point under test is what the *post-write* None does to the store.
+    monkeypatch.setattr(mw, "_file_sha256", lambda _p: None)
+    r = mw.write_xmp_metadata(str(tmp_path), [_entry()], overwrite_external=True)
+    assert r['written'] == 1
+
+    persisted = json.loads(store.read_text(encoding='utf-8'))
+    # No null values anywhere, and the stale entry was dropped rather than
+    # overwritten with null.
+    assert None not in persisted.values()
+    assert fp_key not in persisted


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The overwrite guard in `write_xmp_metadata` used `_is_kestrel_xmp`, which only checks whether the file contains the Kestrel namespace substring. So a sidecar Kestrel wrote and the user then edited in Lightroom/darktable still counted as "ours" and was **silently overwritten** — the external edits were lost with nothing added to `skipped_conflicts`.

## Fix

Record a `sha256` of each sidecar as Kestrel writes it, in `.kestrel/xmp_fingerprints.json`. On the next write, a sidecar is overwritten without confirmation **only** when it is a Kestrel file **and** unchanged since (its current hash matches the recorded one). A hash mismatch routes it through the existing conflict path (added to `skipped_conflicts` unless `overwrite_external=True`).

To avoid a UX regression for existing installs, a Kestrel sidecar with **no recorded fingerprint** (written by a pre-fingerprint version) keeps the prior behavior (treated as ours) rather than flagging every pre-existing sidecar; the next write records a hash, closing the gap going forward. The store is loaded once per call and saved atomically (temp file + `os.replace`); a missing/corrupt store degrades to the legacy behavior and never blocks writes.

## Testing

`analyzer/tests/unit/test_xmp_overwrite_fingerprint.py`:
- unchanged Kestrel sidecar is overwritten silently;
- an externally-edited Kestrel sidecar is preserved and reported in `skipped_conflicts` (the core bug);
- `overwrite_external=True` forces the write;
- a legacy Kestrel sidecar with no fingerprint is overwritten (no mass conflicts);
- a non-Kestrel external XMP is still skipped.

Existing `test_metadata_writer*.py` and `test_security_xmp_path_traversal.py` pass unchanged.

## Note

Re-verified as still present on current `main`. Highest real-world value of the remaining review findings: it prevents silent loss of a user's Lightroom/darktable edits.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c5090e64-798b-45af-8972-8263f4d5554a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c5090e64-798b-45af-8972-8263f4d5554a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

