### PR TITLE
fix(culling): resolve reject/undo mains case-insensitively

### DIFF
--- a/analyzer/api_bridge.py
+++ b/analyzer/api_bridge.py
@@ -6334,6 +6334,22 @@ class Api:
             print(f"[API] sign_out() -> Error: {e}", flush=True)
             return {"success": False, "error": str(e)}
 
+    class _DirIndex(dict):
+        """Case-folded name -> last on-disk spelling, plus the raw listing.
+
+        Companion lookup still uses last-wins ``self[lower]`` (a string).
+        Main-file resolve uses ``.names`` so two files that differ only by
+        case on a case-sensitive filesystem are not collapsed onto whichever
+        listing came last. ``names`` is None when listdir failed.
+        """
+
+        def __init__(self, names: list[str] | None):
+            super().__init__()
+            self.names = names
+            if names:
+                for entry in names:
+                    self[entry.lower()] = entry
+
     def _build_dir_index(self, root_path: str) -> dict:
         """Map lowercased entry name -> real on-disk name for one directory.
 
@@ -6349,13 +6365,13 @@ class Api:
         (kestrel_analyzer/config.py) already applies when it decides a
         same-stem JPG belongs to a RAW.
 
-        Returns {} if the directory is unreadable, so callers degrade to
-        "no companions found" rather than raising.
+        Returns an empty index if the directory is unreadable, so callers
+        degrade to "no companions found" rather than raising.
         """
         try:
-            return {entry.lower(): entry for entry in os.listdir(root_path)}
+            return self._DirIndex(os.listdir(root_path))
         except OSError:
-            return {}
+            return self._DirIndex(None)
 
     def _resolve_dir_filename(self, filename: str, dir_index: dict | None,
                               directory: str) -> str | None:
@@ -6366,6 +6382,11 @@ class Api:
         reject/undo path used a case-sensitive join, which fails on
         case-sensitive filesystems and can rewrite casing on macOS/Windows.
 
+        Exact listing match wins. A unique case-insensitive match is used
+        when the requested spelling is absent. If two files differ only by
+        case and the request is not an exact listing hit, return None rather
+        than moving the last-folded index entry.
+
         Falls back to ``filename`` when the listing is unavailable but the
         exact path exists (listdir failed).
         """
@@ -6373,11 +6394,21 @@ class Api:
         if not name:
             return None
         index = dir_index if dir_index is not None else self._build_dir_index(directory)
-        hit = index.get(name.lower())
-        if hit:
-            return hit
-        if os.path.exists(os.path.join(directory, name)):
+        names = getattr(index, 'names', None)
+        if names is None:
+            try:
+                names = os.listdir(directory)
+            except OSError:
+                if os.path.exists(os.path.join(directory, name)):
+                    return name
+                return index.get(name.lower()) if index else None
+
+        if name in names:
             return name
+        folded = name.lower()
+        ci_hits = [entry for entry in names if entry.lower() == folded]
+        if len(ci_hits) == 1:
+            return ci_hits[0]
         return None
 
     def _find_sidecar_file(self, root_path: str, filename: str, ext: str = '.xmp',

--- a/analyzer/api_bridge.py
+++ b/analyzer/api_bridge.py
@@ -6335,20 +6335,35 @@ class Api:
             return {"success": False, "error": str(e)}
 
     class _DirIndex(dict):
-        """Case-folded name -> last on-disk spelling, plus the raw listing.
+        """Case-folded name -> last on-disk spelling, plus lookup tables.
 
         Companion lookup still uses last-wins ``self[lower]`` (a string).
-        Main-file resolve uses ``.names`` so two files that differ only by
-        case on a case-sensitive filesystem are not collapsed onto whichever
-        listing came last. ``names`` is None when listdir failed.
+        Main-file resolve uses ``names_set`` / ``folded_counts`` so two files
+        that differ only by case are not collapsed onto whichever listing
+        came last, in O(1) per request. ``names`` is None when listdir failed.
         """
 
         def __init__(self, names: list[str] | None):
             super().__init__()
             self.names = names
-            if names:
-                for entry in names:
-                    self[entry.lower()] = entry
+            self.names_set: set[str] = set()
+            self.folded_counts: dict[str, int] = {}
+            if not names:
+                return
+            for entry in names:
+                key = entry.lower()
+                self[key] = entry
+                self.names_set.add(entry)
+                self.folded_counts[key] = self.folded_counts.get(key, 0) + 1
+
+        def resolve(self, name: str) -> str | None:
+            """Exact spelling, else the unique case-insensitive hit, else None."""
+            if name in self.names_set:
+                return name
+            folded = name.lower()
+            if self.folded_counts.get(folded, 0) == 1:
+                return self[folded]
+            return None
 
     def _build_dir_index(self, root_path: str) -> dict:
         """Map lowercased entry name -> real on-disk name for one directory.
@@ -6394,22 +6409,15 @@ class Api:
         if not name:
             return None
         index = dir_index if dir_index is not None else self._build_dir_index(directory)
-        names = getattr(index, 'names', None)
-        if names is None:
-            try:
-                names = os.listdir(directory)
-            except OSError:
-                if os.path.exists(os.path.join(directory, name)):
-                    return name
-                return index.get(name.lower()) if index else None
-
-        if name in names:
-            return name
-        folded = name.lower()
-        ci_hits = [entry for entry in names if entry.lower() == folded]
-        if len(ci_hits) == 1:
-            return ci_hits[0]
-        return None
+        if isinstance(index, self._DirIndex) and index.names is not None:
+            return index.resolve(name)
+        try:
+            listing = os.listdir(directory)
+        except OSError:
+            if os.path.exists(os.path.join(directory, name)):
+                return name
+            return index.get(name.lower()) if index else None
+        return self._DirIndex(listing).resolve(name)
 
     def _find_sidecar_file(self, root_path: str, filename: str, ext: str = '.xmp',
                            dir_index: dict | None = None):

--- a/analyzer/api_bridge.py
+++ b/analyzer/api_bridge.py
@@ -6357,6 +6357,29 @@ class Api:
         except OSError:
             return {}
 
+    def _resolve_dir_filename(self, filename: str, dir_index: dict | None,
+                              directory: str) -> str | None:
+        """Return the on-disk spelling of ``filename`` in ``directory``.
+
+        The UI / CSV may hold ``img.cr3`` while the camera wrote ``IMG.CR3``.
+        Companion lookup already goes through ``_build_dir_index``; the main
+        reject/undo path used a case-sensitive join, which fails on
+        case-sensitive filesystems and can rewrite casing on macOS/Windows.
+
+        Falls back to ``filename`` when the listing is unavailable but the
+        exact path exists (listdir failed).
+        """
+        name = str(filename or '').strip()
+        if not name:
+            return None
+        index = dir_index if dir_index is not None else self._build_dir_index(directory)
+        hit = index.get(name.lower())
+        if hit:
+            return hit
+        if os.path.exists(os.path.join(directory, name)):
+            return name
+        return None
+
     def _find_sidecar_file(self, root_path: str, filename: str, ext: str = '.xmp',
                            dir_index: dict | None = None):
         """Find sidecar file with given extension for an image file.
@@ -6429,19 +6452,23 @@ class Api:
         """
         moved_files = []
 
-        # Move main file
-        src = os.path.join(root_path, filename)
-        dst = os.path.join(reject_dir, filename)
+        real_name = self._resolve_dir_filename(filename, dir_index, root_path)
+        if not real_name:
+            return False, moved_files
+
+        # Move main file under its real on-disk spelling.
+        src = os.path.join(root_path, real_name)
+        dst = os.path.join(reject_dir, real_name)
         try:
             if os.path.exists(src):
                 shutil.move(src, dst)
-                moved_files.append(filename)
+                moved_files.append(real_name)
             else:
                 return False, moved_files
         except Exception:
             return False, moved_files
 
-        companion_files = self._find_companion_files(root_path, filename, dir_index=dir_index)
+        companion_files = self._find_companion_files(root_path, real_name, dir_index=dir_index)
         if companion_files:
             for companion in companion_files:
                 companion_src = os.path.join(root_path, companion)
@@ -6557,19 +6584,23 @@ class Api:
         """
         restored_files = []
 
-        # Restore main file
-        src = os.path.join(reject_dir, filename)
-        dst = os.path.join(root_path, filename)
+        real_name = self._resolve_dir_filename(filename, dir_index, reject_dir)
+        if not real_name:
+            return False, restored_files
+
+        # Restore main file under its real on-disk spelling.
+        src = os.path.join(reject_dir, real_name)
+        dst = os.path.join(root_path, real_name)
         try:
             if os.path.exists(src):
                 shutil.move(src, dst)
-                restored_files.append(filename)
+                restored_files.append(real_name)
             else:
                 return False, restored_files
         except Exception:
             return False, restored_files
 
-        companion_files = self._find_companion_files(reject_dir, filename, dir_index=dir_index)
+        companion_files = self._find_companion_files(reject_dir, real_name, dir_index=dir_index)
         if companion_files:
             for companion in companion_files:
                 companion_src = os.path.join(reject_dir, companion)

--- a/analyzer/tests/unit/test_reject_move.py
+++ b/analyzer/tests/unit/test_reject_move.py
@@ -21,20 +21,22 @@ def _require_case_sensitive_fs(directory: Path) -> None:
     """Skip if this filesystem cannot host two names that differ only by case."""
     upper = directory / "CaseProbe.tmp"
     lower = directory / "caseprobe.tmp"
-    upper.write_bytes(b"U")
     try:
-        lower.write_bytes(b"L")
-    except OSError:
-        pytest.skip("filesystem cannot create a second case variant")
-    listed = {
-        p.name
-        for p in directory.iterdir()
-        if p.suffix == ".tmp" and p.name.lower() == "caseprobe.tmp"
-    }
-    if listed != {"CaseProbe.tmp", "caseprobe.tmp"}:
-        pytest.skip("filesystem folds case; cannot host two case variants")
-    upper.unlink()
-    lower.unlink()
+        upper.write_bytes(b"U")
+        try:
+            lower.write_bytes(b"L")
+        except OSError:
+            pytest.skip("filesystem cannot create a second case variant")
+        listed = {
+            p.name
+            for p in directory.iterdir()
+            if p.suffix == ".tmp" and p.name.lower() == "caseprobe.tmp"
+        }
+        if listed != {"CaseProbe.tmp", "caseprobe.tmp"}:
+            pytest.skip("filesystem folds case; cannot host two case variants")
+    finally:
+        upper.unlink(missing_ok=True)
+        lower.unlink(missing_ok=True)
 
 
 @pytest.fixture

--- a/analyzer/tests/unit/test_reject_move.py
+++ b/analyzer/tests/unit/test_reject_move.py
@@ -313,3 +313,72 @@ class TestCompanionCaseInsensitivity:
         reject_dir = workdir / "_KESTREL_Rejects"
         for i in range(10):
             assert (reject_dir / f"IMG_8{i:03d}.JPG").exists()
+
+
+class TestMainFilenameCaseInsensitivity:
+    """Main-file reject/undo must use on-disk spelling, not a case-sensitive join.
+
+    Companion lookup already goes through ``_build_dir_index``. The RAW/JPEG
+    itself was joined as ``os.path.join(root, requested_name)``, so
+    ``img.cr3`` missed ``IMG.CR3`` on Linux and could rewrite casing on
+    macOS/Windows.
+    """
+
+    @pytest.fixture
+    def api(self):
+        return api_bridge.Api()
+
+    def test_resolve_dir_filename_returns_on_disk_spelling(self, api, tmp_path):
+        (tmp_path / "IMG_0100.CR3").write_bytes(b"\x00" * 16)
+        index = api._build_dir_index(str(tmp_path))
+        assert api._resolve_dir_filename("img_0100.cr3", index, str(tmp_path)) == "IMG_0100.CR3"
+        assert api._resolve_dir_filename("IMG_0100.CR3", index, str(tmp_path)) == "IMG_0100.CR3"
+        assert api._resolve_dir_filename("missing.CR3", index, str(tmp_path)) is None
+
+    def test_reject_moves_when_requested_case_differs(self, api, tmp_path):
+        workdir = tmp_path / "workdir"
+        workdir.mkdir()
+        (workdir / "IMG_0101.CR3").write_bytes(b"\x00" * 64)
+        (workdir / "IMG_0101.JPG").write_bytes(b"\xff" * 64)
+
+        result = api.move_rejects_to_folder(str(workdir), ["img_0101.cr3"])
+        assert result["success"] is True
+        assert result["errors"] == []
+
+        reject_dir = workdir / "_KESTREL_Rejects"
+        assert (reject_dir / "IMG_0101.CR3").exists()
+        assert (reject_dir / "IMG_0101.JPG").exists()
+        assert not (workdir / "IMG_0101.CR3").exists()
+        # Must not create a second, case-folded name in the reject folder.
+        reject_names = [p.name for p in reject_dir.iterdir() if p.is_file()]
+        assert "img_0101.cr3" not in reject_names
+
+    def test_undo_restores_when_requested_case_differs(self, api, tmp_path):
+        workdir = tmp_path / "workdir"
+        workdir.mkdir()
+        (workdir / "IMG_0102.CR3").write_bytes(b"\x00" * 64)
+        (workdir / "IMG_0102.JPG").write_bytes(b"\xff" * 64)
+
+        api.move_rejects_to_folder(str(workdir), ["IMG_0102.CR3"])
+        reject_dir = workdir / "_KESTREL_Rejects"
+        assert (reject_dir / "IMG_0102.CR3").exists()
+
+        result = api.undo_reject_move(str(workdir), ["img_0102.cr3"])
+        assert result["success"] is True
+        assert result["errors"] == []
+
+        assert (workdir / "IMG_0102.CR3").exists()
+        assert (workdir / "IMG_0102.JPG").exists()
+        assert not (reject_dir / "IMG_0102.CR3").exists()
+
+    def test_reject_unknown_name_still_fails(self, api, tmp_path):
+        workdir = tmp_path / "workdir"
+        workdir.mkdir()
+        (workdir / "IMG_0103.CR3").write_bytes(b"\x00" * 16)
+
+        result = api.move_rejects_to_folder(str(workdir), ["IMG_9999.CR3"])
+        assert result["success"] is True
+        assert result["errors"]
+        assert (workdir / "IMG_0103.CR3").exists()
+        assert not (workdir / "_KESTREL_Rejects" / "IMG_0103.CR3").exists()
+

--- a/analyzer/tests/unit/test_reject_move.py
+++ b/analyzer/tests/unit/test_reject_move.py
@@ -17,6 +17,26 @@ import api_bridge
 pytestmark = pytest.mark.unit
 
 
+def _require_case_sensitive_fs(directory: Path) -> None:
+    """Skip if this filesystem cannot host two names that differ only by case."""
+    upper = directory / "CaseProbe.tmp"
+    lower = directory / "caseprobe.tmp"
+    upper.write_bytes(b"U")
+    try:
+        lower.write_bytes(b"L")
+    except OSError:
+        pytest.skip("filesystem cannot create a second case variant")
+    listed = {
+        p.name
+        for p in directory.iterdir()
+        if p.suffix == ".tmp" and p.name.lower() == "caseprobe.tmp"
+    }
+    if listed != {"CaseProbe.tmp", "caseprobe.tmp"}:
+        pytest.skip("filesystem folds case; cannot host two case variants")
+    upper.unlink()
+    lower.unlink()
+
+
 @pytest.fixture
 def api():
     """Create an Api instance for testing."""
@@ -381,4 +401,49 @@ class TestMainFilenameCaseInsensitivity:
         assert result["errors"]
         assert (workdir / "IMG_0103.CR3").exists()
         assert not (workdir / "_KESTREL_Rejects" / "IMG_0103.CR3").exists()
+
+    def test_resolve_prefers_exact_spelling_when_both_case_variants_exist(
+        self, api, tmp_path
+    ):
+        """A folded index last-wins; mains must still pick the requested file."""
+        _require_case_sensitive_fs(tmp_path)
+        (tmp_path / "IMG_X.CR3").write_bytes(b"UPPER")
+        (tmp_path / "img_x.cr3").write_bytes(b"lower")
+        index = api._build_dir_index(str(tmp_path))
+        assert api._resolve_dir_filename("IMG_X.CR3", index, str(tmp_path)) == "IMG_X.CR3"
+        assert api._resolve_dir_filename("img_x.cr3", index, str(tmp_path)) == "img_x.cr3"
+        assert api._resolve_dir_filename("Img_x.CR3", index, str(tmp_path)) is None
+
+    def test_reject_moves_only_the_requested_case_variant(self, api, tmp_path):
+        workdir = tmp_path / "workdir"
+        workdir.mkdir()
+        _require_case_sensitive_fs(workdir)
+        (workdir / "IMG_X.CR3").write_bytes(b"UPPER")
+        (workdir / "img_x.cr3").write_bytes(b"lower")
+
+        result = api.move_rejects_to_folder(str(workdir), ["IMG_X.CR3"])
+        assert result["success"] is True
+        assert result["errors"] == []
+
+        reject_dir = workdir / "_KESTREL_Rejects"
+        assert (reject_dir / "IMG_X.CR3").read_bytes() == b"UPPER"
+        assert (workdir / "img_x.cr3").read_bytes() == b"lower"
+        assert not (workdir / "IMG_X.CR3").exists()
+        assert not (reject_dir / "img_x.cr3").exists()
+
+    def test_reject_refuses_ambiguous_folded_name(self, api, tmp_path):
+        workdir = tmp_path / "workdir"
+        workdir.mkdir()
+        _require_case_sensitive_fs(workdir)
+        (workdir / "IMG_X.CR3").write_bytes(b"UPPER")
+        (workdir / "img_x.cr3").write_bytes(b"lower")
+
+        result = api.move_rejects_to_folder(str(workdir), ["Img_x.CR3"])
+        assert result["errors"]
+        assert (workdir / "IMG_X.CR3").read_bytes() == b"UPPER"
+        assert (workdir / "img_x.cr3").read_bytes() == b"lower"
+        reject_dir = workdir / "_KESTREL_Rejects"
+        if reject_dir.exists():
+            moved = [p.name for p in reject_dir.iterdir() if p.is_file()]
+            assert moved == []
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Companion lookup for reject/undo already goes through `_build_dir_index` (case-insensitive, real on-disk spelling). The **main** file still used a case-sensitive `os.path.join(root, requested_name)`.

The UI / CSV can hold `img.cr3` while the camera wrote `IMG.CR3`:
- On case-sensitive filesystems (Linux) the move fails (`exists()` is false) and the file stays in the shoot folder.
- On case-insensitive filesystems (macOS/Windows default) `exists()` succeeds but `shutil.move` can rewrite the destination casing, so later exact-name undo/UI lookups diverge.

## Fix

`_resolve_dir_filename` maps the requested name through the directory listing (same index companions already use) and move/restore under the real on-disk spelling. Exact-path fallback remains if listdir is unavailable.

## Testing

`analyzer/tests/unit/test_reject_move.py` (`TestMainFilenameCaseInsensitivity`):
- Resolver returns the on-disk spelling for mixed-case requests.
- Reject with `img_0101.cr3` moves `IMG_0101.CR3` (+ JPG companion) and does not create a folded name in `_KESTREL_Rejects`.
- Undo with a folded name restores the original spelling.
- Unknown names still error; existing exact-case tests still pass.

Red-green on this Linux workspace: the new reject/undo tests fail on current `main` (`img_0101.cr3: move failed` / `not found in rejects`) and pass with the fix (23 passed).

## Note

Re-verified as still present on current `main`. Companion extension case-insensitivity is already on `main`; this PR covers the main filename only.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5fc36961-3868-454b-b2fe-d27e1fde9b5c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5fc36961-3868-454b-b2fe-d27e1fde9b5c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

