### PR TITLE
fix: do not treat corrupt scenedata as an empty folder- #18

### DIFF
--- a/analyzer/kestrel_analyzer/database.py
+++ b/analyzer/kestrel_analyzer/database.py
@@ -304,21 +304,48 @@ def update_scenedata_with_database(scenedata: dict, database: pd.DataFrame) -> d
     return scenedata
 
 
+class ScenedataCorruptError(ValueError):
+    """Raised when kestrel_scenedata.json exists but cannot be loaded as a JSON object.
+
+    A missing file is a fresh folder. A corrupt file is not: callers that treat
+    empty ``scenes`` as "rebuild from CSV" would overwrite user ratings.
+    """
+
+
 def load_scenedata(kestrel_dir: str) -> dict:
-    """Load kestrel_scenedata.json. Returns an empty initialized dict if the file is missing."""
+    """Load kestrel_scenedata.json.
+
+    Returns an empty initialized dict if the file is missing. If the file
+    exists but cannot be read or parsed as a JSON object, raises
+    :class:`ScenedataCorruptError` instead of returning empty.
+    """
     scenedata_path = os.path.join(kestrel_dir, SCENEDATA_FILENAME)
-    if os.path.exists(scenedata_path):
-        try:
-            with open(scenedata_path, "r", encoding="utf-8") as f:
-                data = json.load(f)
-            # Ensure required keys (forward compatibility)
-            data.setdefault("version", SCENEDATA_VERSION)
-            data.setdefault("image_ratings", {})
-            data.setdefault("scenes", {})
-            return data
-        except Exception as e:
-            _warn(f"[database] failed to load {SCENEDATA_FILENAME}: {e}")
-    return {"version": SCENEDATA_VERSION, "image_ratings": {}, "scenes": {}}
+    if not os.path.exists(scenedata_path):
+        return {"version": SCENEDATA_VERSION, "image_ratings": {}, "scenes": {}}
+
+    try:
+        with open(scenedata_path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as e:
+        _warn(f"[database] failed to load {SCENEDATA_FILENAME}: {e}")
+        raise ScenedataCorruptError(
+            f"{SCENEDATA_FILENAME} exists but is unreadable: {e}"
+        ) from e
+
+    if not isinstance(data, dict):
+        _warn(
+            f"[database] failed to load {SCENEDATA_FILENAME}: "
+            f"expected a JSON object, got {type(data).__name__}"
+        )
+        raise ScenedataCorruptError(
+            f"{SCENEDATA_FILENAME} exists but is not a JSON object "
+            f"(got {type(data).__name__})"
+        )
+
+    data.setdefault("version", SCENEDATA_VERSION)
+    data.setdefault("image_ratings", {})
+    data.setdefault("scenes", {})
+    return data
 
 
 def save_scenedata(scenedata: dict, kestrel_dir: str) -> None:

--- a/analyzer/tests/unit/test_scenedata_corrupt_load.py
+++ b/analyzer/tests/unit/test_scenedata_corrupt_load.py
@@ -1,0 +1,123 @@
+"""Corrupt kestrel_scenedata.json must not be treated as an empty folder.
+
+Repro (FINDINGS S0-01): a file with ratings is overwritten by invalid JSON
+``{``. The old load_scenedata swallowed the parse error and returned
+``image_ratings={}`` / ``scenes={}``. pipeline.py then saw ``not scenes``
+and rebuilt from the CSV, wiping ratings and tags.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from kestrel_analyzer.config import SCENEDATA_FILENAME
+from kestrel_analyzer.database import (
+    SCENEDATA_VERSION,
+    ScenedataCorruptError,
+    build_scenedata_from_database,
+    load_scenedata,
+    save_scenedata,
+    update_scenedata_with_database,
+)
+
+
+pytestmark = pytest.mark.unit
+
+
+_RATED = {
+    "version": SCENEDATA_VERSION,
+    "image_ratings": {"IMG_001.CR3": 5},
+    "scenes": {
+        "1": {
+            "scene_id": "1",
+            "image_filenames": ["IMG_001.CR3"],
+            "name": "Keepers",
+            "status": "accepted",
+            "user_tags": {
+                "species": ["Parus major"],
+                "families": [],
+                "finalized": True,
+            },
+        }
+    },
+}
+
+
+def _kestrel(tmp_path: Path) -> Path:
+    kestrel_dir = tmp_path / ".kestrel"
+    kestrel_dir.mkdir()
+    return kestrel_dir
+
+
+class TestCorruptScenedataLoad:
+    def test_invalid_json_raises_and_leaves_file(self, tmp_path):
+        kestrel_dir = _kestrel(tmp_path)
+        path = kestrel_dir / SCENEDATA_FILENAME
+        path.write_text(json.dumps(_RATED), encoding="utf-8")
+        path.write_text("{", encoding="utf-8")
+
+        with pytest.raises(ScenedataCorruptError):
+            load_scenedata(str(kestrel_dir))
+
+        assert path.read_text(encoding="utf-8") == "{"
+        assert [p.name for p in kestrel_dir.iterdir()] == [SCENEDATA_FILENAME]
+
+    def test_non_object_json_raises(self, tmp_path):
+        kestrel_dir = _kestrel(tmp_path)
+        (kestrel_dir / SCENEDATA_FILENAME).write_text("[]", encoding="utf-8")
+
+        with pytest.raises(ScenedataCorruptError, match="not a JSON object"):
+            load_scenedata(str(kestrel_dir))
+
+    def test_pipeline_post_analysis_does_not_rebuild_over_corrupt_file(self, tmp_path):
+        """Neighbor: pipeline.py post-analysis treats empty scenes as fresh.
+
+        The handler wraps load/save in ``except Exception`` and must skip the
+        save when load raises, so the corrupt bytes stay on disk.
+        """
+        kestrel_dir = _kestrel(tmp_path)
+        path = kestrel_dir / SCENEDATA_FILENAME
+        path.write_text("{", encoding="utf-8")
+        database = pd.DataFrame(
+            {"filename": ["IMG_001.CR3"], "scene_count": [1]}
+        )
+
+        try:
+            existing_scenedata = load_scenedata(str(kestrel_dir))
+            if not existing_scenedata.get("scenes"):
+                save_scenedata(
+                    build_scenedata_from_database(database), str(kestrel_dir)
+                )
+            else:
+                update_scenedata_with_database(existing_scenedata, database)
+                save_scenedata(existing_scenedata, str(kestrel_dir))
+        except ScenedataCorruptError:
+            pass
+
+        assert path.read_text(encoding="utf-8") == "{"
+
+
+class TestScenedataLoadNeighbors:
+    def test_missing_file_still_returns_initialized_dict(self, tmp_path):
+        kestrel_dir = _kestrel(tmp_path)
+
+        result = load_scenedata(str(kestrel_dir))
+
+        assert result["version"] == SCENEDATA_VERSION
+        assert result["image_ratings"] == {}
+        assert result["scenes"] == {}
+
+    def test_valid_rated_file_roundtrip(self, tmp_path):
+        kestrel_dir = _kestrel(tmp_path)
+        save_scenedata(_RATED, str(kestrel_dir))
+
+        loaded = load_scenedata(str(kestrel_dir))
+
+        assert loaded == _RATED
+        assert loaded["image_ratings"]["IMG_001.CR3"] == 5
+        assert loaded["scenes"]["1"]["name"] == "Keepers"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

An existing `kestrel_scenedata.json` that fails to parse (e.g. `{`) used to make `load_scenedata` return the initialized empty dict. The post-analysis path in `pipeline.py` treats empty `scenes` as a fresh folder and rebuilds from the CSV, which wipes user ratings and tags.

Missing files still return the empty init dict. Corrupt or non-object JSON now raises `ScenedataCorruptError`. The pipeline already wraps that load/save in `except Exception`, so the save is skipped and the corrupt file stays on disk.

Out of scope: WP-02 (upgrade abort), WP-15 (lost-update), #121 (atomic scenedata writes).

## Test plan

- `pytest analyzer/tests/unit/test_scenedata_corrupt_load.py analyzer/tests/unit/test_database.py -m unit -q`
- Corrupt `{` after a rated file → raise, file unchanged
- Missing file and valid roundtrip still behave as before

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f204d3df-2a90-4759-873e-d85c8807e9e6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f204d3df-2a90-4759-873e-d85c8807e9e6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

