### PR TITLE
fix: abort save_database if culled preserve-read fails

### DIFF
--- a/analyzer/kestrel_analyzer/database.py
+++ b/analyzer/kestrel_analyzer/database.py
@@ -482,6 +482,9 @@ def save_database(database: pd.DataFrame, db_path: str) -> None:
     and merges them back into the pipeline's DataFrame before writing, so
     user decisions made during analysis are not lost.
 
+    If that read fails, the existing CSV is left unchanged and the error
+    propagates so callers do not treat the save as successful.
+
     Legacy user columns (rating, scene_name, etc.) are stripped — those now
     live in kestrel_scenedata.json.
     """
@@ -505,7 +508,11 @@ def save_database(database: pd.DataFrame, db_path: str) -> None:
                             zip(disk_df["filename"].astype(str), disk_df[col])
                         )
                         database[col] = database["filename"].astype(str).map(col_map)
-        except Exception:
-            pass  # If we can't read the existing CSV, just write what we have
+        except Exception as e:
+            _warn(
+                f"[database] failed to read UI columns from {db_path} "
+                f"before save; leaving existing CSV unchanged: {e}"
+            )
+            raise
 
     _to_csv_atomic(database, db_path)

--- a/analyzer/tests/unit/test_database.py
+++ b/analyzer/tests/unit/test_database.py
@@ -62,28 +62,24 @@ class TestDatabaseSave:
         )
 
     def test_save_database_preserves_culled_from_disk(self, temp_kestrel_dir, sample_database):
-        """save_database should read culled/culled_origin from on-disk version before overwriting."""
-        # Create initial CSV with culled data
+        """Pipeline BASE_COLUMNS save must keep on-disk culled / culled_origin."""
         sample_database.loc[0] = [None] * len(BASE_COLUMNS)
         sample_database.loc[0, 'filename'] = 'IMG_001.CR3'
-        sample_database.loc[0, 'culled'] = True
-        sample_database.loc[0, 'culled_origin'] = 'manual'
+        sample_database.loc[0, 'species'] = 'aves'
+        sample_database['culled'] = 1
+        sample_database['culled_origin'] = 'manual'
 
         csv_path = temp_kestrel_dir / "kestrel_database.csv"
         sample_database.to_csv(csv_path, index=False)
 
-        # Create a modified version (without culled info)
-        modified = sample_database.copy()
-        modified.loc[0, 'culled'] = False
-        modified.loc[0, 'culled_origin'] = None
+        pipeline = sample_database.drop(columns=['culled', 'culled_origin'])
+        save_database(pipeline, str(csv_path))
 
-        # Save the modified version (which should read culled from disk and preserve it)
-        save_database(modified, str(csv_path))
-
-        # Reload and verify culled data was preserved
         reloaded = pd.read_csv(csv_path)
-        # Note: The actual behavior depends on the implementation of save_database
-        # This test documents the expected behavior
+        assert int(reloaded.loc[0, 'culled']) == 1
+        assert reloaded.loc[0, 'culled_origin'] == 'manual'
+        assert reloaded.loc[0, 'filename'] == 'IMG_001.CR3'
+        assert reloaded.loc[0, 'species'] == 'aves'
 
 
 class TestScenedata:

--- a/analyzer/tests/unit/test_save_database_preserve_culled.py
+++ b/analyzer/tests/unit/test_save_database_preserve_culled.py
@@ -1,0 +1,59 @@
+"""save_database must not drop UI culled flags when the preserve-read fails.
+
+S0-04: a bare ``except Exception: pass`` around the on-disk read let the
+pipeline write BASE_COLUMNS over a CSV that already had ``culled=manual``.
+"""
+
+from pathlib import Path
+import sys
+
+import pandas as pd
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from kestrel_analyzer.database import BASE_COLUMNS, save_database
+
+
+pytestmark = pytest.mark.unit
+
+
+def _pipeline_row(filename: str = "IMG_001.CR3") -> pd.DataFrame:
+    row = {col: None for col in BASE_COLUMNS}
+    row["filename"] = filename
+    row["species"] = "aves"
+    row["quality"] = 0.5
+    return pd.DataFrame([row])
+
+
+def _disk_csv_with_culled(path: Path) -> bytes:
+    df = _pipeline_row()
+    df["culled"] = 1
+    df["culled_origin"] = "manual"
+    df.to_csv(path, index=False)
+    return path.read_bytes()
+
+
+class TestSaveDatabasePreserveCulled:
+    def test_read_failure_leaves_culled_csv_intact(self, tmp_path, monkeypatch):
+        csv_path = tmp_path / "kestrel_database.csv"
+        original = _disk_csv_with_culled(csv_path)
+
+        def boom(*_a, **_k):
+            raise OSError("simulated disk read failure")
+
+        monkeypatch.setattr(
+            "kestrel_analyzer.database.read_database_csv", boom
+        )
+
+        with pytest.raises(OSError, match="simulated disk read failure"):
+            save_database(_pipeline_row(), str(csv_path))
+
+        assert csv_path.read_bytes() == original
+
+    def test_missing_file_still_writes_pipeline_frame(self, tmp_path):
+        csv_path = tmp_path / "kestrel_database.csv"
+        save_database(_pipeline_row(), str(csv_path))
+        reloaded = pd.read_csv(csv_path)
+        assert reloaded.loc[0, "filename"] == "IMG_001.CR3"
+        assert "culled" not in reloaded.columns


### PR DESCRIPTION
## Summary

`save_database` swallowed any failure while reading on-disk `culled` / `culled_origin` (`except Exception: pass`) and then wrote the pipeline `BASE_COLUMNS` frame over the live CSV. Culling decisions made in the UI during analysis were dropped silently.

A failed preserve-read now logs and re-raises. `_to_csv_atomic` does not run, so the existing file stays intact and callers do not treat the save as done.

Happy-path merge is unchanged: UI columns are copied from disk only when they are absent from the pipeline frame.

Reviewed on https://github.com/wolfgangh/ProjectKestrel/pull/21

Out of scope: WP-03 (cloud merge atomic writes), #121 scenedata atomic helpers, pipeline retry after a failed save.

## Test plan

- `pytest analyzer/tests/unit/test_save_database_preserve_culled.py analyzer/tests/unit/test_database.py analyzer/tests/unit/test_database_atomic_save.py -m unit -v`
- 14 passed
- Arrange: disk CSV with `culled=1`, `culled_origin=manual`; `read_database_csv` raises
- Assert: `OSError` propagates, original CSV bytes unchanged
- Neighbor: successful pipeline save without those columns still preserves disk culled flags; atomic CSV write tests still pass