### PR TITLE
fix(logging): avoid utcnow RecursionError in showwarning hook

### DIFF
--- a/analyzer/kestrel_analyzer/database.py
+++ b/analyzer/kestrel_analyzer/database.py
@@ -6,7 +6,7 @@ import time
 import pandas as pd
 
 from .config import DATABASE_NAME, METADATA_FILENAME, SCENEDATA_FILENAME, VERSION
-from .logging_utils import log_warning, _utc_now_naive
+from .logging_utils import log_warning, utc_now_naive
 
 # Leveled console logging — kestrel_analyzer is sometimes imported standalone
 # (e.g. tests), so fall back to a no-op if settings_utils isn't reachable.
@@ -83,7 +83,7 @@ def load_database(kestrel_dir: str, analyzer_name: str, log_path: str = None):
                 metadata = {
                     "version": VERSION,
                     "analyzer": analyzer_name,
-                    "created_utc": _utc_now_naive().isoformat() + "Z",
+                    "created_utc": utc_now_naive().isoformat() + "Z",
                     "database_file": DATABASE_NAME,
                 }
                 with open(metadata_path, "w", encoding="utf-8") as mf:
@@ -134,7 +134,7 @@ def _perform_db_upgrade(
 
     # Rename old CSV as backup, then save new one without legacy columns
     try:
-        timestamp = _utc_now_naive().strftime("%Y%m%d_%H%M%S")
+        timestamp = utc_now_naive().strftime("%Y%m%d_%H%M%S")
         old_path = os.path.join(kestrel_dir, f"OLD_kestrel_database_{timestamp}.csv")
         os.rename(db_path, old_path)
         cleaned = database.drop(

--- a/analyzer/kestrel_analyzer/database.py
+++ b/analyzer/kestrel_analyzer/database.py
@@ -2,12 +2,11 @@ import json
 import os
 import tempfile
 import time
-from datetime import datetime
 
 import pandas as pd
 
 from .config import DATABASE_NAME, METADATA_FILENAME, SCENEDATA_FILENAME, VERSION
-from .logging_utils import log_warning
+from .logging_utils import log_warning, _utc_now_naive
 
 # Leveled console logging — kestrel_analyzer is sometimes imported standalone
 # (e.g. tests), so fall back to a no-op if settings_utils isn't reachable.
@@ -84,7 +83,7 @@ def load_database(kestrel_dir: str, analyzer_name: str, log_path: str = None):
                 metadata = {
                     "version": VERSION,
                     "analyzer": analyzer_name,
-                    "created_utc": datetime.utcnow().isoformat() + "Z",
+                    "created_utc": _utc_now_naive().isoformat() + "Z",
                     "database_file": DATABASE_NAME,
                 }
                 with open(metadata_path, "w", encoding="utf-8") as mf:
@@ -135,7 +134,7 @@ def _perform_db_upgrade(
 
     # Rename old CSV as backup, then save new one without legacy columns
     try:
-        timestamp = datetime.utcnow().strftime("%Y%m%d_%H%M%S")
+        timestamp = _utc_now_naive().strftime("%Y%m%d_%H%M%S")
         old_path = os.path.join(kestrel_dir, f"OLD_kestrel_database_{timestamp}.csv")
         os.rename(db_path, old_path)
         cleaned = database.drop(

--- a/analyzer/kestrel_analyzer/logging_utils.py
+++ b/analyzer/kestrel_analyzer/logging_utils.py
@@ -1,5 +1,6 @@
 import json
 import os
+import threading
 import traceback
 from datetime import datetime, timezone
 from pathlib import Path
@@ -28,7 +29,7 @@ except (ImportError, ValueError):
         def error(*_a, **_kw): pass  # type: ignore[no-redef]
 
 
-def _utc_now_naive() -> datetime:
+def utc_now_naive() -> datetime:
     """UTC now as a naive datetime.
 
     The deprecated naive-UTC constructor emits DeprecationWarning on
@@ -41,11 +42,11 @@ def _utc_now_naive() -> datetime:
 
 
 def _utc_timestamp() -> str:
-    return _utc_now_naive().isoformat() + "Z"
+    return utc_now_naive().isoformat() + "Z"
 
 
 def _file_timestamp() -> str:
-    return _utc_now_naive().strftime("%Y%m%dT%H%M%SZ")
+    return utc_now_naive().strftime("%Y%m%dT%H%M%SZ")
 
 
 def resolve_log_dir(folder: Optional[str]) -> str:
@@ -121,14 +122,17 @@ def make_logged_showwarning(
     The hook is re-entrancy-safe: if logging itself emits a warning (the
     historical ``datetime.utcnow`` DeprecationWarning, or any other), the
     nested call returns immediately instead of stacking until RecursionError.
+
+    The guard is thread-local: ``warnings.showwarning`` is process-global, and
+    decoder/worker threads can warn concurrently. A plain closure boolean
+    would drop or interleave those unrelated warnings.
     """
-    in_handler = False
+    state = threading.local()
 
     def _showwarning(message, category, filename, lineno, file=None, line=None):
-        nonlocal in_handler
-        if in_handler:
+        if getattr(state, "in_handler", False):
             return
-        in_handler = True
+        state.in_handler = True
         try:
             log_warning(
                 log_path,
@@ -144,7 +148,7 @@ def make_logged_showwarning(
                     message, category, filename, lineno, file=file, line=line
                 )
         finally:
-            in_handler = False
+            state.in_handler = False
 
     return _showwarning
 

--- a/analyzer/kestrel_analyzer/logging_utils.py
+++ b/analyzer/kestrel_analyzer/logging_utils.py
@@ -29,6 +29,9 @@ except (ImportError, ValueError):
         def error(*_a, **_kw): pass  # type: ignore[no-redef]
 
 
+_log_write_lock = threading.RLock()
+
+
 def utc_now_naive() -> datetime:
     """UTC now as a naive datetime.
 
@@ -85,10 +88,14 @@ def _read_log_entries(log_path: str) -> list:
 
 def log_event(log_path: str, entry: Dict[str, Any]) -> None:
     entry_with_time = {"timestamp_utc": _utc_timestamp(), **entry}
-    entries = _read_log_entries(log_path)
-    entries.append(entry_with_time)
-    with open(log_path, "w", encoding="utf-8") as handle:
-        json.dump(entries, handle, indent=2)
+    # Decoder threads can hit the warning hook concurrently. Serialize the
+    # read-modify-write so overlapping log_warning/log_exception calls cannot
+    # tear the JSON file or drop earlier session entries.
+    with _log_write_lock:
+        entries = _read_log_entries(log_path)
+        entries.append(entry_with_time)
+        with open(log_path, "w", encoding="utf-8") as handle:
+            json.dump(entries, handle, indent=2)
 
 
 def log_exception(

--- a/analyzer/kestrel_analyzer/logging_utils.py
+++ b/analyzer/kestrel_analyzer/logging_utils.py
@@ -1,7 +1,7 @@
 import json
 import os
 import traceback
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, Optional
 
@@ -28,12 +28,24 @@ except (ImportError, ValueError):
         def error(*_a, **_kw): pass  # type: ignore[no-redef]
 
 
+def _utc_now_naive() -> datetime:
+    """UTC now as a naive datetime.
+
+    The deprecated naive-UTC constructor emits DeprecationWarning on
+    Python 3.12+. If a ``warnings.showwarning`` hook logs via
+    :func:`log_warning` (which stamps the entry with this helper), that
+    warning would re-enter the hook and raise RecursionError.
+    ``datetime.now(timezone.utc)`` is silent.
+    """
+    return datetime.now(timezone.utc).replace(tzinfo=None)
+
+
 def _utc_timestamp() -> str:
-    return datetime.utcnow().isoformat() + "Z"
+    return _utc_now_naive().isoformat() + "Z"
 
 
 def _file_timestamp() -> str:
-    return datetime.utcnow().strftime("%Y%m%dT%H%M%SZ")
+    return _utc_now_naive().strftime("%Y%m%dT%H%M%SZ")
 
 
 def resolve_log_dir(folder: Optional[str]) -> str:
@@ -96,6 +108,45 @@ def log_exception(
             "traceback": traceback.format_exc(),
         },
     )
+
+
+def make_logged_showwarning(
+    log_path: str,
+    stage_ctx: Dict[str, Any],
+    folder: Optional[str] = None,
+    original_showwarning=None,
+):
+    """Build a ``warnings.showwarning`` hook that writes to the JSON log.
+
+    The hook is re-entrancy-safe: if logging itself emits a warning (the
+    historical ``datetime.utcnow`` DeprecationWarning, or any other), the
+    nested call returns immediately instead of stacking until RecursionError.
+    """
+    in_handler = False
+
+    def _showwarning(message, category, filename, lineno, file=None, line=None):
+        nonlocal in_handler
+        if in_handler:
+            return
+        in_handler = True
+        try:
+            log_warning(
+                log_path,
+                message,
+                category=category,
+                filename=filename,
+                lineno=lineno,
+                stage=stage_ctx.get("stage"),
+                context={"file": stage_ctx.get("file"), "folder": folder},
+            )
+            if original_showwarning:
+                original_showwarning(
+                    message, category, filename, lineno, file=file, line=line
+                )
+        finally:
+            in_handler = False
+
+    return _showwarning
 
 
 def log_warning(

--- a/analyzer/kestrel_analyzer/logging_utils.py
+++ b/analyzer/kestrel_analyzer/logging_utils.py
@@ -128,7 +128,9 @@ def make_logged_showwarning(
 
     The hook is re-entrancy-safe: if logging itself emits a warning (the
     historical ``datetime.utcnow`` DeprecationWarning, or any other), the
-    nested call returns immediately instead of stacking until RecursionError.
+    nested call skips JSON logging instead of stacking until RecursionError.
+    Nested warnings are still forwarded to ``original_showwarning`` so they
+    are not silently dropped.
 
     The guard is thread-local: ``warnings.showwarning`` is process-global, and
     decoder/worker threads can warn concurrently. A plain closure boolean
@@ -138,6 +140,10 @@ def make_logged_showwarning(
 
     def _showwarning(message, category, filename, lineno, file=None, line=None):
         if getattr(state, "in_handler", False):
+            if original_showwarning is not None:
+                original_showwarning(
+                    message, category, filename, lineno, file=file, line=line
+                )
             return
         state.in_handler = True
         try:

--- a/analyzer/kestrel_analyzer/pipeline.py
+++ b/analyzer/kestrel_analyzer/pipeline.py
@@ -43,7 +43,13 @@ from .image_utils import decode_embedded_preview, read_image, read_image_for_pip
 from .ratings import quality_to_rating, resolve_thresholds
 from .similarity import compute_image_similarity_akaze, compute_similarity_timestamp
 from .raw_exif import get_capture_time
-from .logging_utils import get_log_path, log_event, log_exception, log_warning
+from .logging_utils import (
+    get_log_path,
+    log_event,
+    log_exception,
+    log_warning,
+    make_logged_showwarning,
+)
 
 try:
     from ..settings_utils import load_persisted_settings, debug as _debug, info as _info, error as _error
@@ -547,21 +553,12 @@ class AnalysisPipeline:
         stage_ctx = {"stage": "startup", "file": None}
 
         original_showwarning = warnings.showwarning
-
-        def _showwarning(message, category, filename, lineno, file=None, line=None):
-            log_warning(
-                self._log_path,
-                message,
-                category=category,
-                filename=filename,
-                lineno=lineno,
-                stage=stage_ctx["stage"],
-                context={"file": stage_ctx["file"], "folder": folder},
-            )
-            if original_showwarning:
-                original_showwarning(message, category, filename, lineno, file=file, line=line)
-
-        warnings.showwarning = _showwarning
+        warnings.showwarning = make_logged_showwarning(
+            self._log_path,
+            stage_ctx,
+            folder=folder,
+            original_showwarning=original_showwarning,
+        )
 
         try:
             stage_ctx["stage"] = "list_files"

--- a/analyzer/queue_manager.py
+++ b/analyzer/queue_manager.py
@@ -41,7 +41,7 @@ def _coerce_detector_name(value) -> str:
 
 
 def _utc_timestamp() -> str:
-    return datetime.utcnow().isoformat() + 'Z'
+    return datetime.now(timezone.utc).replace(tzinfo=None).isoformat() + 'Z'
 
 
 def _ensure_pipeline_path() -> bool:

--- a/analyzer/tests/unit/test_utc_showwarning.py
+++ b/analyzer/tests/unit/test_utc_showwarning.py
@@ -94,17 +94,26 @@ def test_log_warning_does_not_recurse_under_error_filter(tmp_path):
 
 
 def test_logged_showwarning_is_reentrant_when_logging_emits(tmp_path, monkeypatch):
-    """If log_warning itself warns, the hook must not RecursionError."""
+    """If log_warning itself warns, the hook must not RecursionError.
+
+    Nested warnings skip JSON logging (that is the recursion path) but must
+    still reach the previous showwarning hook so they are not dropped.
+    """
     import kestrel_analyzer.logging_utils as logging_utils
 
     log_path = str(tmp_path / "kestrel.log.json")
     stage_ctx = {"stage": "startup", "file": None}
-    original = warnings.showwarning
+    previous = warnings.showwarning
+    forwarded: list[str] = []
+
+    def original_showwarning(message, category, filename, lineno, file=None, line=None):
+        forwarded.append(str(message))
+
     hook = make_logged_showwarning(
         log_path,
         stage_ctx,
         folder=str(tmp_path),
-        original_showwarning=None,
+        original_showwarning=original_showwarning,
     )
 
     real_log_warning = logging_utils.log_warning
@@ -118,11 +127,14 @@ def test_logged_showwarning_is_reentrant_when_logging_emits(tmp_path, monkeypatc
     try:
         warnings.warn("outer warning", UserWarning)
     finally:
-        warnings.showwarning = original
+        warnings.showwarning = previous
 
     entries = json.loads(Path(log_path).read_text(encoding="utf-8"))
     messages = [e["message"] for e in entries]
     assert any("outer warning" in m for m in messages)
+    assert not any("nested warning from logger" in m for m in messages)
+    assert any("nested warning from logger" in m for m in forwarded)
+    assert any("outer warning" in m for m in forwarded)
 
 
 def test_logged_showwarning_does_not_drop_concurrent_threads(tmp_path, monkeypatch):

--- a/analyzer/tests/unit/test_utc_showwarning.py
+++ b/analyzer/tests/unit/test_utc_showwarning.py
@@ -168,6 +168,27 @@ def test_logged_showwarning_does_not_drop_concurrent_threads(tmp_path, monkeypat
     assert any("from-thread-2" in m for m in seen)
 
 
+def test_concurrent_log_warning_keeps_valid_json(tmp_path):
+    """Overlapping log_event writes must not tear or drop the JSON log."""
+    log_path = str(tmp_path / "kestrel.log.json")
+    n = 8
+    barrier = threading.Barrier(n)
+
+    def worker(i: int) -> None:
+        barrier.wait()
+        log_warning(log_path, f"msg-{i}", stage="unit")
+
+    threads = [threading.Thread(target=worker, args=(i,)) for i in range(n)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    entries = json.loads(Path(log_path).read_text(encoding="utf-8"))
+    messages = {e["message"] for e in entries}
+    assert {f"msg-{i}" for i in range(n)} <= messages
+
+
 def test_logged_showwarning_records_category_and_stage(tmp_path):
     log_path = str(tmp_path / "kestrel.log.json")
     stage_ctx = {"stage": "list_files", "file": "IMG_001.CR3"}

--- a/analyzer/tests/unit/test_utc_showwarning.py
+++ b/analyzer/tests/unit/test_utc_showwarning.py
@@ -1,0 +1,145 @@
+"""Regression tests for the utcnow / showwarning RecursionError (F11).
+
+On Python 3.12+, ``datetime.utcnow()`` emits DeprecationWarning. The analysis
+pipeline installs a ``warnings.showwarning`` hook that logs via
+``log_warning`` → ``_utc_timestamp``. If that stamp still called ``utcnow``,
+the warning re-entered the hook until RecursionError (seen on the CLI
+``process_folder`` path, including ``TestPipelineOverrides``).
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import warnings
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from kestrel_analyzer.logging_utils import (  # noqa: E402
+    _file_timestamp,
+    _utc_now_naive,
+    _utc_timestamp,
+    log_warning,
+    make_logged_showwarning,
+)
+from queue_manager import _utc_timestamp as queue_utc_timestamp  # noqa: E402
+
+
+pytestmark = pytest.mark.unit
+
+_ANALYZER_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_utc_now_naive_is_naive_and_close_to_utc():
+    dt = _utc_now_naive()
+    assert dt.tzinfo is None
+    aware = datetime.now(timezone.utc).replace(tzinfo=None)
+    assert abs((aware - dt).total_seconds()) < 2.0
+
+
+def test_utc_timestamp_keeps_naive_zulu_suffix():
+    ts = _utc_timestamp()
+    assert ts.endswith("Z")
+    assert "+00:00" not in ts
+    parsed = datetime.fromisoformat(ts[:-1])
+    assert parsed.tzinfo is None
+
+
+def test_file_timestamp_format():
+    stamp = _file_timestamp()
+    datetime.strptime(stamp, "%Y%m%dT%H%M%SZ")
+
+
+def test_utc_helpers_do_not_emit_utcnow_deprecation():
+    with warnings.catch_warnings(record=True) as recorded:
+        warnings.simplefilter("always")
+        _utc_now_naive()
+        _utc_timestamp()
+        _file_timestamp()
+        queue_utc_timestamp()
+    utcnow = [w for w in recorded if "utcnow" in str(w.message).lower()]
+    assert utcnow == []
+
+
+def test_log_warning_does_not_recurse_under_error_filter(tmp_path):
+    """Treat DeprecationWarning as error: logging must not raise."""
+    log_path = str(tmp_path / "kestrel.log.json")
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        log_warning(log_path, "hello", category=UserWarning, stage="unit")
+    entries = json.loads(Path(log_path).read_text(encoding="utf-8"))
+    assert entries[-1]["message"] == "hello"
+    assert entries[-1]["timestamp_utc"].endswith("Z")
+
+
+def test_logged_showwarning_is_reentrant_when_logging_emits(tmp_path, monkeypatch):
+    """If log_warning itself warns, the hook must not RecursionError."""
+    import kestrel_analyzer.logging_utils as logging_utils
+
+    log_path = str(tmp_path / "kestrel.log.json")
+    stage_ctx = {"stage": "startup", "file": None}
+    original = warnings.showwarning
+    hook = make_logged_showwarning(
+        log_path,
+        stage_ctx,
+        folder=str(tmp_path),
+        original_showwarning=None,
+    )
+
+    real_log_warning = logging_utils.log_warning
+
+    def noisy_log_warning(*args, **kwargs):
+        warnings.warn("nested warning from logger", UserWarning)
+        return real_log_warning(*args, **kwargs)
+
+    monkeypatch.setattr(logging_utils, "log_warning", noisy_log_warning)
+    warnings.showwarning = hook
+    try:
+        warnings.warn("outer warning", UserWarning)
+    finally:
+        warnings.showwarning = original
+
+    entries = json.loads(Path(log_path).read_text(encoding="utf-8"))
+    messages = [e["message"] for e in entries]
+    assert any("outer warning" in m for m in messages)
+
+
+def test_logged_showwarning_records_category_and_stage(tmp_path):
+    log_path = str(tmp_path / "kestrel.log.json")
+    stage_ctx = {"stage": "list_files", "file": "IMG_001.CR3"}
+    original = warnings.showwarning
+    warnings.showwarning = make_logged_showwarning(
+        log_path,
+        stage_ctx,
+        folder="/photos",
+        original_showwarning=None,
+    )
+    try:
+        warnings.warn("pipeline note", RuntimeWarning)
+    finally:
+        warnings.showwarning = original
+
+    entry = json.loads(Path(log_path).read_text(encoding="utf-8"))[-1]
+    assert entry["stage"] == "list_files"
+    assert entry["category"] == "RuntimeWarning"
+    assert entry["context"]["file"] == "IMG_001.CR3"
+    assert entry["context"]["folder"] == "/photos"
+
+
+def test_analyzer_sources_do_not_call_datetime_utcnow():
+    """Keep the RecursionError from coming back via a leftover utcnow()."""
+    offenders = []
+    skip_parts = {".venv", "venv", "node_modules", "__pycache__", ".git"}
+    for path in _ANALYZER_ROOT.rglob("*.py"):
+        if any(part in skip_parts for part in path.parts):
+            continue
+        if "tests" in path.parts:
+            continue
+        text = path.read_text(encoding="utf-8")
+        if ".utcnow(" in text:
+            offenders.append(str(path.relative_to(_ANALYZER_ROOT)))
+    assert offenders == []

--- a/analyzer/tests/unit/test_utc_showwarning.py
+++ b/analyzer/tests/unit/test_utc_showwarning.py
@@ -9,8 +9,10 @@ the warning re-entered the hook until RecursionError (seen on the CLI
 
 from __future__ import annotations
 
+import ast
 import json
 import sys
+import threading
 import warnings
 from datetime import datetime, timezone
 from pathlib import Path
@@ -21,10 +23,10 @@ sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
 from kestrel_analyzer.logging_utils import (  # noqa: E402
     _file_timestamp,
-    _utc_now_naive,
     _utc_timestamp,
     log_warning,
     make_logged_showwarning,
+    utc_now_naive,
 )
 from queue_manager import _utc_timestamp as queue_utc_timestamp  # noqa: E402
 
@@ -34,8 +36,23 @@ pytestmark = pytest.mark.unit
 _ANALYZER_ROOT = Path(__file__).resolve().parents[2]
 
 
+def _utcnow_call_linenos(source: str) -> list[int]:
+    """Line numbers of real ``utcnow()`` / ``datetime.utcnow()`` calls."""
+    tree = ast.parse(source)
+    lines: list[int] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if isinstance(func, ast.Attribute) and func.attr == "utcnow":
+            lines.append(getattr(node, "lineno", 0))
+        elif isinstance(func, ast.Name) and func.id == "utcnow":
+            lines.append(getattr(node, "lineno", 0))
+    return lines
+
+
 def test_utc_now_naive_is_naive_and_close_to_utc():
-    dt = _utc_now_naive()
+    dt = utc_now_naive()
     assert dt.tzinfo is None
     aware = datetime.now(timezone.utc).replace(tzinfo=None)
     assert abs((aware - dt).total_seconds()) < 2.0
@@ -57,7 +74,7 @@ def test_file_timestamp_format():
 def test_utc_helpers_do_not_emit_utcnow_deprecation():
     with warnings.catch_warnings(record=True) as recorded:
         warnings.simplefilter("always")
-        _utc_now_naive()
+        utc_now_naive()
         _utc_timestamp()
         _file_timestamp()
         queue_utc_timestamp()
@@ -108,6 +125,49 @@ def test_logged_showwarning_is_reentrant_when_logging_emits(tmp_path, monkeypatc
     assert any("outer warning" in m for m in messages)
 
 
+def test_logged_showwarning_does_not_drop_concurrent_threads(tmp_path, monkeypatch):
+    """A shared boolean guard would skip the second thread's warning."""
+    import kestrel_analyzer.logging_utils as logging_utils
+
+    log_path = str(tmp_path / "kestrel.log.json")
+    hook = make_logged_showwarning(
+        log_path,
+        {"stage": "decode", "file": None},
+        original_showwarning=None,
+    )
+    real_log_warning = logging_utils.log_warning
+    entered = threading.Event()
+    release = threading.Event()
+    seen: list[str] = []
+    seen_lock = threading.Lock()
+
+    def blocking_log_warning(*args, **kwargs):
+        message = str(args[1] if len(args) > 1 else kwargs.get("message"))
+        with seen_lock:
+            seen.append(message)
+        if "from-thread-1" in message:
+            entered.set()
+            assert release.wait(timeout=2.0)
+        return real_log_warning(*args, **kwargs)
+
+    monkeypatch.setattr(logging_utils, "log_warning", blocking_log_warning)
+    original = warnings.showwarning
+    warnings.showwarning = hook
+    try:
+        t1 = threading.Thread(target=lambda: warnings.warn("from-thread-1", UserWarning))
+        t1.start()
+        assert entered.wait(timeout=2.0)
+        warnings.warn("from-thread-2", UserWarning)
+        release.set()
+        t1.join(timeout=2.0)
+    finally:
+        release.set()
+        warnings.showwarning = original
+
+    assert any("from-thread-1" in m for m in seen)
+    assert any("from-thread-2" in m for m in seen)
+
+
 def test_logged_showwarning_records_category_and_stage(tmp_path):
     log_path = str(tmp_path / "kestrel.log.json")
     stage_ctx = {"stage": "list_files", "file": "IMG_001.CR3"}
@@ -130,8 +190,19 @@ def test_logged_showwarning_records_category_and_stage(tmp_path):
     assert entry["context"]["folder"] == "/photos"
 
 
+def test_utcnow_call_detector_ignores_comments_and_finds_calls():
+    source = """
+# datetime.utcnow() in a comment must not count
+x = datetime.utcnow()
+y = utcnow()
+z = datetime.utcnow ()
+"""
+    lines = _utcnow_call_linenos(source)
+    assert lines == [3, 4, 5]
+
+
 def test_analyzer_sources_do_not_call_datetime_utcnow():
-    """Keep the RecursionError from coming back via a leftover utcnow()."""
+    """Keep the RecursionError from coming back via a leftover utcnow() call."""
     offenders = []
     skip_parts = {".venv", "venv", "node_modules", "__pycache__", ".git"}
     for path in _ANALYZER_ROOT.rglob("*.py"):
@@ -139,7 +210,12 @@ def test_analyzer_sources_do_not_call_datetime_utcnow():
             continue
         if "tests" in path.parts:
             continue
-        text = path.read_text(encoding="utf-8")
-        if ".utcnow(" in text:
-            offenders.append(str(path.relative_to(_ANALYZER_ROOT)))
+        source = path.read_text(encoding="utf-8")
+        try:
+            lines = _utcnow_call_linenos(source)
+        except SyntaxError:
+            continue
+        if lines:
+            rel = path.relative_to(_ANALYZER_ROOT)
+            offenders.append(f"{rel}:{lines}")
     assert offenders == []

--- a/analyzer/visualizer.py
+++ b/analyzer/visualizer.py
@@ -32,7 +32,7 @@ import threading
 import time
 
 from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Optional, TextIO
 
 # --- Extracted modules ---
@@ -170,7 +170,7 @@ def _enable_runtime_log_capture() -> str:
     try:
         runtime_dir = os.path.join(base_log_dir, 'logs')
         os.makedirs(runtime_dir, exist_ok=True)
-        ts = datetime.utcnow().strftime('%Y%m%dT%H%M%SZ')
+        ts = datetime.now(timezone.utc).replace(tzinfo=None).strftime('%Y%m%dT%H%M%SZ')
         runtime_log_path = os.path.join(runtime_dir, f'kestrel_runtime_{ts}.log')
 
         _RUNTIME_LOG_HANDLE = open(runtime_log_path, 'a', encoding='utf-8', buffering=1)
@@ -182,7 +182,7 @@ def _enable_runtime_log_capture() -> str:
 
 
 def _utc_now_iso() -> str:
-    return datetime.utcnow().isoformat() + 'Z'
+    return datetime.now(timezone.utc).replace(tzinfo=None).isoformat() + 'Z'
 
 
 # Settings key holding the previous session's outcome. One of:
@@ -378,7 +378,7 @@ def _mark_session_start() -> None:
         )
 
         try:
-            today_utc = datetime.utcnow().strftime('%Y-%m-%d')
+            today_utc = datetime.now(timezone.utc).strftime('%Y-%m-%d')
             last_ping = str(settings.get('last_open_ping_utc', '') or '').strip()
             legal_agreed = str(settings.get('legal_agreed_version', '') or '').strip()
             if (

--- a/analyzer/visualizer.py
+++ b/analyzer/visualizer.py
@@ -315,7 +315,7 @@ def _prior_session_still_running(prev_pid: int, prev_started: str) -> bool:
     started = _parse_session_timestamp(prev_started)
     if started is None:
         return False
-    age_s = (datetime.utcnow() - started).total_seconds()
+    age_s = (datetime.now(timezone.utc).replace(tzinfo=None) - started).total_seconds()
     # A small negative tolerance absorbs clock skew around the write.
     return -60 <= age_s <= _CONCURRENT_INSTANCE_MAX_AGE_S
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

On Python 3.12+, `datetime.utcnow()` emits `DeprecationWarning`. `AnalysisPipeline.process_folder` installs a `warnings.showwarning` hook that logs via `log_warning`, and that helper stamped entries with `utcnow` as well. The warning therefore re-entered the hook until `RecursionError`.

That breaks the CLI/`process_folder` path (including `analyzer/tests/unit/test_cli_args.py::TestPipelineOverrides` on Python 3.12). The hook lived in `analyzer/kestrel_analyzer/pipeline.py`; timestamps were also produced from `logging_utils`, `queue_manager`, `database`, and `visualizer`.

## Fix

- Replace `datetime.utcnow()` with `datetime.now(timezone.utc)` (naive UTC where existing `isoformat() + "Z"` callers depend on it). Public helper: `utc_now_naive()` in `logging_utils` (used by `database` metadata/backup stamps).
- Make the pipeline warning hook re-entrant via `make_logged_showwarning`. The guard is **thread-local** so concurrent decoder warnings are not dropped.
- `log_event` serializes its JSON read-modify-write with an `RLock` so concurrent `log_warning` calls cannot tear the session log.

## Testing

`analyzer/tests/unit/test_utc_showwarning.py`:
- UTC helpers stay naive-`Z` and do not emit an `utcnow` DeprecationWarning.
- `log_warning` does not raise when `DeprecationWarning` is treated as error.
- Nested warning from inside the hook does not RecursionError.
- Concurrent threads both log (thread-local guard).
- Concurrent `log_warning` writes keep a valid JSON file with every message.
- Leftover `utcnow()` calls are detected via AST, not a substring scan.

`TestPipelineOverrides` still cannot run in this environment (`rawpy`/`cv2` pipeline import). The new tests cover the stamp + hook without importing the ML stack.

## Note

Re-verified as still present on current `main`. Defense in depth: even if some other warning fires during logging, the hook will not recurse.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5fc36961-3868-454b-b2fe-d27e1fde9b5c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5fc36961-3868-454b-b2fe-d27e1fde9b5c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

