### PR TITLE
fix: abort legacy CSV strip if scenedata save fails

### DIFF
--- a/analyzer/kestrel_analyzer/database.py
+++ b/analyzer/kestrel_analyzer/database.py
@@ -115,7 +115,12 @@ def _needs_upgrade(database: pd.DataFrame, kestrel_dir: str) -> bool:
 def _perform_db_upgrade(
     database: pd.DataFrame, kestrel_dir: str, db_path: str, log_path: str = None
 ) -> pd.DataFrame:
-    """Migrate legacy database: extract user data to scenedata.json and strip legacy columns."""
+    """Migrate legacy database: extract user data to scenedata.json and strip legacy columns.
+
+    The live CSV is renamed and stripped only after scenedata is saved.
+    If that save fails, the original CSV (including ratings) is left intact
+    and the error is re-raised so callers do not treat the upgrade as done.
+    """
     # Build and save scenedata from legacy database
     try:
         scenedata = _build_scenedata_from_legacy_db(database)
@@ -132,6 +137,7 @@ def _perform_db_upgrade(
             )
         else:
             _warn(f"[database] failed to migrate legacy database: {e}")
+        raise
 
     # Rename old CSV as backup, then save new one without legacy columns
     try:

--- a/analyzer/tests/unit/test_db_upgrade_scenedata_fail.py
+++ b/analyzer/tests/unit/test_db_upgrade_scenedata_fail.py
@@ -1,0 +1,118 @@
+"""Legacy upgrade must not strip CSV ratings if scenedata save fails.
+
+Repro (FINDINGS S0-02): ``_perform_db_upgrade`` caught ``save_scenedata``
+errors, logged them, then still renamed the CSV and dropped ``rating`` /
+``scene_name``. Ratings were then in neither JSON nor CSV.
+"""
+
+import sys
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from kestrel_analyzer.config import DATABASE_NAME, SCENEDATA_FILENAME
+from kestrel_analyzer.database import (
+    LEGACY_USER_COLUMNS,
+    _perform_db_upgrade,
+    load_database,
+    load_scenedata,
+)
+
+
+pytestmark = pytest.mark.unit
+
+
+def _legacy_frame() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "filename": ["IMG_001.CR3", "IMG_002.CR3"],
+            "scene_count": [1, 1],
+            "rating": [5, 4],
+            "normalized_rating": [1.0, 0.8],
+            "scene_name": ["Keepers", "Keepers"],
+            "rating_origin": ["manual", "manual"],
+        }
+    )
+
+
+def _write_legacy_csv(kestrel_dir: Path, database: pd.DataFrame) -> Path:
+    db_path = kestrel_dir / DATABASE_NAME
+    database.to_csv(db_path, index=False)
+    return db_path
+
+
+class TestUpgradeAbortsOnScenedataSaveFailure:
+    def test_csv_ratings_unchanged_when_save_scenedata_raises(
+        self, tmp_path, monkeypatch
+    ):
+        kestrel_dir = tmp_path / ".kestrel"
+        kestrel_dir.mkdir()
+        database = _legacy_frame()
+        db_path = _write_legacy_csv(kestrel_dir, database)
+        original = db_path.read_bytes()
+
+        def _boom(_scenedata, _kestrel_dir):
+            raise OSError("disk full")
+
+        monkeypatch.setattr(
+            "kestrel_analyzer.database.save_scenedata", _boom
+        )
+
+        with pytest.raises(OSError, match="disk full"):
+            _perform_db_upgrade(
+                database.copy(), str(kestrel_dir), str(db_path), None
+            )
+
+        assert db_path.read_bytes() == original
+        on_disk = pd.read_csv(db_path)
+        assert list(on_disk["rating"]) == [5, 4]
+        assert list(on_disk["scene_name"]) == ["Keepers", "Keepers"]
+        assert not (kestrel_dir / SCENEDATA_FILENAME).exists()
+        assert list(kestrel_dir.glob("OLD_kestrel_database_*.csv")) == []
+
+    def test_load_database_propagates_and_does_not_strip(
+        self, tmp_path, monkeypatch
+    ):
+        """Neighbor: production caller is load_database → _perform_db_upgrade."""
+        kestrel_dir = tmp_path / ".kestrel"
+        kestrel_dir.mkdir()
+        db_path = _write_legacy_csv(kestrel_dir, _legacy_frame())
+        original = db_path.read_bytes()
+
+        def _boom(_scenedata, _kestrel_dir):
+            raise OSError("disk full")
+
+        monkeypatch.setattr(
+            "kestrel_analyzer.database.save_scenedata", _boom
+        )
+
+        with pytest.raises(OSError, match="disk full"):
+            load_database(str(kestrel_dir), "test_analyzer", None)
+
+        assert db_path.read_bytes() == original
+
+
+class TestUpgradeNeighborSuccess:
+    def test_successful_save_still_strips_legacy_columns(self, tmp_path):
+        kestrel_dir = tmp_path / ".kestrel"
+        kestrel_dir.mkdir()
+        database = _legacy_frame()
+        db_path = _write_legacy_csv(kestrel_dir, database)
+
+        result = _perform_db_upgrade(
+            database.copy(), str(kestrel_dir), str(db_path), None
+        )
+
+        for col in LEGACY_USER_COLUMNS:
+            assert col not in result.columns
+        live = pd.read_csv(db_path)
+        for col in LEGACY_USER_COLUMNS:
+            assert col not in live.columns
+        scenedata = load_scenedata(str(kestrel_dir))
+        assert scenedata["image_ratings"]["IMG_001.CR3"] == 5
+        assert scenedata["image_ratings"]["IMG_002.CR3"] == 4
+        assert scenedata["scenes"]["1"]["name"] == "Keepers"
+        assert list(kestrel_dir.glob("OLD_kestrel_database_*.csv"))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`_perform_db_upgrade` logged a failed `save_scenedata` and still renamed the live CSV and dropped legacy columns (`rating`, `scene_name`, …). User ratings then existed in neither JSON nor CSV.

The upgrade now re-raises after the log. Strip/rename run only after a successful scenedata save; the original CSV is left intact.

Out of scope: WP-01 (corrupt load), WP-03 (cloud merge atomic writes), #121, #124.

## Test plan

- `pytest analyzer/tests/unit/test_db_upgrade_scenedata_fail.py analyzer/tests/compat/test_database_migration.py analyzer/tests/unit/test_database.py -v`
- 25 passed, 6 skipped
- Arrange: legacy CSV with ratings; `save_scenedata` raises
- Assert: original CSV bytes unchanged, no `OLD_kestrel_database_*.csv`, error propagates
- Neighbor: successful save still strips legacy columns and migrates ratings

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f204d3df-2a90-4759-873e-d85c8807e9e6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f204d3df-2a90-4759-873e-d85c8807e9e6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

