### PR TITLE
fix: refuse .kestrel wipe while analysis is running

### DIFF
--- a/analyzer/api_bridge.py
+++ b/analyzer/api_bridge.py
@@ -1226,15 +1226,31 @@ class Api:
             return {'success': False, 'error': str(e)}
 
     def clear_kestrel_data(self, folder_path: str):
-        """Delete the contents of the .kestrel folder within the given folder."""
+        """Delete the .kestrel folder in ``folder_path``.
+
+        Refuses while a queue item for that root is ``running`` so analysis
+        cannot write into a directory that is being deleted.
+        """
         try:
-            _, kestrel_dir, _, err = self._resolve_folder_root_and_kestrel(
+            root_real, kestrel_dir, _, err = self._resolve_folder_root_and_kestrel(
                 folder_path,
                 context='clear_kestrel_data',
                 require_root_exists=True,
             )
             if err:
                 return {'success': False, 'error': err}
+
+            if _queue_manager.has_running_writer(root_real):
+                warn(
+                    f'[API] clear_kestrel_data refused: analysis running for {root_real}'
+                )
+                return {
+                    'success': False,
+                    'error': (
+                        'Cannot clear .kestrel while analysis is running '
+                        'for this folder'
+                    ),
+                }
 
             if not os.path.isdir(kestrel_dir):
                 return {'success': True, 'message': 'No .kestrel folder found'}

--- a/analyzer/queue_manager.py
+++ b/analyzer/queue_manager.py
@@ -7,6 +7,7 @@ for folder analysis, and the _QueueItem dataclass used internally.
 from __future__ import annotations
 
 import os
+import shutil
 import sys
 import threading
 import time as _time_mod
@@ -38,6 +39,18 @@ _ALLOWED_DETECTOR_NAMES = {'mdv5a', 'mdv1000-cedar'}
 def _coerce_detector_name(value) -> str:
     name = str(value or _DEFAULT_DETECTOR_NAME).strip().lower()
     return name if name in _ALLOWED_DETECTOR_NAMES else _DEFAULT_DETECTOR_NAME
+
+
+def _folder_identity(path: str) -> str:
+    """Stable key for comparing photo-folder roots across queue and bridge."""
+    return os.path.normcase(os.path.realpath(os.path.abspath(path)))
+
+
+def _wipe_kestrel_dir(folder_path: str) -> None:
+    """Remove ``folder/.kestrel``. Raises on failure; does not swallow errors."""
+    kestrel_dir = os.path.join(folder_path, ".kestrel")
+    if os.path.isdir(kestrel_dir):
+        shutil.rmtree(kestrel_dir)
 
 
 def _utc_timestamp() -> str:
@@ -219,6 +232,20 @@ class QueueManager:
     @property
     def is_paused(self) -> bool:
         return not self._pause_event.is_set()
+
+    def has_running_writer(self, folder_path: str) -> bool:
+        """True if a queue item for ``folder_path`` is currently ``running``.
+
+        ``running`` means ``process_folder`` may be writing CSV/JSON/exports.
+        Pending items are not writers yet; the pre-analysis ``.kestrel`` wipe
+        happens while the item is still pending.
+        """
+        folder_key = _folder_identity(folder_path)
+        with self._lock:
+            return any(
+                it.status == "running" and _folder_identity(it.path) == folder_key
+                for it in self._items
+            )
 
     def get_status(self) -> dict:
         with self._lock:
@@ -425,18 +452,13 @@ class QueueManager:
             if item is None:
                 break
 
-            with self._lock:
-                item.status = 'running'
-                item.start_time = _time_mod.time()
-                item.initial_processed = 0
-            self._persist_recovery_state()
-
-            # ── Phase 3: per-item gates BEFORE the heavy pipeline call ────────
+            # ── Phase 3: per-item gates BEFORE marking running / pipeline ──
             # 1. skip_if_already_done — silently mark done without touching
             #    .kestrel if the folder is still fully analyzed with no errors.
             #    Re-inspect now (not at queue-build time) because state might
             #    have changed between dialog confirmation and the worker
-            #    reaching this folder.
+            #    reaching this folder. Keep status pending until we know work
+            #    will run, so UI clear cannot race a live writer.
             if item.skip_if_already_done and not self._retry_errored:
                 try:
                     import folder_inspector as _inspector
@@ -467,15 +489,38 @@ class QueueManager:
             # 2. delete_kestrel_on_start — wipe .kestrel JUST BEFORE this
             #    folder's analysis begins (NOT at queue-build time). If the
             #    user cancels mid-queue, later folders keep their .kestrel.
+            #    Never wipe while a writer already holds this root (status
+            #    running); a failed wipe aborts the item instead of analyzing
+            #    into a half-deleted directory.
             if item.delete_kestrel_on_start:
+                if self.has_running_writer(item.path):
+                    with self._lock:
+                        item.status = "error"
+                        item.end_time = _time_mod.time()
+                        item.error = (
+                            "Refusing to delete .kestrel while analysis is "
+                            "running for this folder"
+                        )
+                    error(f"[queue] {item.error}: {item.path!r}")
+                    self._persist_recovery_state()
+                    continue
                 try:
-                    import shutil as _shutil
-                    kestrel_dir = os.path.join(item.path, '.kestrel')
-                    if os.path.isdir(kestrel_dir):
-                        _shutil.rmtree(kestrel_dir, ignore_errors=True)
-                        info(f'[queue] Deleted .kestrel for {item.name!r} (per-item flag)')
+                    _wipe_kestrel_dir(item.path)
+                    info(f"[queue] Deleted .kestrel for {item.name!r} (per-item flag)")
                 except Exception as e:
-                    error(f'[queue] Failed to delete .kestrel for {item.path!r}: {e}')
+                    error(f"[queue] Failed to delete .kestrel for {item.path!r}: {e}")
+                    with self._lock:
+                        item.status = "error"
+                        item.end_time = _time_mod.time()
+                        item.error = str(e)
+                    self._persist_recovery_state()
+                    continue
+
+            with self._lock:
+                item.status = "running"
+                item.start_time = _time_mod.time()
+                item.initial_processed = 0
+            self._persist_recovery_state()
 
             try:
                 current_settings = load_persisted_settings()

--- a/analyzer/tests/unit/test_clear_kestrel_running.py
+++ b/analyzer/tests/unit/test_clear_kestrel_running.py
@@ -1,0 +1,179 @@
+"""Refuse .kestrel deletion while analysis is writing that folder.
+
+S0-05: ``clear_kestrel_data`` and the queue's ``delete_kestrel_on_start``
+wipe used ``shutil.rmtree`` while a queue item could already be ``running``.
+"""
+
+from pathlib import Path
+import sys
+import threading
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+import api_bridge
+from queue_manager import QueueManager, _QueueItem
+
+
+pytestmark = pytest.mark.unit
+
+_CSV_BYTES = b"filename,culled\nIMG_001.CR3,1\n"
+
+
+def _folder_with_csv(tmp_path: Path) -> tuple[Path, Path]:
+    folder = tmp_path / "photos"
+    kestrel = folder / ".kestrel"
+    kestrel.mkdir(parents=True)
+    csv_path = kestrel / "kestrel_database.csv"
+    csv_path.write_bytes(_CSV_BYTES)
+    return folder, csv_path
+
+
+class _BlockingPipeline:
+    """Stand-in for AnalysisPipeline: blocks inside process_folder."""
+
+    def __init__(self):
+        self.entered = threading.Event()
+        self.release = threading.Event()
+        self.csv_existed_on_enter: bool | None = None
+        self.calls = 0
+        self.detector_name = "mdv5a"
+
+    def process_folder(self, folder, **_kwargs):
+        csv_path = Path(folder) / ".kestrel" / "kestrel_database.csv"
+        self.csv_existed_on_enter = csv_path.is_file()
+        self.calls += 1
+        self.entered.set()
+        assert self.release.wait(timeout=5), "test did not release process_folder"
+
+
+@pytest.fixture
+def api():
+    return api_bridge.Api()
+
+
+class TestClearKestrelWhileRunning:
+    def test_clear_refuses_and_keeps_csv_when_item_running(
+        self, tmp_path, monkeypatch, api
+    ):
+        folder, csv_path = _folder_with_csv(tmp_path)
+        original = csv_path.read_bytes()
+
+        qm = QueueManager()
+        item = _QueueItem(str(folder), folder.name)
+        item.status = "running"
+        with qm._lock:
+            qm._items.append(item)
+        monkeypatch.setattr(api_bridge, "_queue_manager", qm)
+
+        result = api.clear_kestrel_data(str(folder))
+
+        assert result["success"] is False
+        assert "running" in str(result.get("error", "")).lower()
+        assert csv_path.read_bytes() == original
+        assert csv_path.is_file()
+
+    def test_clear_succeeds_when_queue_idle(self, tmp_path, monkeypatch, api):
+        folder, csv_path = _folder_with_csv(tmp_path)
+        qm = QueueManager()
+        monkeypatch.setattr(api_bridge, "_queue_manager", qm)
+
+        result = api.clear_kestrel_data(str(folder))
+
+        assert result["success"] is True
+        assert not csv_path.exists()
+        assert not (folder / ".kestrel").exists()
+
+    def test_clear_refuses_during_process_folder(
+        self, tmp_path, monkeypatch, api
+    ):
+        folder, csv_path = _folder_with_csv(tmp_path)
+        original = csv_path.read_bytes()
+
+        qm = QueueManager()
+        pipeline = _BlockingPipeline()
+        qm._pipeline = pipeline
+        monkeypatch.setattr(api_bridge, "_queue_manager", qm)
+
+        started = qm.enqueue([str(folder)])
+        assert started.get("success") is True
+        assert pipeline.entered.wait(timeout=5)
+
+        try:
+            result = api.clear_kestrel_data(str(folder))
+            assert result["success"] is False
+            assert csv_path.read_bytes() == original
+        finally:
+            pipeline.release.set()
+            if qm._thread is not None:
+                qm._thread.join(timeout=5)
+
+    def test_delete_on_start_waits_until_no_writer(
+        self, tmp_path, monkeypatch, api
+    ):
+        """Re-analyze wipe must not run while process_folder holds the CSV."""
+        folder, csv_path = _folder_with_csv(tmp_path)
+
+        qm = QueueManager()
+        pipeline = _BlockingPipeline()
+        qm._pipeline = pipeline
+        monkeypatch.setattr(api_bridge, "_queue_manager", qm)
+
+        rmtree_during_write = []
+        real_rmtree = __import__("shutil").rmtree
+
+        def _watch_rmtree(path, *args, **kwargs):
+            if pipeline.entered.is_set() and not pipeline.release.is_set():
+                rmtree_during_write.append(str(path))
+            return real_rmtree(path, *args, **kwargs)
+
+        monkeypatch.setattr("shutil.rmtree", _watch_rmtree)
+        monkeypatch.setattr("queue_manager.shutil.rmtree", _watch_rmtree)
+
+        started = qm.enqueue(
+            [str(folder)],
+            per_item_options={str(folder): {"delete_kestrel_on_start": True}},
+        )
+        assert started.get("success") is True
+        assert pipeline.entered.wait(timeout=5)
+
+        try:
+            assert rmtree_during_write == []
+            result = api.clear_kestrel_data(str(folder))
+            assert result["success"] is False
+            assert "running" in str(result.get("error", "")).lower()
+        finally:
+            pipeline.release.set()
+            if qm._thread is not None:
+                qm._thread.join(timeout=5)
+
+        assert pipeline.calls == 1
+        assert pipeline.csv_existed_on_enter is False
+
+    def test_failed_start_wipe_aborts_and_leaves_csv(self, tmp_path, monkeypatch):
+        folder, csv_path = _folder_with_csv(tmp_path)
+        original = csv_path.read_bytes()
+
+        qm = QueueManager()
+        pipeline = _BlockingPipeline()
+        qm._pipeline = pipeline
+
+        def boom(*_a, **_k):
+            raise OSError("busy")
+
+        monkeypatch.setattr("queue_manager.shutil.rmtree", boom)
+
+        started = qm.enqueue(
+            [str(folder)],
+            per_item_options={str(folder): {"delete_kestrel_on_start": True}},
+        )
+        assert started.get("success") is True
+        if qm._thread is not None:
+            qm._thread.join(timeout=5)
+
+        assert pipeline.calls == 0
+        assert csv_path.read_bytes() == original
+        with qm._lock:
+            assert qm._items[0].status == "error"
+            assert "busy" in qm._items[0].error


### PR DESCRIPTION
## Summary

`clear_kestrel_data` called `shutil.rmtree` on the live `.kestrel` directory even when a queue item for that folder was `running`. Concurrent analysis could write CSV/JSON/exports into a tree that was being deleted.

The bridge now refuses the clear while `QueueManager.has_running_writer` is true for that root. The queue's `delete_kestrel_on_start` wipe runs while the item is still `pending` (before `process_folder`). A failed wipe aborts the item instead of analyzing into a half-deleted directory (`ignore_errors=True` removed).

Reviewed on https://github.com/wolfgangh/ProjectKestrel/pull/22

Out of scope: cloud-JS clear-before-submit (same `clear_kestrel_data` guard covers it), WP-04, other queue flags.

## Test plan

- `pytest analyzer/tests/unit/test_clear_kestrel_running.py analyzer/tests/unit/test_api_bridge_pure.py -m unit -v`
- 70 passed
- Arrange: queue item `running`, `.kestrel` with CSV
- Act: `clear_kestrel_data` / `delete_kestrel_on_start` during `process_folder`
- Assert: `rmtree` does not run under the writer; original CSV bytes unchanged; idle clear still succeeds; failed start-wipe leaves CSV intact and does not start the pipeline