### PR TITLE
Don't report a still-running instance as an unclean shutdown

### DIFF
--- a/analyzer/tests/unit/test_shutdown_tracker_logging.py
+++ b/analyzer/tests/unit/test_shutdown_tracker_logging.py
@@ -25,8 +25,11 @@ try:
         _log_shutdown_state,
         _mark_session_clean_exit,
         _mark_session_exit_reason,
+        _parse_session_timestamp,
         _pid_is_alive,
+        _prior_session_still_running,
         _settings_file_hint,
+        _utc_now_iso,
         _verify_exit_reason_persisted,
     )
 except Exception as e:  # pragma: no cover - environment-dependent
@@ -81,6 +84,49 @@ class TestPidLiveness:
 
     def test_garbage_input_does_not_raise(self):
         assert _pid_is_alive(None) is None
+
+
+class TestPriorSessionStillRunning:
+    """A second instance launched while the first is open must not report
+    the first one — still on screen — as an unclean shutdown."""
+
+    def test_live_pid_from_a_recent_session_is_still_running(self):
+        assert _prior_session_still_running(os.getpid(), _utc_now_iso()) is True
+
+    def test_dead_pid_is_not_still_running(self, monkeypatch):
+        monkeypatch.setattr(visualizer, '_pid_is_alive', lambda _pid: False)
+        assert _prior_session_still_running(4242, _utc_now_iso()) is False
+
+    def test_undeterminable_pid_is_not_still_running(self, monkeypatch):
+        monkeypatch.setattr(visualizer, '_pid_is_alive', lambda _pid: None)
+        assert _prior_session_still_running(4242, _utc_now_iso()) is False
+
+    def test_live_pid_from_a_stale_session_reads_as_pid_reuse(self, monkeypatch):
+        """Pids are recycled; a weeks-old session matching a live pid is far
+        more likely an unrelated process than the same app still running."""
+        monkeypatch.setattr(visualizer, '_pid_is_alive', lambda _pid: True)
+        assert _prior_session_still_running(4242, '2026-07-01T00:00:00Z') is False
+
+    def test_missing_or_unparseable_timestamp_fails_closed(self, monkeypatch):
+        monkeypatch.setattr(visualizer, '_pid_is_alive', lambda _pid: True)
+        assert _prior_session_still_running(4242, '') is False
+        assert _prior_session_still_running(4242, 'not-a-timestamp') is False
+
+    def test_small_clock_skew_is_tolerated(self, monkeypatch):
+        from datetime import timedelta
+        monkeypatch.setattr(visualizer, '_pid_is_alive', lambda _pid: True)
+        just_ahead = (visualizer.datetime.utcnow() + timedelta(seconds=5)).isoformat() + 'Z'
+        assert _prior_session_still_running(4242, just_ahead) is True
+
+
+class TestParseSessionTimestamp:
+    def test_round_trips_utc_now_iso(self):
+        assert _parse_session_timestamp(_utc_now_iso()) is not None
+
+    def test_empty_and_garbage_return_none(self):
+        assert _parse_session_timestamp('') is None
+        assert _parse_session_timestamp(None) is None
+        assert _parse_session_timestamp('yesterday') is None
 
 
 class TestLogHelpers:
@@ -239,6 +285,45 @@ class TestSessionStartLogging:
         lines = shutdown_log()
         assert any('prior session OK' in ln for ln in lines)
         assert 'last_unclean_shutdown_utc' not in fake_settings['data']
+
+    def test_still_running_prior_session_is_not_flagged(self, fake_settings, shutdown_log):
+        """The concurrent-instance case: the first window is still open, so
+        its 'unknown' means "has not exited yet", not "crashed"."""
+        fake_settings['data'] = {
+            EXIT_REASON_KEY: 'unknown',
+            'app_session_started_utc': _utc_now_iso(),
+            'app_session_pid': os.getpid(),
+        }
+        visualizer._mark_session_start()
+        lines = shutdown_log()
+        assert any('prior session still running' in ln for ln in lines)
+        assert not any('FLAGGING prior session unclean' in ln for ln in lines)
+        assert 'last_unclean_shutdown_utc' not in fake_settings['data']
+
+    def test_still_running_does_not_clear_an_earlier_pending_flag(self, fake_settings):
+        """Suppressing this prompt must not swallow a real one already queued."""
+        fake_settings['data'] = {
+            EXIT_REASON_KEY: 'unknown',
+            'app_session_started_utc': _utc_now_iso(),
+            'app_session_pid': os.getpid(),
+            'last_unclean_shutdown_utc': '2026-07-01T00:00:00Z',
+        }
+        visualizer._mark_session_start()
+        assert fake_settings['data']['last_unclean_shutdown_utc'] == '2026-07-01T00:00:00Z'
+
+    def test_dead_prior_session_is_still_flagged(self, monkeypatch, fake_settings, shutdown_log):
+        """The guard is narrow: a prior session that really did die still
+        raises the recovery prompt, however recent it was."""
+        monkeypatch.setattr(visualizer, '_pid_is_alive', lambda _pid: False)
+        started = _utc_now_iso()
+        fake_settings['data'] = {
+            EXIT_REASON_KEY: 'unknown',
+            'app_session_started_utc': started,
+            'app_session_pid': 4242,
+        }
+        visualizer._mark_session_start()
+        assert any('FLAGGING prior session unclean' in ln for ln in shutdown_log())
+        assert fake_settings['data']['last_unclean_shutdown_utc'] == started
 
     def test_opens_new_session_as_unknown(self, fake_settings, shutdown_log):
         fake_settings['data'] = {EXIT_REASON_KEY: 'clean'}

--- a/analyzer/visualizer.py
+++ b/analyzer/visualizer.py
@@ -251,6 +251,56 @@ def _pid_is_alive(pid: int) -> Optional[bool]:
         return None
 
 
+# How recently the previous session must have started for a live pid to be
+# read as "that instance is still running" rather than "that pid was
+# recycled onto an unrelated process". See _prior_session_still_running.
+_CONCURRENT_INSTANCE_MAX_AGE_S = 24 * 60 * 60
+
+
+def _parse_session_timestamp(value: str) -> Optional[datetime]:
+    """Parse an ``_utc_now_iso()`` stamp back to a naive UTC datetime.
+
+    Returns None for anything unparseable, including the empty string
+    written before a session has ever been recorded.
+    """
+    text = str(value or '').strip()
+    if not text:
+        return None
+    try:
+        return datetime.fromisoformat(text.rstrip('Z'))
+    except Exception:
+        return None
+
+
+def _prior_session_still_running(prev_pid: int, prev_started: str) -> bool:
+    """True when the previous session's process is still running right now.
+
+    Launching a second copy of Kestrel while the first is open is the one
+    case where the exit-reason state machine cannot mean what it says: the
+    new instance reads the first one's *open* session ('unknown', because
+    it has not exited) and, taken at face value, that reads as an unclean
+    shutdown. Nothing crashed — the first window is still on screen.
+
+    Liveness alone is not enough to conclude that, because pids are
+    recycled: a session from three weeks ago whose pid is live again is far
+    more likely to be an unrelated process than the same app still running.
+    Requiring the prior session to have started within the last day keeps
+    the check to the case it is meant for (a second launch minutes or hours
+    later) and leaves a genuinely stale record classified as before.
+
+    Both halves fail closed: an undeterminable pid or an unparseable
+    timestamp returns False, i.e. the pre-existing behaviour.
+    """
+    if _pid_is_alive(prev_pid) is not True:
+        return False
+    started = _parse_session_timestamp(prev_started)
+    if started is None:
+        return False
+    age_s = (datetime.utcnow() - started).total_seconds()
+    # A small negative tolerance absorbs clock skew around the write.
+    return -60 <= age_s <= _CONCURRENT_INSTANCE_MAX_AGE_S
+
+
 def _settings_file_hint() -> Optional[str]:
     """Basename + parent of the settings file, for the session-start line.
 
@@ -348,7 +398,21 @@ def _mark_session_start() -> None:
         # Only 'crash' and 'unknown' get surfaced as recoverable unclean
         # shutdowns. 'os_shutdown' is intentionally suppressed so PC reboots
         # don't generate false crash dialogs.
-        if prev_reason in ('crash', 'unknown') and prev_started:
+        should_flag = prev_reason in ('crash', 'unknown') and bool(prev_started)
+        if should_flag and _prior_session_still_running(prev_pid, prev_started):
+            # A second instance started while the first is still open. The
+            # first session reads 'unknown' only because it has not exited
+            # yet, so flagging it would prompt the user to report a crash
+            # for a window still in front of them. Leave any genuinely
+            # pending flag from an earlier session alone rather than
+            # clearing it here.
+            _log_shutdown_state(
+                'session_start: prior session still running, not flagging unclean',
+                reason=prev_reason,
+                prev_pid=prev_pid or None,
+                prev_started=prev_started,
+            )
+        elif should_flag:
             settings['last_unclean_shutdown_utc'] = prev_started
             _log_shutdown_state(
                 'session_start: FLAGGING prior session unclean',


### PR DESCRIPTION
## What

`_mark_session_start()` flags the previous session as an unclean shutdown whenever its recorded exit reason is `'unknown'`. That is correct for a session that died — but it is also what an *open* session looks like, because `'unknown'` is written at startup and only replaced on exit.

So when a user launches a second copy of Kestrel while the first window is still on screen, the new instance reads the first one's still-open state, calls it an unclean shutdown, and prompts the user to file a crash report for an app that has not crashed and is still running.

## Evidence

The `[shutdown]` instrumentation added for the recovery-dialog false-positive investigation logs `prev_pid_alive` specifically to test this hypothesis, with the comment "Prime suspect for the false positives." This week's recovery reports confirm it. Several arrive with a session-start line like:

```
[shutdown] session_start: classifying prior session raw_exit_reason='unknown' classified=unknown
    prev_pid=1266 prev_pid_alive=True legacy_closed_cleanly=False already_migrated=True
[shutdown] session_start: FLAGGING prior session unclean reason=unknown ...
```

where the prior session started only ~1–90 minutes earlier. In one of them the very next line is `Port 8765 unavailable; using 8766 instead` — the second instance failing to bind the first one's port, which is about as direct as this evidence gets.

## The change

Gate the unclean flag on the prior session actually being gone.

Liveness alone is not sufficient, because pids are recycled: one report has `prev_pid_alive=True` for a session that started 22 days earlier, which is a recycled pid rather than a three-week-old window. So `_prior_session_still_running()` requires **both** a live pid **and** a prior session that started within the last day.

Both halves fail closed — an undeterminable pid or an unparseable timestamp returns `False`, i.e. exactly the pre-existing behaviour. The suppressed branch also deliberately leaves a genuinely pending `last_unclean_shutdown_utc` from an earlier session in place, rather than routing into the clearing branch and swallowing a real report.

The 24-hour bound means a first instance left open for more than a day still produces the old false prompt when a second one launches. That is a deliberate trade: widening the window trades a rarer false prompt for a higher chance of suppressing a genuine crash report on pid reuse.

## Scope

This is a different root cause from #114 (clean-exit marked after teardown, so a stall loses the marker). Both produce a false recovery prompt; neither subsumes the other. This PR does not touch the teardown ordering.

## Testing

- `pytest analyzer/tests/unit` — 677 passed, 3 skipped (3 modules excluded from collection only because `rawpy` has no wheel in this container; unrelated to this change).
- Reproduced the bug against the pre-change module: two `_mark_session_start()` calls with the first pid still live set `last_unclean_shutdown_utc` (prompt would fire); with the fix they do not.
- New unit tests cover the helper (live/dead/undeterminable pid, pid reuse, unparseable timestamp, clock skew), the concurrent-instance case end to end, the preserved earlier flag, and the unchanged dead-prior-session path.