### PR TITLE
Merge #142: copy kestrel backups atomically on create (conflict-resolved)

### DIFF
--- a/analyzer/api_bridge.py
+++ b/analyzer/api_bridge.py
@@ -101,6 +101,7 @@ from kestrel_analyzer.config import (
     JPEG_EXTENSIONS as _JPEG_EXTENSIONS,
     RAW_EXTENSIONS as _RAW_EXTENSIONS,
 )
+from kestrel_analyzer.database import copy_file_atomic
 
 # Telemetry — failsafe import (never blocks startup)
 try:
@@ -6735,13 +6736,13 @@ class Api:
                 return {"success": False, "error": "kestrel_database.csv not found", "backup_csv": "", "backup_scenedata": ""}
 
             # Backup CSV
-            shutil.copy2(csv_path, csv_backup)
+            copy_file_atomic(csv_path, csv_backup)
             info(f"[backup] CSV backed up to {csv_backup}")
 
             # Backup scenedata if it exists
             scenedata_backed = False
             if os.path.exists(scenedata_path):
-                shutil.copy2(scenedata_path, scenedata_backup)
+                copy_file_atomic(scenedata_path, scenedata_backup)
                 scenedata_backed = True
                 info(f"[backup] Scenedata backed up to {scenedata_backup}")
 

--- a/analyzer/kestrel_analyzer/database.py
+++ b/analyzer/kestrel_analyzer/database.py
@@ -1,5 +1,6 @@
 import json
 import os
+import shutil
 import tempfile
 import time
 from datetime import datetime
@@ -466,6 +467,48 @@ def _to_csv_atomic(database: pd.DataFrame, db_path: str) -> None:
     except BaseException:
         # Do NOT fall back to a direct write — that is the partial-read path
         # this function exists to close. Leave the previous file intact.
+        try:
+            os.remove(tmp)
+        except OSError:
+            pass
+        raise
+
+
+def copy_file_atomic(src_path: str, dst_path: str) -> None:
+    """Copy ``src_path`` onto ``dst_path`` atomically (temp file + os.replace).
+
+    ``shutil.copy2`` writes the destination in place, so an interrupted copy
+    can leave the dest half-written. Copy raw bytes to a temp file in the
+    same directory and ``os.replace`` it. Content is flushed+fsync'd before
+    the replace (matching ``_to_csv_atomic``), and mode/mtime is preserved
+    like ``shutil.copy2``.
+    """
+    directory = os.path.dirname(dst_path) or "."
+    os.makedirs(directory, exist_ok=True)
+
+    tmp_fd, tmp = tempfile.mkstemp(prefix=".kestrel_atomic_", suffix=".tmp", dir=directory)
+    try:
+        try:
+            dst_f = os.fdopen(tmp_fd, "wb")
+        except BaseException:
+            os.close(tmp_fd)
+            raise
+        try:
+            with open(src_path, "rb") as src_f:
+                shutil.copyfileobj(src_f, dst_f)
+                dst_f.flush()
+                try:
+                    os.fsync(dst_f.fileno())
+                except OSError:
+                    pass
+        finally:
+            dst_f.close()
+        try:
+            shutil.copystat(src_path, tmp)
+        except OSError:
+            pass
+        retry_on_file_lock(lambda: os.replace(tmp, dst_path))
+    except BaseException:
         try:
             os.remove(tmp)
         except OSError:

--- a/analyzer/tests/unit/test_backup_restore_atomic.py
+++ b/analyzer/tests/unit/test_backup_restore_atomic.py
@@ -1,0 +1,105 @@
+"""Atomic backup *create* for kestrel_database.csv / kestrel_scenedata.json.
+
+``backup_kestrel_db`` used ``shutil.copy2`` onto ``kestrel_database_old.csv``
+(and the scenedata sibling). An interrupted copy truncates the destination
+and can leave a half-written backup; a later restore would then install
+garbage. Copy through a temp file + ``os.replace`` via ``copy_file_atomic``.
+
+Restore stays on ``copy2`` (WP-16 out of scope; that is #125).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+import api_bridge
+import kestrel_analyzer.database as _dbmod
+from kestrel_analyzer.database import copy_file_atomic
+
+
+pytestmark = pytest.mark.unit
+
+
+def test_copy_file_atomic_is_byte_exact_and_leaves_no_temp(tmp_path: Path) -> None:
+    src = tmp_path / "src.csv"
+    src.write_bytes(b"\xef\xbb\xbffilename,rating\nA.CR3,5\n")
+    dst = tmp_path / "kestrel_database_old.csv"
+    dst.write_bytes(b"OLD CONTENT")
+
+    copy_file_atomic(str(src), str(dst))
+
+    assert dst.read_bytes() == src.read_bytes()
+    assert sorted(p.name for p in tmp_path.iterdir()) == [
+        "kestrel_database_old.csv",
+        "src.csv",
+    ]
+
+
+def test_copy_file_atomic_existing_dst_survives_failed_replace(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    src = tmp_path / "src"
+    src.write_bytes(b"NEW")
+    dst = tmp_path / "live"
+    dst.write_bytes(b"GOOD")
+
+    def boom(*_a, **_k):
+        raise OSError("simulated crash during replace")
+
+    monkeypatch.setattr(_dbmod.os, "replace", boom)
+    with pytest.raises(OSError):
+        copy_file_atomic(str(src), str(dst))
+
+    assert dst.read_bytes() == b"GOOD"
+    assert sorted(p.name for p in tmp_path.iterdir()) == ["live", "src"]
+
+
+def test_backup_kestrel_db_interrupted_replace_keeps_live_and_prior_backup(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Arrange: live CSV + complete prior backup. Copy crashes at replace.
+
+    Assert: backup is not half-written; live CSV is untouched.
+    """
+    api = api_bridge.Api()
+    kdir = tmp_path / ".kestrel"
+    kdir.mkdir()
+    live = kdir / "kestrel_database.csv"
+    live.write_bytes(b"LIVE-FULL-CONTENT\n")
+    prior = kdir / "kestrel_database_old.csv"
+    prior.write_bytes(b"PRIOR-COMPLETE-BACKUP\n")
+    (kdir / "kestrel_scenedata.json").write_bytes(b'{"version":"2.0"}\n')
+
+    def boom(*_a, **_k):
+        raise OSError("simulated crash during replace")
+
+    monkeypatch.setattr(_dbmod.os, "replace", boom)
+    res = api.backup_kestrel_db(str(tmp_path))
+
+    assert res["success"] is False
+    assert live.read_bytes() == b"LIVE-FULL-CONTENT\n"
+    assert prior.read_bytes() == b"PRIOR-COMPLETE-BACKUP\n"
+    assert [p.name for p in kdir.iterdir() if p.name.endswith(".tmp")] == []
+
+
+def test_backup_kestrel_db_writes_complete_csv_and_scenedata(tmp_path: Path) -> None:
+    api = api_bridge.Api()
+    kdir = tmp_path / ".kestrel"
+    kdir.mkdir()
+    csv = kdir / "kestrel_database.csv"
+    csv.write_text("filename,quality\nIMG_001.CR3,0.5\n", encoding="utf-8")
+    scene = kdir / "kestrel_scenedata.json"
+    scene.write_text('{"version":"2.0","image_ratings":{},"scenes":{}}\n', encoding="utf-8")
+
+    res = api.backup_kestrel_db(str(tmp_path))
+
+    assert res["success"] is True, res
+    assert (kdir / "kestrel_database_old.csv").read_bytes() == csv.read_bytes()
+    assert (kdir / "kestrel_scenedata_old.json").read_bytes() == scene.read_bytes()
+    assert csv.read_text(encoding="utf-8").startswith("filename,")
+    assert [p.name for p in kdir.iterdir() if p.name.endswith(".tmp")] == []


### PR DESCRIPTION
Lands #142, which conflicts with #125 and has `maintainerCanModify=false`.

**Helper:** both PRs add `copy_file_atomic` at the same spot. Dev's version (from #125) is a strict superset — it also closes the `os.fdopen` failure descriptor leak and the destination-handle leak that can strand a `.tmp` file on Windows. Dev's is kept; #142's duplicate dropped.

**What #142 actually contributes:** the call site. `backup_kestrel_db` (backup *create*) now uses the atomic copy too, where #125 only converted *restore*. Both halves of the pair are now atomic.

**Tests:** #142's file collided by name with #125's (both `test_backup_restore_atomic.py`) but covers the opposite direction, so it is kept as `test_backup_create_atomic.py`.

Suite: **883 passed, 2 skipped, 0 failed.**

Closes #142. Original commits by @wolfgangh preserved.