### PR TITLE
Salvage #115: rotate the reject-move undo point instead of overwriting it

### DIFF
--- a/analyzer/api_bridge.py
+++ b/analyzer/api_bridge.py
@@ -7097,6 +7097,19 @@ class Api:
             if not os.path.exists(csv_path):
                 return {"success": False, "error": "kestrel_database.csv not found", "backup_csv": "", "backup_scenedata": ""}
 
+            # Preserve any backup already sitting in the slot before we overwrite
+            # it. There is only one canonical `_old` name per file and Undo
+            # restores from it, so a second reject move would otherwise destroy
+            # the first move's undo point with no warning. Rotate a slot only
+            # when its replacement is actually about to be written: scenedata is
+            # optional, and archiving its `_old` without writing a new one would
+            # leave Undo able to restore the CSV but not the scene data it
+            # belongs to.
+            rotate_pairs = [(csv_backup, 'precull_kestrel_database', '.csv')]
+            if os.path.exists(scenedata_path):
+                rotate_pairs.append((scenedata_backup, 'precull_kestrel_scenedata', '.json'))
+            rotated = self._rotate_existing_backups(kestrel_dir, rotate_pairs)
+
             # Backup CSV
             copy_file_atomic(csv_path, csv_backup)
             info(f"[backup] CSV backed up to {csv_backup}")
@@ -7112,11 +7125,76 @@ class Api:
                 "success": True,
                 "backup_csv": csv_backup,
                 "backup_scenedata": scenedata_backup if scenedata_backed else "",
+                "rotated_previous": rotated,
                 "error": ""
             }
         except Exception as e:
             error(f"[API] backup_kestrel_db error: {e}")
             return {"success": False, "error": str(e), "backup_csv": "", "backup_scenedata": ""}
+
+    #: How many timestamped ``OLD_*`` copies to keep per file. Unlike the
+    #: schema-upgrade backups this shares a name with, rotation here happens on
+    #: every reject move, so an actively culled folder would otherwise
+    #: accumulate a full database copy per pass forever.
+    _BACKUP_ARCHIVE_RETENTION = 3
+
+    def _rotate_existing_backups(self, kestrel_dir: str, pairs) -> bool:
+        """Move existing ``*_old`` backups aside under a timestamped name.
+
+        ``pairs`` is a sequence of ``(existing_backup_path, stem, extension)``;
+        only slots whose replacement is about to be written should be passed.
+
+        Returns True if anything was rotated. Best-effort: a failure here must
+        not abort the caller's own backup, because failing to take the new
+        backup is strictly worse than failing to preserve the previous one.
+        """
+        rotated = False
+        try:
+            # Imported locally, as elsewhere in this module — api_bridge has no
+            # module-level datetime import.
+            from datetime import datetime, timezone
+            timestamp = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+            for existing, stem, ext in pairs:
+                if not os.path.exists(existing):
+                    continue
+                prefix = f"OLD_{stem}_"
+                archived = os.path.join(kestrel_dir, f"{prefix}{timestamp}{ext}")
+                # Two moves inside one second would collide. Suffix rather than
+                # skip: skipping leaves the previous undo point to be
+                # overwritten by the copy2 that follows.
+                if os.path.exists(archived):
+                    for n in range(1, 100):
+                        candidate = os.path.join(kestrel_dir, f"{prefix}{timestamp}_{n}{ext}")
+                        if not os.path.exists(candidate):
+                            archived = candidate
+                            break
+                    else:
+                        continue
+                os.replace(existing, archived)
+                rotated = True
+                info(f"[backup] Previous backup preserved as {os.path.basename(archived)}")
+                self._prune_backup_archives(kestrel_dir, prefix, ext)
+        except Exception as e:
+            warn(f"[backup] Could not rotate previous backup (continuing): {e}")
+        return rotated
+
+    def _prune_backup_archives(self, kestrel_dir: str, prefix: str, ext: str) -> None:
+        """Keep only the newest ``_BACKUP_ARCHIVE_RETENTION`` archived copies."""
+        try:
+            archives = sorted(
+                name for name in os.listdir(kestrel_dir)
+                if name.startswith(prefix) and name.endswith(ext)
+            )
+            # Names are prefix + %Y%m%d_%H%M%S [+ _n] + ext, so lexical order is
+            # chronological and the tail is the newest.
+            for stale in archives[:-self._BACKUP_ARCHIVE_RETENTION]:
+                try:
+                    os.remove(os.path.join(kestrel_dir, stale))
+                    debug(f"[backup] Pruned old archive {stale}")
+                except Exception as e:
+                    warn(f"[backup] Could not prune {stale}: {e}")
+        except Exception as e:
+            warn(f"[backup] Could not prune old archives (continuing): {e}")
 
     def restore_kestrel_db_backup(self, root_path: str):
         """Restore both kestrel_database.csv and kestrel_scenedata.json from backups.

--- a/analyzer/tests/unit/test_reject_move_safety.py
+++ b/analyzer/tests/unit/test_reject_move_safety.py
@@ -1,0 +1,173 @@
+"""Data-safety guards around the culling reject-move and its undo point.
+
+The culling assistant can move rejected photos into ``_KESTREL_Rejects`` and
+offers an Undo that restores them together with the pre-move database. This
+file covers the backup half of that promise:
+
+    Taking a new backup must not destroy the previous one. There is a single
+    canonical ``kestrel_database_old.csv`` slot, so a second reject move over
+    the same folder would otherwise overwrite the first move's restore point
+    with no warning — losing the curation (ratings, labels, crop choices) the
+    first pass produced.
+
+The other half — that moving or restoring a file must never overwrite a file
+already at the destination, because cameras reuse filenames across cards — is
+covered by ``test_reject_move.py`` against the implementation that shipped in
+#120.
+
+It matters because the files involved are the user's originals.
+"""
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+try:
+    from api_bridge import Api
+except Exception as e:  # pragma: no cover - environment-dependent
+    pytest.skip(f'api_bridge not importable in this env: {e}', allow_module_level=True)
+
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def api():
+    """An Api instance without __init__ (which needs a webview window).
+
+    Only the self-contained file helpers are exercised here.
+    """
+    obj = Api.__new__(Api)
+    obj._culling_companion_extensions = ['.xmp', '.jpg']
+    return obj
+
+
+@pytest.fixture
+def shoot(tmp_path):
+    """A folder with an analyzed .kestrel database and a rejects subfolder."""
+    kdir = tmp_path / '.kestrel'
+    kdir.mkdir()
+    (kdir / 'kestrel_database.csv').write_text('filename,quality\nPASS1.CR3,0.9\n')
+    (kdir / 'kestrel_scenedata.json').write_text('{"version":"2.0"}')
+    (tmp_path / '_KESTREL_Rejects').mkdir()
+    return tmp_path
+
+
+class TestBackupRotation:
+    def test_second_backup_preserves_the_first(self, api, shoot):
+        first = api.backup_kestrel_db(str(shoot))
+        assert first['success']
+        assert not first['rotated_previous']
+
+        # Simulate the first reject move rewriting the working database.
+        (shoot / '.kestrel' / 'kestrel_database.csv').write_text(
+            'filename,quality\nPASS2.CR3,0.5\n'
+        )
+
+        second = api.backup_kestrel_db(str(shoot))
+        assert second['success']
+        assert second['rotated_previous'], 'previous backup was not rotated aside'
+
+        archived = sorted(
+            p for p in os.listdir(shoot / '.kestrel')
+            if p.startswith('OLD_precull_kestrel_database_')
+        )
+        assert archived, 'no timestamped archive of the previous backup'
+        content = (shoot / '.kestrel' / archived[0]).read_text()
+        assert 'PASS1.CR3' in content, 'the first pass restore point was lost'
+
+    def test_scenedata_backup_is_rotated_too(self, api, shoot):
+        api.backup_kestrel_db(str(shoot))
+        api.backup_kestrel_db(str(shoot))
+        archived = [
+            p for p in os.listdir(shoot / '.kestrel')
+            if p.startswith('OLD_precull_kestrel_scenedata_')
+        ]
+        assert archived
+
+    def test_current_slot_still_holds_the_newest_backup(self, api, shoot):
+        api.backup_kestrel_db(str(shoot))
+        (shoot / '.kestrel' / 'kestrel_database.csv').write_text(
+            'filename,quality\nNEWEST.CR3,0.1\n'
+        )
+        api.backup_kestrel_db(str(shoot))
+        # Undo restores from the canonical slot; it must be the most recent
+        # state, so undoing the second move rolls back exactly that move.
+        current = (shoot / '.kestrel' / 'kestrel_database_old.csv').read_text()
+        assert 'NEWEST.CR3' in current
+
+
+class TestArchiveHousekeeping:
+    def test_schema_upgrade_backups_are_never_pruned(self, api, shoot):
+        """``database._perform_db_upgrade`` writes OLD_kestrel_database_*.csv.
+
+        Those fire once per schema upgrade and are the only copy of the
+        pre-upgrade database. Rotation here fires on every cull pass, so the
+        two must not share a namespace or pruning would eat them.
+        """
+        kdir = shoot / '.kestrel'
+        upgrade_backup = kdir / 'OLD_kestrel_database_20200101_000000.csv'
+        upgrade_backup.write_text('filename,quality\nPRE_UPGRADE.CR3,0.9\n')
+
+        for i in range(api._BACKUP_ARCHIVE_RETENTION + 3):
+            (kdir / 'kestrel_database.csv').write_text(f'filename,quality\nP{i}.CR3,0.5\n')
+            api.backup_kestrel_db(str(shoot))
+
+        assert upgrade_backup.exists(), 'schema-upgrade backup was pruned'
+        assert 'PRE_UPGRADE.CR3' in upgrade_backup.read_text()
+
+    def test_archives_are_capped(self, api, shoot):
+        kdir = shoot / '.kestrel'
+        for i in range(api._BACKUP_ARCHIVE_RETENTION + 4):
+            (kdir / 'kestrel_database.csv').write_text(f'filename,quality\nP{i}.CR3,0.5\n')
+            api.backup_kestrel_db(str(shoot))
+
+        archives = [p for p in os.listdir(kdir) if p.startswith('OLD_precull_kestrel_database_')]
+        assert len(archives) <= api._BACKUP_ARCHIVE_RETENTION, (
+            f'{len(archives)} archives kept; a culled folder would grow without bound'
+        )
+
+    def test_same_second_rotations_do_not_lose_a_restore_point(self, api, shoot):
+        """Two moves inside one second must not collapse into one archive."""
+        kdir = shoot / '.kestrel'
+        (kdir / 'kestrel_database.csv').write_text('filename,quality\nFIRST.CR3,0.9\n')
+        api.backup_kestrel_db(str(shoot))
+        (kdir / 'kestrel_database.csv').write_text('filename,quality\nSECOND.CR3,0.5\n')
+        api.backup_kestrel_db(str(shoot))
+        (kdir / 'kestrel_database.csv').write_text('filename,quality\nTHIRD.CR3,0.1\n')
+        api.backup_kestrel_db(str(shoot))
+
+        archived = [p for p in os.listdir(kdir) if p.startswith('OLD_precull_kestrel_database_')]
+        bodies = [(kdir / name).read_text() for name in archived]
+        assert any('FIRST.CR3' in b for b in bodies), 'first restore point lost'
+        assert any('SECOND.CR3' in b for b in bodies), 'second restore point lost'
+
+    def test_scenedata_slot_is_not_stranded_when_there_is_no_scenedata(self, api, shoot):
+        """Rotating a slot whose replacement is never written breaks Undo.
+
+        Undo restores the CSV and the scene data together; archiving the
+        scenedata backup while writing no new one leaves them mismatched.
+        """
+        (shoot / '.kestrel' / 'kestrel_scenedata.json').unlink()
+        api.backup_kestrel_db(str(shoot))
+        (shoot / '.kestrel' / 'kestrel_scenedata_old.json').write_text('{"version":"2.0"}')
+
+        api.backup_kestrel_db(str(shoot))
+
+        assert (shoot / '.kestrel' / 'kestrel_scenedata_old.json').exists(), (
+            'scenedata backup slot was rotated away with nothing to replace it'
+        )
+
+# The rest of this PR's original suite covered reject/undo refusing to
+# overwrite an existing destination, and a `failed_filenames` key on
+# move_rejects_to_folder. Both landed first via #120, which implements the same
+# guarantee with a stronger mechanism (hardlink-or-O_EXCL rather than an
+# exists() check, so the TOCTOU window is closed) and reports the outcome as
+# structured `skipped` / `moved_requested` lists instead of a flat list of
+# names. Those tests were written against the superseded 2-tuple return and are
+# dropped here rather than rewritten; `test_reject_move.py` covers the same
+# behaviour against the contract that shipped.


### PR DESCRIPTION
Lands the one part of #115 that is not already on `dev`. #115 conflicts because three of its four changes were superseded by #120.

| #115 change | Status |
|---|---|
| reject/undo refuse to overwrite destination | superseded by #120 — which uses hardlink-or-`O_EXCL` instead of an `exists()` check, closing the TOCTOU window #115 leaves |
| report files that did not move | superseded by #120's structured `skipped` / `moved_requested` |
| culling.html: don't drop rows for photos still on disk | superseded by #120 — dev filters on what *actually moved*, more robust than "everything not reported failed" |
| **rotate the backup slot** | **not covered anywhere — taken here** |

## The real bug

There is one canonical `kestrel_database_old.csv` slot and Undo restores from it. A second reject move over the same folder overwrites the first move's restore point with no warning, losing the ratings, labels and crop choices that pass produced. `backup_kestrel_db` now rotates an existing backup to a timestamped `OLD_precull_*` copy first, keeping the newest three.

The `precull_` marker keeps these separate from `database._perform_db_upgrade`'s `OLD_*` files — those fire once per schema upgrade and must be kept; these fire every cull pass and are pruned.

## Two adjustments to #115's code

- `datetime.utcnow()` → `datetime.now(timezone.utc)`. #129 removed every `utcnow()` from `analyzer/` and added a guard test that fails if one returns; #115 predates it. Imported locally — `api_bridge` has no module-level datetime import.
- Rotation inserted ahead of dev's `copy_file_atomic` rather than #115's `shutil.copy2`.

## Tests

#115's **7 rotation tests kept and passing**. Its other 9 asserted the 2-tuple return #120 replaced (`too many values to unpack`); dropped rather than rewritten, with a note pointing at `test_reject_move.py`, which covers that behaviour against the contract that shipped.

Suite: **919 passed, 6 skipped, 0 failed.**

Closes #115.