### PR TITLE
fix: write cloud pack-merge CSV/JSON atomically

### DIFF
--- a/analyzer/cloud_compute_client.py
+++ b/analyzer/cloud_compute_client.py
@@ -1252,6 +1252,47 @@ def merge_pack_into_kestrel(
             shutil.copy2(src_metadata, target_kestrel / "kestrel_metadata.json")
 
 
+def _write_file_atomic(
+    path: Path,
+    write: Callable[[Any], None],
+    *,
+    newline: Optional[str] = None,
+) -> None:
+    """Write ``path`` via tempfile + fsync + ``os.replace``.
+
+    Mirrors ``kestrel_analyzer.database._to_csv_atomic`` and
+    ``settings_utils.save_settings``: the destination is never opened with
+    ``"w"``, so a crash or ENOSPC cannot truncate a live ``.kestrel`` file.
+    ``write`` receives the open temp file. Failures propagate; the previous
+    destination is left intact.
+    """
+    directory = str(path.parent)
+    os.makedirs(directory, exist_ok=True)
+    tmp_fd, tmp = tempfile.mkstemp(
+        prefix=".kestrel_merge_",
+        suffix=".tmp",
+        dir=directory,
+    )
+    try:
+        open_kw: dict[str, Any] = {"encoding": "utf-8"}
+        if newline is not None:
+            open_kw["newline"] = newline
+        with os.fdopen(tmp_fd, "w", **open_kw) as f:
+            write(f)
+            try:
+                f.flush()
+                os.fsync(f.fileno())
+            except OSError:
+                pass
+        os.replace(tmp, path)
+    except BaseException:
+        try:
+            os.remove(tmp)
+        except OSError:
+            pass
+        raise
+
+
 def _merge_database_csv(
     src: Path,
     dst: Path,
@@ -1353,11 +1394,13 @@ def _merge_database_csv(
             except (TypeError, ValueError):
                 pass
 
-    with dst.open("w", encoding="utf-8", newline="") as f:
+    def _write_csv(f) -> None:
         writer = csv.DictWriter(f, fieldnames=fieldnames, extrasaction="ignore")
         writer.writeheader()
         for key in sorted_keys:
             writer.writerow(rows[key])
+
+    _write_file_atomic(dst, _write_csv, newline="")
 
 
 def _rebuild_scenedata_from_csv(
@@ -1521,8 +1564,7 @@ def _merge_scenedata_additive(src: Path, dst: Path) -> None:
         return
 
     if not dst.is_file():
-        with dst.open("w", encoding="utf-8") as f:
-            json.dump(incoming, f, indent=2)
+        _write_file_atomic(dst, lambda f: json.dump(incoming, f, indent=2))
         return
 
     try:
@@ -1576,5 +1618,4 @@ def _merge_scenedata_additive(src: Path, dst: Path) -> None:
                 if f not in local_scene and f in inc_scene:
                     local_scene[f] = inc_scene[f]
 
-    with dst.open("w", encoding="utf-8") as f:
-        json.dump(existing, f, indent=2)
+    _write_file_atomic(dst, lambda f: json.dump(existing, f, indent=2))

--- a/analyzer/cloud_compute_client.py
+++ b/analyzer/cloud_compute_client.py
@@ -40,6 +40,11 @@ try:
 except ImportError:  # pragma: no cover - package-style import path
     from analyzer.net_tls import ssl_context as _ssl_context
 
+try:
+    from kestrel_analyzer.database import retry_on_file_lock
+except ImportError:  # pragma: no cover - package-style import path
+    from analyzer.kestrel_analyzer.database import retry_on_file_lock
+
 
 _DEFAULT_API_BASE = "https://cloudcompute.projectkestrel.org"
 _MAX_UPLOAD_WORKERS = 6
@@ -1264,7 +1269,9 @@ def _write_file_atomic(
     ``settings_utils.save_settings``: the destination is never opened with
     ``"w"``, so a crash or ENOSPC cannot truncate a live ``.kestrel`` file.
     ``write`` receives the open temp file. Failures propagate; the previous
-    destination is left intact.
+    destination is left intact. ``os.replace`` goes through
+    ``retry_on_file_lock`` so a Windows UI reader holding the CSV does not
+    abort the pack merge.
     """
     directory = str(path.parent)
     os.makedirs(directory, exist_ok=True)
@@ -1284,7 +1291,7 @@ def _write_file_atomic(
                 os.fsync(f.fileno())
             except OSError:
                 pass
-        os.replace(tmp, path)
+        retry_on_file_lock(lambda: os.replace(tmp, path))
     except BaseException:
         try:
             os.remove(tmp)

--- a/analyzer/tests/unit/test_cloud_merge_atomic.py
+++ b/analyzer/tests/unit/test_cloud_merge_atomic.py
@@ -1,0 +1,191 @@
+"""Cloud pack-merge must not truncate live .kestrel CSV/JSON on write failure.
+
+Repro (FINDINGS S0-03): ``_merge_database_csv`` and ``_merge_scenedata_additive``
+opened the destination with ``"w"``. Crash/ENOSPC after truncate left a
+zero-length ``kestrel_database.csv`` / ``kestrel_scenedata.json``.
+"""
+
+import csv
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from cloud_compute_client import (  # noqa: E402
+    _merge_database_csv,
+    _merge_scenedata_additive,
+)
+
+
+pytestmark = pytest.mark.unit
+
+
+def _write_csv(path: Path, rows: list[dict]) -> bytes:
+    fieldnames = list(rows[0].keys())
+    with path.open("w", encoding="utf-8", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+    return path.read_bytes()
+
+
+class TestMergeCsvAtomic:
+    def test_failed_write_leaves_local_csv_byte_identical(self, tmp_path, monkeypatch):
+        dst = tmp_path / "kestrel_database.csv"
+        original = _write_csv(
+            dst,
+            [
+                {
+                    "filename": "IMG_001.CR3",
+                    "species": "American Goldfinch",
+                    "culled": "1",
+                    "culled_origin": "manual",
+                }
+            ],
+        )
+        src = tmp_path / "pack.csv"
+        _write_csv(
+            src,
+            [
+                {
+                    "filename": "IMG_001.CR3",
+                    "species": "House Finch",
+                    "culled": "0",
+                    "culled_origin": "",
+                },
+                {
+                    "filename": "IMG_002.CR3",
+                    "species": "Northern Cardinal",
+                    "culled": "0",
+                    "culled_origin": "",
+                },
+            ],
+        )
+
+        def _boom(self, row):
+            raise OSError("No space left on device")
+
+        monkeypatch.setattr(csv.DictWriter, "writerow", _boom)
+
+        with pytest.raises(OSError, match="No space left on device"):
+            _merge_database_csv(src, dst)
+
+        assert dst.read_bytes() == original
+        leftover = [p.name for p in tmp_path.iterdir() if p.suffix == ".tmp"]
+        assert leftover == []
+
+    def test_successful_merge_keeps_local_culled(self, tmp_path):
+        dst = tmp_path / "kestrel_database.csv"
+        _write_csv(
+            dst,
+            [
+                {
+                    "filename": "IMG_001.CR3",
+                    "species": "American Goldfinch",
+                    "culled": "1",
+                    "culled_origin": "manual",
+                }
+            ],
+        )
+        src = tmp_path / "pack.csv"
+        _write_csv(
+            src,
+            [
+                {
+                    "filename": "IMG_001.CR3",
+                    "species": "House Finch",
+                    "culled": "0",
+                    "culled_origin": "",
+                },
+                {
+                    "filename": "IMG_002.CR3",
+                    "species": "Northern Cardinal",
+                    "culled": "0",
+                    "culled_origin": "",
+                },
+            ],
+        )
+
+        _merge_database_csv(src, dst)
+
+        rows = {r["filename"]: r for r in csv.DictReader(dst.open(encoding="utf-8"))}
+        assert rows["IMG_001.CR3"]["culled"] == "1"
+        assert rows["IMG_001.CR3"]["culled_origin"] == "manual"
+        assert rows["IMG_001.CR3"]["species"] == "American Goldfinch"
+        assert rows["IMG_002.CR3"]["species"] == "Northern Cardinal"
+
+
+class TestMergeScenedataAtomic:
+    def test_failed_write_leaves_local_json_byte_identical(self, tmp_path, monkeypatch):
+        dst = tmp_path / "kestrel_scenedata.json"
+        payload = {
+            "version": "2.0",
+            "image_ratings": {"IMG_001.CR3": 5},
+            "scenes": {
+                "1": {
+                    "scene_id": "1",
+                    "image_filenames": ["IMG_001.CR3"],
+                    "name": "Keepers",
+                    "status": "reviewed",
+                    "user_tags": {"species": [], "families": [], "finalized": False},
+                }
+            },
+        }
+        dst.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+        original = dst.read_bytes()
+        src = tmp_path / "pack_scenedata.json"
+        src.write_text(
+            json.dumps(
+                {
+                    "version": "2.0",
+                    "image_ratings": {"IMG_001.CR3": 0, "IMG_002.CR3": 3},
+                    "scenes": {},
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        def _boom(*_a, **_k):
+            raise OSError("No space left on device")
+
+        monkeypatch.setattr("cloud_compute_client.json.dump", _boom)
+
+        with pytest.raises(OSError, match="No space left on device"):
+            _merge_scenedata_additive(src, dst)
+
+        assert dst.read_bytes() == original
+        leftover = [p.name for p in tmp_path.iterdir() if p.suffix == ".tmp"]
+        assert leftover == []
+
+    def test_successful_merge_keeps_local_ratings(self, tmp_path):
+        dst = tmp_path / "kestrel_scenedata.json"
+        dst.write_text(
+            json.dumps(
+                {
+                    "version": "2.0",
+                    "image_ratings": {"IMG_001.CR3": 5},
+                    "scenes": {},
+                }
+            ),
+            encoding="utf-8",
+        )
+        src = tmp_path / "pack_scenedata.json"
+        src.write_text(
+            json.dumps(
+                {
+                    "version": "2.0",
+                    "image_ratings": {"IMG_001.CR3": 0, "IMG_002.CR3": 3},
+                    "scenes": {},
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        _merge_scenedata_additive(src, dst)
+
+        merged = json.loads(dst.read_text(encoding="utf-8"))
+        assert merged["image_ratings"]["IMG_001.CR3"] == 5
+        assert merged["image_ratings"]["IMG_002.CR3"] == 3

--- a/analyzer/tests/unit/test_cloud_merge_atomic.py
+++ b/analyzer/tests/unit/test_cloud_merge_atomic.py
@@ -7,6 +7,7 @@ zero-length ``kestrel_database.csv`` / ``kestrel_scenedata.json``.
 
 import csv
 import json
+import os
 import sys
 from pathlib import Path
 
@@ -116,6 +117,88 @@ class TestMergeCsvAtomic:
         assert rows["IMG_001.CR3"]["culled_origin"] == "manual"
         assert rows["IMG_001.CR3"]["species"] == "American Goldfinch"
         assert rows["IMG_002.CR3"]["species"] == "Northern Cardinal"
+
+    def test_replace_retries_permission_error(self, tmp_path, monkeypatch):
+        dst = tmp_path / "kestrel_database.csv"
+        _write_csv(
+            dst,
+            [
+                {
+                    "filename": "IMG_001.CR3",
+                    "species": "American Goldfinch",
+                    "culled": "1",
+                    "culled_origin": "manual",
+                }
+            ],
+        )
+        src = tmp_path / "pack.csv"
+        _write_csv(
+            src,
+            [
+                {
+                    "filename": "IMG_002.CR3",
+                    "species": "Northern Cardinal",
+                    "culled": "0",
+                    "culled_origin": "",
+                }
+            ],
+        )
+
+        calls = {"n": 0}
+        real_replace = os.replace
+
+        def _flaky(src_path, dst_path):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise PermissionError("sharing violation")
+            return real_replace(src_path, dst_path)
+
+        monkeypatch.setattr("cloud_compute_client.os.replace", _flaky)
+        monkeypatch.setattr("kestrel_analyzer.database.time.sleep", lambda *_a, **_k: None)
+
+        _merge_database_csv(src, dst)
+
+        assert calls["n"] >= 2
+        rows = {r["filename"]: r for r in csv.DictReader(dst.open(encoding="utf-8"))}
+        assert rows["IMG_001.CR3"]["culled"] == "1"
+        assert rows["IMG_002.CR3"]["species"] == "Northern Cardinal"
+
+    def test_exhausted_permission_error_leaves_csv_intact(self, tmp_path, monkeypatch):
+        dst = tmp_path / "kestrel_database.csv"
+        original = _write_csv(
+            dst,
+            [
+                {
+                    "filename": "IMG_001.CR3",
+                    "species": "American Goldfinch",
+                    "culled": "1",
+                    "culled_origin": "manual",
+                }
+            ],
+        )
+        src = tmp_path / "pack.csv"
+        _write_csv(
+            src,
+            [
+                {
+                    "filename": "IMG_002.CR3",
+                    "species": "Northern Cardinal",
+                    "culled": "0",
+                    "culled_origin": "",
+                }
+            ],
+        )
+
+        def _locked(_src, _dst):
+            raise PermissionError("sharing violation")
+
+        monkeypatch.setattr("cloud_compute_client.os.replace", _locked)
+        monkeypatch.setattr("kestrel_analyzer.database.time.sleep", lambda *_a, **_k: None)
+
+        with pytest.raises(PermissionError, match="sharing violation"):
+            _merge_database_csv(src, dst)
+
+        assert dst.read_bytes() == original
 
 
 class TestMergeScenedataAtomic:


### PR DESCRIPTION
## Summary

`_merge_database_csv` and `_merge_scenedata_additive` opened the live `.kestrel` destination with `"w"`. A crash or ENOSPC after truncate could wipe `culled` flags and ratings.

Writes now go through tempfile + fsync + `os.replace`, matching `_to_csv_atomic` / `settings_utils`. On Windows, `os.replace` is wrapped in `retry_on_file_lock` so a UI reader holding `kestrel_database.csv` does not fail the merge after the temp file is already written.

Merge semantics are unchanged.

Reviewed on https://github.com/wolfgangh/ProjectKestrel/pull/20

Out of scope: WP-01, WP-02, #121 `save_scenedata`, Pack-ZIP, Perch.

## Test plan

- `pytest analyzer/tests/unit/test_cloud_merge_atomic.py analyzer/tests/integration/test_pack_merge.py -v`
- Failed CSV/JSON write leaves the local file byte-identical
- `PermissionError` on `os.replace` is retried; exhausted retry leaves the original CSV intact
- Neighbor: local `culled` / ratings still win on a successful merge