### PR TITLE
Merge #141: merge UI scenedata fields before post-analysis save (conflict-resolved)

### DIFF
--- a/analyzer/kestrel_analyzer/database.py
+++ b/analyzer/kestrel_analyzer/database.py
@@ -304,6 +304,55 @@ def update_scenedata_with_database(scenedata: dict, database: pd.DataFrame) -> d
     return scenedata
 
 
+def merge_scenedata_ui_fields(target: dict, source: dict) -> dict:
+    """Overlay UI-owned fields from ``source`` onto ``target``.
+
+    ``image_ratings``: source wins per filename. Per-scene ``name``,
+    ``status``, and ``user_tags``: source wins when the scene id exists in
+    both. Scene membership (``image_filenames``) is left to the analysis
+    database. Mutates and returns ``target``.
+    """
+    src_ratings = source.get("image_ratings")
+    if isinstance(src_ratings, dict) and src_ratings:
+        dst_ratings = target.setdefault("image_ratings", {})
+        if isinstance(dst_ratings, dict):
+            dst_ratings.update(src_ratings)
+
+    src_scenes = source.get("scenes")
+    dst_scenes = target.setdefault("scenes", {})
+    if not isinstance(src_scenes, dict) or not isinstance(dst_scenes, dict):
+        return target
+    for sid, src_scene in src_scenes.items():
+        if not isinstance(src_scene, dict):
+            continue
+        dst = dst_scenes.get(str(sid))
+        if dst is None and sid != str(sid):
+            dst = dst_scenes.get(sid)
+        if not isinstance(dst, dict):
+            continue
+        for field in ("name", "status", "user_tags"):
+            if field in src_scene:
+                dst[field] = src_scene[field]
+    return target
+
+
+def finalize_scenedata_after_analysis(kestrel_dir: str, database: pd.DataFrame) -> None:
+    """Write scenedata after analysis without clobbering concurrent UI edits.
+
+    Reloads from disk immediately before save and overlays ratings, scene
+    names, approve status, and ``user_tags`` so a stale in-memory copy
+    cannot wipe what the UI already persisted.
+    """
+    existing = load_scenedata(kestrel_dir)
+    if not existing.get("scenes"):
+        out = build_scenedata_from_database(database)
+    else:
+        out = update_scenedata_with_database(existing, database)
+    latest = load_scenedata(kestrel_dir)
+    merge_scenedata_ui_fields(out, latest)
+    save_scenedata(out, kestrel_dir)
+
+
 def load_scenedata(kestrel_dir: str) -> dict:
     """Load kestrel_scenedata.json. Returns an empty initialized dict if the file is missing."""
     scenedata_path = os.path.join(kestrel_dir, SCENEDATA_FILENAME)

--- a/analyzer/kestrel_analyzer/pipeline.py
+++ b/analyzer/kestrel_analyzer/pipeline.py
@@ -27,10 +27,7 @@ from .config import (
 from .database import (
     load_database,
     save_database,
-    load_scenedata,
-    save_scenedata,
-    build_scenedata_from_database,
-    update_scenedata_with_database,
+    finalize_scenedata_after_analysis,
 )
 from .exposure_compensation import (
     apply_exposure_crop_numpy,
@@ -1513,15 +1510,11 @@ class AnalysisPipeline:
                             stage="post_analysis_normalization",
                         )
 
-                    # Create or update kestrel_scenedata.json
+                    # Create or update kestrel_scenedata.json. Reload+merge
+                    # UI fields immediately before save so ratings/names/tags
+                    # written during the run are not overwritten (S1-08).
                     try:
-                        existing_scenedata = load_scenedata(kestrel_dir)
-                        if not existing_scenedata.get("scenes"):
-                            new_scenedata = build_scenedata_from_database(database)
-                            save_scenedata(new_scenedata, kestrel_dir)
-                        else:
-                            update_scenedata_with_database(existing_scenedata, database)
-                            save_scenedata(existing_scenedata, kestrel_dir)
+                        finalize_scenedata_after_analysis(kestrel_dir, database)
                     except Exception as _sd_e:
                         log_warning(
                             self._log_path,

--- a/analyzer/tests/unit/test_scenedata_lost_update.py
+++ b/analyzer/tests/unit/test_scenedata_lost_update.py
@@ -1,0 +1,125 @@
+"""Lost-update: UI scenedata writes during analysis must survive post-analysis save.
+
+The pipeline used to load scenedata (or treat it as empty) and then
+``save_scenedata`` a built/updated copy. Ratings, scene names, approve
+status, and ``user_tags`` the UI wrote to disk while analysis was running
+were overwritten.
+
+Filesystem only; no RAWs or weights.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from kestrel_analyzer.database import (
+    SCENEDATA_VERSION,
+    finalize_scenedata_after_analysis,
+    load_scenedata,
+    save_scenedata,
+)
+
+
+pytestmark = pytest.mark.unit
+
+_UI_SCENE = {
+    "scene_id": "1",
+    "image_filenames": ["IMG_001.CR3"],
+    "name": "Morning hawk",
+    "status": "approved",
+    "user_tags": {
+        "species": ["Red-tailed Hawk"],
+        "families": ["Accipitridae"],
+        "finalized": True,
+    },
+}
+
+_UI_SCENEDATA = {
+    "version": SCENEDATA_VERSION,
+    "image_ratings": {"IMG_001.CR3": 4},
+    "scenes": {"1": dict(_UI_SCENE)},
+}
+
+
+def _kestrel(tmp_path: Path) -> Path:
+    kestrel = tmp_path / ".kestrel"
+    kestrel.mkdir()
+    return kestrel
+
+
+def _database() -> pd.DataFrame:
+    return pd.DataFrame({"filename": ["IMG_001.CR3"], "scene_count": [1]})
+
+
+def _assert_ui_fields_survived(got: dict) -> None:
+    assert got["image_ratings"]["IMG_001.CR3"] == 4
+    scene = got["scenes"]["1"]
+    assert scene["name"] == "Morning hawk"
+    assert scene["status"] == "approved"
+    assert scene["user_tags"]["species"] == ["Red-tailed Hawk"]
+    assert scene["user_tags"]["families"] == ["Accipitridae"]
+    assert scene["user_tags"]["finalized"] is True
+
+
+class TestScenedataLostUpdate:
+    def test_ui_fields_survive_stale_empty_first_load(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Pipeline held an empty in-memory copy; disk already has UI edits."""
+        kestrel = _kestrel(tmp_path)
+        save_scenedata(_UI_SCENEDATA, str(kestrel))
+
+        import kestrel_analyzer.database as dbmod
+
+        original_load = dbmod.load_scenedata
+        calls = {"n": 0}
+
+        def fake_load(kestrel_dir: str) -> dict:
+            calls["n"] += 1
+            if calls["n"] == 1:
+                return {
+                    "version": SCENEDATA_VERSION,
+                    "image_ratings": {},
+                    "scenes": {},
+                }
+            return original_load(kestrel_dir)
+
+        monkeypatch.setattr(dbmod, "load_scenedata", fake_load)
+        finalize_scenedata_after_analysis(str(kestrel), _database())
+
+        got = original_load(str(kestrel))
+        _assert_ui_fields_survived(got)
+        assert "IMG_001.CR3" in got["scenes"]["1"]["image_filenames"]
+
+    def test_ratings_on_disk_survive_empty_scenes_rebuild(self, tmp_path: Path) -> None:
+        """``not scenes`` took build_scenedata_from_database and dropped ratings."""
+        kestrel = _kestrel(tmp_path)
+        save_scenedata(
+            {
+                "version": SCENEDATA_VERSION,
+                "image_ratings": {"IMG_001.CR3": 4},
+                "scenes": {},
+            },
+            str(kestrel),
+        )
+        finalize_scenedata_after_analysis(str(kestrel), _database())
+        got = load_scenedata(str(kestrel))
+        assert got["image_ratings"]["IMG_001.CR3"] == 4
+        assert "1" in got["scenes"]
+
+    def test_update_path_keeps_ui_fields_and_adds_new_image(self, tmp_path: Path) -> None:
+        kestrel = _kestrel(tmp_path)
+        save_scenedata(_UI_SCENEDATA, str(kestrel))
+        db = pd.DataFrame(
+            {
+                "filename": ["IMG_001.CR3", "IMG_002.CR3"],
+                "scene_count": [1, 1],
+            }
+        )
+        finalize_scenedata_after_analysis(str(kestrel), db)
+        got = load_scenedata(str(kestrel))
+        _assert_ui_fields_survived(got)
+        assert "IMG_002.CR3" in got["scenes"]["1"]["image_filenames"]


### PR DESCRIPTION
Lands the work from #141, which could not be merged directly: it conflicts with #131 in `database.py` and has `maintainerCanModify=false`, so its branch could not be updated in place.

**Conflict:** #131 added `ScenedataCorruptError`; #141 added `merge_scenedata_ui_fields` and `finalize_scenedata_after_analysis` at the same insertion point. Independent additions — both kept.

**Interaction checked:** `finalize_scenedata_after_analysis` calls `load_scenedata`, which #131 changed to raise instead of returning `{}`. Its only caller, `pipeline.py:1578`, already wraps it in `try/except` and logs a warning — so a corrupt `kestrel_scenedata.json` is now left intact rather than rebuilt over. That is #131's intent, so the two compose correctly.

Suite: **849 passed, 2 skipped, 0 failed.**

Closes #141. Original commits by @wolfgangh are preserved in this merge.