### PR TITLE
perf(logging): make the analysis log JSONL so writes are O(1)

### DIFF
--- a/analyzer/kestrel_analyzer/config.py
+++ b/analyzer/kestrel_analyzer/config.py
@@ -129,4 +129,10 @@ METADATA_FILENAME = "kestrel_metadata.json"
 SCENEDATA_FILENAME = "kestrel_scenedata.json"
 KESTREL_DIR_NAME = ".kestrel"
 LOG_FILENAME_PREFIX = "kestrel_error"
-LOG_FILE_EXTENSION = "json"
+# The analysis log is JSONL (one JSON object per line), so the extension says
+# so: a ``.json`` file that is not a single JSON document misleads every tool
+# and person that opens it. Logs written before the switch are ``.json``
+# arrays and are still read — see ``logging_utils.parse_log_text`` and the
+# legacy extension below, which readers must keep scanning for.
+LOG_FILE_EXTENSION = "jsonl"
+LEGACY_LOG_FILE_EXTENSION = "json"

--- a/analyzer/kestrel_analyzer/logging_utils.py
+++ b/analyzer/kestrel_analyzer/logging_utils.py
@@ -75,27 +75,101 @@ def get_log_path(folder: Optional[str], session_id: Optional[str] = None) -> str
     return os.path.join(log_dir, filename)
 
 
-def _read_log_entries(log_path: str) -> list:
+def parse_log_text(text: str) -> list:
+    """Parse analysis-log text in either on-disk format.
+
+    Two formats exist in the wild and both must stay readable:
+
+    * **JSONL** (current) — one JSON object per line. An unparseable line is
+      skipped rather than failing the file, so a torn final line from a hard
+      process death costs one entry instead of the whole log.
+    * **JSON array** (written before the JSONL switch) — a single
+      pretty-printed list. Installed builds still hold these, and crash
+      reports uploaded from them must keep parsing.
+
+    The formats are told apart by the first non-whitespace character: a
+    legacy file starts with ``[``. Objects in a legacy file are indented
+    across several lines, so line-wise parsing cannot recover a *truncated*
+    array; that case still yields ``[]``, exactly as it did before. Avoiding
+    that unrecoverable shape is the reason for the change.
+    """
+    stripped = text.lstrip()
+    if not stripped:
+        return []
+
+    if stripped[0] == "[":
+        try:
+            data = json.loads(stripped)
+        except Exception:
+            return []
+        return [item for item in data if isinstance(item, dict)] if isinstance(data, list) else []
+
+    entries = []
+    for line in text.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            obj = json.loads(line)
+        except Exception:
+            # A partially-written final line, or foreign content. Skip it and
+            # keep every entry that did land.
+            continue
+        if isinstance(obj, dict):
+            entries.append(obj)
+    return entries
+
+
+def read_log_entries(log_path: str) -> list:
+    """Read an analysis log into a list of entries, oldest first.
+
+    Tolerates both on-disk formats (see :func:`parse_log_text`) and returns
+    ``[]`` for a missing or unreadable file rather than raising — callers are
+    diagnostics paths that must not fail because a log is absent.
+    """
     if not os.path.exists(log_path):
         return []
     try:
         with open(log_path, "r", encoding="utf-8") as handle:
-            data = json.load(handle)
-        return data if isinstance(data, list) else []
+            text = handle.read()
     except Exception:
         return []
+    return parse_log_text(text)
+
+
+# Retained under the old private name: it was the only reader before the JSONL
+# switch, and keeping the alias means any out-of-tree caller keeps working.
+_read_log_entries = read_log_entries
 
 
 def log_event(log_path: str, entry: Dict[str, Any]) -> None:
+    """Append one entry to the analysis log.
+
+    The log is JSONL — one JSON object per line, opened append-only — so a
+    write is O(1) in the number of entries already recorded.
+
+    It was previously a single JSON array that had to be read, re-serialised
+    and rewritten on *every* call, making a run O(n^2) in the number of
+    entries. That cost is why only the four once-per-run setup stages were
+    ever persisted: marking the per-image stages would have made analysis
+    quadratic in file count.
+
+    Serialisation uses ``default=str`` so an object pandas or numpy handed us
+    degrades to its string form instead of raising and discarding the entry —
+    these records exist to explain failures, and losing one to a type error
+    defeats the point. IO errors still propagate: callers on the crash path
+    (``_mark_stage``, ``_log_resolved_providers``) swallow them deliberately,
+    and silently absorbing them here would hide a misconfigured log directory
+    from every caller.
+    """
     entry_with_time = {"timestamp_utc": _utc_timestamp(), **entry}
-    # Decoder threads can hit the warning hook concurrently. Serialize the
-    # read-modify-write so overlapping log_warning/log_exception calls cannot
-    # tear the JSON file or drop earlier session entries.
+    line = json.dumps(entry_with_time, default=str)
+    # ``json.dumps`` escapes any newline inside a value, so one entry is always
+    # exactly one physical line. Worker threads can reach the warning hook
+    # concurrently; the lock keeps their lines from interleaving mid-write.
     with _log_write_lock:
-        entries = _read_log_entries(log_path)
-        entries.append(entry_with_time)
-        with open(log_path, "w", encoding="utf-8") as handle:
-            json.dump(entries, handle, indent=2)
+        with open(log_path, "a", encoding="utf-8") as handle:
+            handle.write(line + "\n")
 
 
 def log_exception(

--- a/analyzer/kestrel_telemetry.py
+++ b/analyzer/kestrel_telemetry.py
@@ -513,16 +513,52 @@ def get_recent_log_tail(
         JSON-formatted payload containing recent analysis/runtime tails, or ''.
     """
     try:
-        from kestrel_analyzer.config import KESTREL_DIR_NAME, LOG_FILENAME_PREFIX, LOG_FILE_EXTENSION
+        from kestrel_analyzer.config import KESTREL_DIR_NAME, LOG_FILENAME_PREFIX, LOG_FILE_EXTENSION, LEGACY_LOG_FILE_EXTENSION
     except ImportError:
         try:
             # Fallback: import from relative path
-            from analyzer.kestrel_analyzer.config import KESTREL_DIR_NAME, LOG_FILENAME_PREFIX, LOG_FILE_EXTENSION
+            from analyzer.kestrel_analyzer.config import KESTREL_DIR_NAME, LOG_FILENAME_PREFIX, LOG_FILE_EXTENSION, LEGACY_LOG_FILE_EXTENSION
         except ImportError:
             # Cannot import config — use defaults
             KESTREL_DIR_NAME = '.kestrel'
             LOG_FILENAME_PREFIX = 'kestrel_error'
-            LOG_FILE_EXTENSION = 'json'
+            LOG_FILE_EXTENSION = 'jsonl'
+            LEGACY_LOG_FILE_EXTENSION = 'json'
+
+    try:
+        from kestrel_analyzer.logging_utils import parse_log_text
+    except ImportError:
+        try:
+            from analyzer.kestrel_analyzer.logging_utils import parse_log_text  # type: ignore
+        except ImportError:
+            def parse_log_text(text):  # type: ignore[misc]
+                """Minimal stand-in mirroring logging_utils.parse_log_text.
+
+                Crash reporting must keep working even when the analyzer
+                package cannot be imported — that is precisely the situation
+                a crash report is describing.
+                """
+                stripped = text.lstrip()
+                if not stripped:
+                    return []
+                if stripped[0] == '[':
+                    try:
+                        data = json.loads(stripped)
+                    except Exception:
+                        return []
+                    return [i for i in data if isinstance(i, dict)] if isinstance(data, list) else []
+                out = []
+                for line in text.splitlines():
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        obj = json.loads(line)
+                    except Exception:
+                        continue
+                    if isinstance(obj, dict):
+                        out.append(obj)
+                return out
 
     try:
         # Build list of candidate log directories
@@ -540,7 +576,13 @@ def get_recent_log_tail(
                 continue
             try:
                 for fname in os.listdir(log_dir):
-                    if fname.startswith(LOG_FILENAME_PREFIX) and fname.endswith(f'.{LOG_FILE_EXTENSION}'):
+                    # Both extensions: current sessions write .jsonl, but a
+                    # machine that has just updated still holds .json logs from
+                    # earlier runs, and those are often the ones describing the
+                    # crash being reported.
+                    if fname.startswith(LOG_FILENAME_PREFIX) and fname.endswith(
+                        (f'.{LOG_FILE_EXTENSION}', f'.{LEGACY_LOG_FILE_EXTENSION}')
+                    ):
                         fp = os.path.join(log_dir, fname)
                         try:
                             mt = os.path.getmtime(fp)
@@ -556,9 +598,9 @@ def get_recent_log_tail(
 
         if analysis_path:
             with open(analysis_path, 'r', encoding='utf-8') as f:
-                data = json.load(f)
-            if isinstance(data, list):
-                payload['analysis_entries'] = data[-max_entries:]
+                entries = parse_log_text(f.read())
+            if entries:
+                payload['analysis_entries'] = entries[-max_entries:]
 
         # Runtime logs are plain text files in <...>/.kestrel/logs/
         runtime_file_limit = max(1, min(int(runtime_log_files or 1), 5))

--- a/analyzer/tests/unit/test_log_jsonl_format.py
+++ b/analyzer/tests/unit/test_log_jsonl_format.py
@@ -1,0 +1,224 @@
+"""The analysis log is JSONL: append-only writes, per-line recovery.
+
+Two properties motivated the format change, and each is pinned here.
+
+**Cost.** The log was a single JSON array that ``log_event`` read,
+re-serialised and rewrote on every call, so recording n entries cost O(n^2).
+That is why only the four once-per-run setup stages were ever persisted:
+marking the per-image stages would have made an analysis run quadratic in
+file count. Appending one line is O(1) regardless of how much is already
+there.
+
+**Recoverability.** A process killed mid-write leaves a partial trailing
+record. In a JSON array that makes the *whole document* unparseable, so the
+log describing a crash is lost precisely when it is needed — the failure mode
+this instrumentation exists to avoid. In JSONL the damage is confined to the
+final line and every earlier entry still reads back.
+
+Logs written before the switch are JSON arrays and installed builds still
+hold them, so the reader must keep parsing both shapes.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from kestrel_analyzer.config import (  # noqa: E402
+    LEGACY_LOG_FILE_EXTENSION,
+    LOG_FILE_EXTENSION,
+)
+from kestrel_analyzer.logging_utils import (  # noqa: E402
+    get_log_path,
+    log_event,
+    parse_log_text,
+    read_log_entries,
+)
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# Writing
+# ---------------------------------------------------------------------------
+
+
+def test_each_event_is_one_line(tmp_path):
+    log_path = str(tmp_path / "log.jsonl")
+    for i in range(5):
+        log_event(log_path, {"level": "info", "event": "stage", "n": i})
+
+    lines = [ln for ln in Path(log_path).read_text(encoding="utf-8").splitlines() if ln.strip()]
+    assert len(lines) == 5
+    assert [json.loads(ln)["n"] for ln in lines] == [0, 1, 2, 3, 4]
+
+
+def test_writes_are_append_only(tmp_path):
+    """The bytes already on disk are never rewritten.
+
+    This is the property that makes the write O(1): the previous format
+    reproduced the entire file on every call.
+    """
+    log_path = str(tmp_path / "log.jsonl")
+    for i in range(20):
+        log_event(log_path, {"event": "stage", "n": i})
+    before = Path(log_path).read_bytes()
+
+    log_event(log_path, {"event": "stage", "n": 20})
+    after = Path(log_path).read_bytes()
+
+    assert after.startswith(before), "an existing region of the log was rewritten"
+    assert json.loads(after[len(before):].decode("utf-8").strip())["n"] == 20
+
+
+def test_every_entry_is_timestamped(tmp_path):
+    log_path = str(tmp_path / "log.jsonl")
+    log_event(log_path, {"event": "analysis_start"})
+    entry = read_log_entries(log_path)[-1]
+    assert entry["timestamp_utc"].endswith("Z")
+    assert entry["event"] == "analysis_start"
+
+
+def test_a_newline_inside_a_value_stays_on_one_line(tmp_path):
+    """Tracebacks contain newlines; one entry must remain one physical line."""
+    log_path = str(tmp_path / "log.jsonl")
+    log_event(log_path, {"event": "error", "traceback": "line one\nline two\nline three"})
+
+    lines = [ln for ln in Path(log_path).read_text(encoding="utf-8").splitlines() if ln.strip()]
+    assert len(lines) == 1
+    assert read_log_entries(log_path)[0]["traceback"] == "line one\nline two\nline three"
+
+
+def test_unserializable_values_degrade_instead_of_losing_the_entry(tmp_path):
+    """``default=str`` keeps a diagnostic record that would otherwise be lost.
+
+    These entries exist to explain a failure. Raising on an odd value would
+    discard the explanation and, on the crash path, mask the real fault.
+    """
+    class Opaque:
+        def __str__(self):
+            return "opaque-value"
+
+    log_path = str(tmp_path / "log.jsonl")
+    log_event(log_path, {"event": "stage", "context": {"obj": Opaque()}})
+
+    assert read_log_entries(log_path)[0]["context"]["obj"] == "opaque-value"
+
+
+def test_io_errors_still_propagate(tmp_path):
+    """Callers on the crash path swallow these deliberately; don't pre-empt them.
+
+    ``_mark_stage`` and ``_log_resolved_providers`` wrap their calls so
+    instrumentation can never fail a run. Swallowing the error here instead
+    would hide a misconfigured log directory from every other caller.
+    """
+    log_path = str(tmp_path / "no" / "such" / "dir" / "log.jsonl")
+    with pytest.raises(OSError):
+        log_event(log_path, {"event": "stage"})
+
+
+# ---------------------------------------------------------------------------
+# Reading — recoverability
+# ---------------------------------------------------------------------------
+
+
+def test_a_torn_final_line_costs_one_entry_not_the_log(tmp_path):
+    """The headline benefit: a mid-write process death stays diagnosable."""
+    log_path = tmp_path / "log.jsonl"
+    for i in range(4):
+        log_event(str(log_path), {"event": "stage", "n": i})
+
+    # Simulate the process dying partway through writing the fifth record.
+    with open(log_path, "a", encoding="utf-8") as handle:
+        handle.write('{"event": "stage", "n": 4, "partial"')
+
+    entries = read_log_entries(str(log_path))
+    assert [e["n"] for e in entries] == [0, 1, 2, 3]
+
+
+def test_a_truncated_legacy_array_is_not_recoverable(tmp_path):
+    """Documents the failure the new format exists to avoid.
+
+    A pretty-printed array spans many lines per object, so line-wise parsing
+    cannot salvage it. One interrupted write costs the entire log — which is
+    the whole argument for JSONL, so it is pinned rather than left implicit.
+    """
+    log_path = tmp_path / "legacy.json"
+    log_path.write_text(
+        '[\n  {\n    "event": "analysis_start"\n  },\n  {\n    "event": "sta',
+        encoding="utf-8",
+    )
+    assert read_log_entries(str(log_path)) == []
+
+
+def test_blank_lines_are_ignored(tmp_path):
+    log_path = tmp_path / "log.jsonl"
+    log_path.write_text('{"event": "a"}\n\n\n{"event": "b"}\n', encoding="utf-8")
+    assert [e["event"] for e in read_log_entries(str(log_path))] == ["a", "b"]
+
+
+def test_missing_file_reads_as_empty(tmp_path):
+    assert read_log_entries(str(tmp_path / "absent.jsonl")) == []
+
+
+def test_empty_file_reads_as_empty(tmp_path):
+    log_path = tmp_path / "log.jsonl"
+    log_path.write_text("", encoding="utf-8")
+    assert read_log_entries(str(log_path)) == []
+
+
+# ---------------------------------------------------------------------------
+# Reading — legacy compatibility
+# ---------------------------------------------------------------------------
+
+
+def test_legacy_json_array_still_reads(tmp_path):
+    """Installed builds hold these, and their crash reports must still parse."""
+    log_path = tmp_path / "kestrel_error_20260725T182313Z.json"
+    log_path.write_text(
+        json.dumps(
+            [
+                {"timestamp_utc": "2026-07-25T18:23:13Z", "event": "analysis_start"},
+                {"timestamp_utc": "2026-07-25T18:23:14Z", "event": "stage", "stage": "load_models"},
+            ],
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+
+    entries = read_log_entries(str(log_path))
+    assert [e["event"] for e in entries] == ["analysis_start", "stage"]
+
+
+def test_non_dict_members_are_dropped_from_a_legacy_array(tmp_path):
+    log_path = tmp_path / "legacy.json"
+    log_path.write_text('[{"event": "a"}, "junk", 7, {"event": "b"}]', encoding="utf-8")
+    assert [e["event"] for e in read_log_entries(str(log_path))] == ["a", "b"]
+
+
+def test_a_legacy_array_is_told_apart_by_its_first_character():
+    """Format detection is structural, not name-based, so a misnamed file works."""
+    assert parse_log_text('  \n [{"event": "a"}]') == [{"event": "a"}]
+    assert parse_log_text('{"event": "a"}\n{"event": "b"}') == [
+        {"event": "a"},
+        {"event": "b"},
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Naming
+# ---------------------------------------------------------------------------
+
+
+def test_new_sessions_write_the_jsonl_extension(tmp_path):
+    path = get_log_path(str(tmp_path))
+    assert path.endswith(f".{LOG_FILE_EXTENSION}")
+    assert LOG_FILE_EXTENSION == "jsonl"
+
+
+def test_the_legacy_extension_is_still_declared():
+    """Readers scan for it; dropping the constant would silently orphan old logs."""
+    assert LEGACY_LOG_FILE_EXTENSION == "json"

--- a/analyzer/tests/unit/test_pipeline_stage_instrumentation.py
+++ b/analyzer/tests/unit/test_pipeline_stage_instrumentation.py
@@ -31,7 +31,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
 try:
     from kestrel_analyzer.pipeline import AnalysisPipeline
-    from kestrel_analyzer.logging_utils import log_event
+    from kestrel_analyzer.logging_utils import log_event, read_log_entries
     from kestrel_analyzer.ml import GPU_EP
 except Exception as exc:  # pragma: no cover - environment-dependent
     # The pipeline pulls in cv2 / onnxruntime / rawpy. Several CI containers
@@ -58,16 +58,17 @@ _SUPPRESS_UTCNOW_RECURSION = pytest.mark.filterwarnings(
 
 
 def _read_log(folder: Path) -> list:
-    """Return every event written to the analysis log under ``folder``."""
+    """Return every event written to the analysis log under ``folder``.
+
+    Deliberately goes through the production reader rather than parsing here,
+    so these tests break if the on-disk format and its reader ever drift
+    apart. Both extensions are globbed: sessions write ``.jsonl``, while a few
+    cases below point ``_log_path`` at an explicit ``.json`` name.
+    """
     log_dir = folder / ".kestrel"
     entries = []
-    for log_file in sorted(log_dir.glob("*.json")):
-        try:
-            data = json.loads(log_file.read_text(encoding="utf-8"))
-        except Exception:
-            continue
-        if isinstance(data, list):
-            entries.extend(data)
+    for log_file in sorted(log_dir.glob("*.json")) + sorted(log_dir.glob("*.jsonl")):
+        entries.extend(read_log_entries(str(log_file)))
     return entries
 
 

--- a/analyzer/tests/unit/test_utc_showwarning.py
+++ b/analyzer/tests/unit/test_utc_showwarning.py
@@ -26,6 +26,7 @@ from kestrel_analyzer.logging_utils import (  # noqa: E402
     _utc_timestamp,
     log_warning,
     make_logged_showwarning,
+    read_log_entries,
     utc_now_naive,
 )
 from queue_manager import _utc_timestamp as queue_utc_timestamp  # noqa: E402
@@ -88,7 +89,7 @@ def test_log_warning_does_not_recurse_under_error_filter(tmp_path):
     with warnings.catch_warnings():
         warnings.simplefilter("error", DeprecationWarning)
         log_warning(log_path, "hello", category=UserWarning, stage="unit")
-    entries = json.loads(Path(log_path).read_text(encoding="utf-8"))
+    entries = read_log_entries(log_path)
     assert entries[-1]["message"] == "hello"
     assert entries[-1]["timestamp_utc"].endswith("Z")
 
@@ -129,7 +130,7 @@ def test_logged_showwarning_is_reentrant_when_logging_emits(tmp_path, monkeypatc
     finally:
         warnings.showwarning = previous
 
-    entries = json.loads(Path(log_path).read_text(encoding="utf-8"))
+    entries = read_log_entries(log_path)
     messages = [e["message"] for e in entries]
     assert any("outer warning" in m for m in messages)
     assert not any("nested warning from logger" in m for m in messages)
@@ -181,7 +182,13 @@ def test_logged_showwarning_does_not_drop_concurrent_threads(tmp_path, monkeypat
 
 
 def test_concurrent_log_warning_keeps_valid_json(tmp_path):
-    """Overlapping log_event writes must not tear or drop the JSON log."""
+    """Overlapping log_event writes must not tear or drop log entries.
+
+    Under the JSONL format the invariant is per line: each concurrent write
+    must land as exactly one complete, parseable line, and none may be lost.
+    That is checked directly here rather than through the tolerant reader,
+    which skips unparseable lines by design and so would hide a torn write.
+    """
     log_path = str(tmp_path / "kestrel.log.json")
     n = 8
     barrier = threading.Barrier(n)
@@ -196,9 +203,14 @@ def test_concurrent_log_warning_keeps_valid_json(tmp_path):
     for t in threads:
         t.join()
 
-    entries = json.loads(Path(log_path).read_text(encoding="utf-8"))
+    lines = [
+        ln for ln in Path(log_path).read_text(encoding="utf-8").splitlines()
+        if ln.strip()
+    ]
+    assert len(lines) == n, f"expected {n} lines, got {len(lines)}"
+    entries = [json.loads(ln) for ln in lines]  # raises if any line was torn
     messages = {e["message"] for e in entries}
-    assert {f"msg-{i}" for i in range(n)} <= messages
+    assert {f"msg-{i}" for i in range(n)} == messages
 
 
 def test_logged_showwarning_records_category_and_stage(tmp_path):
@@ -216,7 +228,7 @@ def test_logged_showwarning_records_category_and_stage(tmp_path):
     finally:
         warnings.showwarning = original
 
-    entry = json.loads(Path(log_path).read_text(encoding="utf-8"))[-1]
+    entry = read_log_entries(log_path)[-1]
     assert entry["stage"] == "list_files"
     assert entry["category"] == "RuntimeWarning"
     assert entry["context"]["file"] == "IMG_001.CR3"


### PR DESCRIPTION
Follow-up to the crash-instrumentation work. Removes the reason the stage trail had to stop at `load_models`.

## The problem

`log_event` read, re-serialised and rewrote the **entire** JSON array on every call, so recording *n* entries cost O(n²). Measured on this machine:

| Entries | JSON array | JSONL |
|---|---|---|
| 500 | 1.59 s | 0.32 s |
| 1500 | **16.02 s** | **1.16 s** |

3× the entries for 10× the time — the quadratic curve, at the file count in the outstanding native-crash reports.

That cost is why only the four once-per-run setup stages are persisted: marking the per-image stages would have made an analysis run quadratic in file count. So the trail stops at `load_models`, and a native death inside the per-image loop is localized only to *"somewhere after the models loaded"* — exactly the window the current crash reports fall into.

**The second benefit matters as much as the speed.** A process killed mid-write leaves a partial trailing record. In a JSON array that makes the whole document unparseable, so the log describing a crash is lost precisely when it is needed. In JSONL the damage is confined to the final line and every earlier entry still reads back.

## What changed

- **`log_event` appends one JSON object per line**, opened append-only. Kept the existing lock so concurrent worker threads cannot interleave mid-line, and kept IO errors propagating — the crash-path callers (`_mark_stage`, `_log_resolved_providers`) swallow them deliberately, and absorbing them here would hide a misconfigured log directory from every other caller.
- **`default=str` on serialisation**, so an odd value degrades to its string form instead of raising and discarding a diagnostic record.
- **New `parse_log_text` / `read_log_entries` read both formats**, told apart by the first non-whitespace character. Logs written before this change are JSON arrays and installed builds still hold them, so their crash reports must keep parsing.
- **`LOG_FILE_EXTENSION` is now `jsonl`** — a `.json` file that is not a single JSON document misleads every tool and person that opens it. `LEGACY_LOG_FILE_EXTENSION` is declared so readers keep scanning for old logs.
- **`kestrel_telemetry.get_recent_log_tail`** scans both extensions and parses via `parse_log_text`. It carries a small inline fallback copy, matching the existing import-fallback pattern in that file, because crash reporting has to work when the analyzer package cannot be imported — which is the situation a crash report describes.

## What this does *not* do

It does **not** yet mark the per-image stages. That is now a decision about log volume (one line per image, so ~1500 lines on a routine outing) rather than a cost problem, and it is left for you to call.

## Testing

New `test_log_jsonl_format.py` (16 cases): append-only writes, one-line-per-entry, newline-bearing values, `default=str` degradation, IO errors still propagating, torn-final-line recovery, and legacy-array compatibility. **Verified the 5 format-dependent cases fail against the old `log_event`** rather than assuming they were meaningful.

The two existing tests that parsed the log by hand now go through the production reader, so the format and its reader cannot drift apart.

- Unit lane: **796 passed, 4 skipped** — identical to the pre-change baseline.
- Full non-UI suite: **1093 passed, 5 failed, 12 skipped**. The 5 failures are in `integration/test_quality_classifier.py` and are **pre-existing and unrelated** — I reproduced them on clean `dev` with this change absent. They are stale tests, not a product bug: they feed a 512×512 crop directly while the model expects 1024×1024, bypassing `get_square_crop(..., resize=True)`, which is what the pipeline actually calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AK7TV8qZ4DPLgrfQbv2LFV