### PR TITLE
fix(io): retry Windows os.replace on settings and cloud JSON

### DIFF
--- a/analyzer/cloud_folder_state.py
+++ b/analyzer/cloud_folder_state.py
@@ -46,6 +46,22 @@ _LOCKS: dict[str, threading.RLock] = {}
 _LOCKS_GLOBAL = threading.Lock()
 
 
+def _retry_on_file_lock(op, attempts: int = 12, delay: float = 0.02):
+    """Run ``op()``, retrying briefly on Windows' transient file-sharing errors.
+
+    Canonical implementation: ``kestrel_analyzer.database.retry_on_file_lock``.
+    This copy exists so folder-local cloud state does not import pandas via
+    ``database``.
+    """
+    for attempt in range(attempts):
+        try:
+            return op()
+        except PermissionError:
+            if attempt == attempts - 1:
+                raise
+            time.sleep(delay * (attempt + 1))
+
+
 def _lock_for(folder_abs: str) -> threading.RLock:
     with _LOCKS_GLOBAL:
         lk = _LOCKS.get(folder_abs)
@@ -96,7 +112,7 @@ def _write_atomic(folder: Path, data: dict) -> None:
     try:
         with os.fdopen(fd, "w", encoding="utf-8") as f:
             json.dump(data, f, indent=2, sort_keys=False)
-        os.replace(tmp_path, final_path)
+        _retry_on_file_lock(lambda: os.replace(tmp_path, final_path))
     except Exception:
         try:
             os.unlink(tmp_path)

--- a/analyzer/cloud_jobs_store.py
+++ b/analyzer/cloud_jobs_store.py
@@ -39,6 +39,21 @@ from typing import Any
 CLOUD_JOBS_FILENAME = "cloud_jobs.json"
 _SAVE_LOCK = threading.RLock()
 
+
+def _retry_on_file_lock(op, attempts: int = 12, delay: float = 0.02):
+    """Run ``op()``, retrying briefly on Windows' transient file-sharing errors.
+
+    Canonical implementation: ``kestrel_analyzer.database.retry_on_file_lock``.
+    This copy exists so the job ledger does not import pandas via ``database``.
+    """
+    for attempt in range(attempts):
+        try:
+            return op()
+        except PermissionError:
+            if attempt == attempts - 1:
+                raise
+            time.sleep(delay * (attempt + 1))
+
 # 'incomplete' = the client disconnected >10min with uploads UNFINISHED. Uploads
 # are halted, but analysis CONTINUES server-side and result packs remain
 # downloadable from R2 for ~30 days. It stays in _TERMINAL_STATUSES because it's
@@ -167,7 +182,7 @@ def _write_atomic(data: dict) -> None:
     try:
         with os.fdopen(fd, "w", encoding="utf-8") as f:
             json.dump(data, f, indent=2, sort_keys=False)
-        os.replace(tmp_path, final_path)
+        _retry_on_file_lock(lambda: os.replace(tmp_path, final_path))
     except Exception:
         try:
             os.unlink(tmp_path)

--- a/analyzer/settings_utils.py
+++ b/analyzer/settings_utils.py
@@ -22,6 +22,24 @@ from typing import Any
 # file specified" on os.replace when the other thread deleted our tmp).
 _SAVE_LOCK = threading.RLock()
 
+
+def _retry_on_file_lock(op, attempts: int = 12, delay: float = 0.02):
+    """Run ``op()``, retrying briefly on Windows' transient file-sharing errors.
+
+    Canonical implementation: ``kestrel_analyzer.database.retry_on_file_lock``.
+    This copy exists so settings I/O does not import pandas via ``database``.
+    ``os.replace`` of ``settings.json`` fails with ``PermissionError`` while
+    Explorer, Defender, or a previous Kestrel instance holds the file.
+    """
+    for attempt in range(attempts):
+        try:
+            return op()
+        except PermissionError:
+            if attempt == attempts - 1:
+                raise
+            time.sleep(delay * (attempt + 1))
+
+
 # Prefix/suffix for ``tempfile.mkstemp`` tmp files we emit. The glob
 # ``settings.json.*.tmp`` uniquely identifies orphans left by a crashed save.
 _TMP_FILE_PREFIX = 'settings.json.'
@@ -929,7 +947,7 @@ def save_persisted_settings(data: dict) -> None:
                 except OSError as exc:
                     warn(f'[settings] could not refresh .bak: {exc}')
 
-            os.replace(tmp, path)
+            _retry_on_file_lock(lambda: os.replace(tmp, path))
         except OSError as exc:
             # Do NOT fall back to a non-atomic direct write — that path is how
             # partial writes corrupt settings.json in the first place. Leave the

--- a/analyzer/tests/unit/test_windows_replace_lock.py
+++ b/analyzer/tests/unit/test_windows_replace_lock.py
@@ -1,0 +1,168 @@
+"""JSON stores must retry ``os.replace`` on Windows sharing violations.
+
+CSV, sidecar, and cloud-merge writers already go through
+``retry_on_file_lock``. ``settings.json``, ``cloud_jobs.json``, and
+``kestrel_cloudcompute.json`` still called bare ``os.replace``, so a
+transient Explorer/Defender lock aborted the save.
+"""
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+import cloud_folder_state
+import cloud_jobs_store
+import settings_utils
+
+
+pytestmark = pytest.mark.unit
+
+
+def _flaky_replace(real_replace, calls):
+    def _replace(src, dst, *a, **k):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise PermissionError(32, "The process cannot access the file")
+        return real_replace(src, dst, *a, **k)
+
+    return _replace
+
+
+def _always_locked(_src, _dst, *_a, **_k):
+    raise PermissionError(32, "The process cannot access the file")
+
+
+class TestSettingsReplaceIsRetried:
+    @pytest.fixture(autouse=True)
+    def _settings_dir(self, tmp_path, monkeypatch):
+        self._path = tmp_path / settings_utils.SETTINGS_FILENAME
+        monkeypatch.setattr(
+            settings_utils, "_get_settings_path", lambda: str(self._path)
+        )
+        monkeypatch.setattr(settings_utils.time, "sleep", lambda *_a, **_k: None)
+
+    def test_transient_permission_error_is_retried(self, monkeypatch):
+        settings_utils.save_persisted_settings({"editor": "darktable"})
+        original = self._path.read_bytes()
+        calls = {"n": 0}
+        monkeypatch.setattr(
+            settings_utils.os, "replace", _flaky_replace(os.replace, calls)
+        )
+
+        settings_utils.save_persisted_settings({"editor": "photoshop"})
+
+        assert calls["n"] >= 2
+        loaded = settings_utils.load_persisted_settings()
+        assert loaded["editor"] == "photoshop"
+        assert self._path.read_bytes() != original
+
+    def test_persistent_lock_leaves_settings_intact(self, monkeypatch):
+        settings_utils.save_persisted_settings({"editor": "darktable"})
+        original = self._path.read_bytes()
+        monkeypatch.setattr(settings_utils.os, "replace", _always_locked)
+
+        settings_utils.save_persisted_settings({"editor": "photoshop"})
+
+        assert self._path.read_bytes() == original
+        leftovers = [p.name for p in self._path.parent.iterdir() if p.suffix == ".tmp"]
+        assert leftovers == []
+
+
+class TestCloudJobsReplaceIsRetried:
+    @pytest.fixture(autouse=True)
+    def _store_dir(self, tmp_path, monkeypatch):
+        self._dir = tmp_path / "userdata"
+        self._dir.mkdir()
+        monkeypatch.setattr(
+            cloud_jobs_store, "_user_data_dir", lambda: str(self._dir)
+        )
+        monkeypatch.setattr(cloud_jobs_store.time, "sleep", lambda *_a, **_k: None)
+
+    def _ledger(self) -> Path:
+        return self._dir / cloud_jobs_store.CLOUD_JOBS_FILENAME
+
+    def test_transient_permission_error_is_retried(self, tmp_path, monkeypatch):
+        folder = tmp_path / "shoot"
+        folder.mkdir()
+        cloud_jobs_store.upsert_job(
+            {"jobId": "job-1", "folderPath": str(folder), "status": "done"}
+        )
+        original = self._ledger().read_bytes()
+        calls = {"n": 0}
+        monkeypatch.setattr(
+            cloud_jobs_store.os, "replace", _flaky_replace(os.replace, calls)
+        )
+
+        cloud_jobs_store.update_job("job-1", status="failed")
+
+        assert calls["n"] >= 2
+        rows = {j["jobId"]: j for j in cloud_jobs_store.load_jobs()}
+        assert rows["job-1"]["status"] == "failed"
+        assert self._ledger().read_bytes() != original
+
+    def test_persistent_lock_leaves_ledger_intact(self, tmp_path, monkeypatch):
+        folder = tmp_path / "shoot"
+        folder.mkdir()
+        cloud_jobs_store.upsert_job(
+            {"jobId": "job-1", "folderPath": str(folder), "status": "done"}
+        )
+        original = self._ledger().read_bytes()
+        monkeypatch.setattr(cloud_jobs_store.os, "replace", _always_locked)
+
+        with pytest.raises(PermissionError):
+            cloud_jobs_store.update_job("job-1", status="failed")
+
+        assert self._ledger().read_bytes() == original
+        leftovers = [p.name for p in self._dir.iterdir() if p.suffix == ".tmp"]
+        assert leftovers == []
+
+
+class TestCloudFolderStateReplaceIsRetried:
+    @pytest.fixture(autouse=True)
+    def _sleep(self, monkeypatch):
+        monkeypatch.setattr(cloud_folder_state.time, "sleep", lambda *_a, **_k: None)
+
+    def _state_file(self, folder: Path) -> Path:
+        return folder / ".kestrel" / cloud_folder_state.CLOUD_FOLDER_STATE_FILENAME
+
+    def test_transient_permission_error_is_retried(self, tmp_path, monkeypatch):
+        folder = tmp_path / "shoot"
+        folder.mkdir()
+        cloud_folder_state.mark_pack_merged(folder, "job-1", "pack_1.zip")
+        original = self._state_file(folder).read_bytes()
+        calls = {"n": 0}
+        monkeypatch.setattr(
+            cloud_folder_state.os, "replace", _flaky_replace(os.replace, calls)
+        )
+
+        cloud_folder_state.mark_pack_merged(folder, "job-1", "pack_2.zip")
+
+        assert calls["n"] >= 2
+        assert cloud_folder_state.list_merged_packs(folder, "job-1") == [
+            "pack_1.zip",
+            "pack_2.zip",
+        ]
+        assert self._state_file(folder).read_bytes() != original
+
+    def test_persistent_lock_leaves_state_intact(self, tmp_path, monkeypatch):
+        folder = tmp_path / "shoot"
+        folder.mkdir()
+        cloud_folder_state.mark_pack_merged(folder, "job-1", "pack_1.zip")
+        original = self._state_file(folder).read_bytes()
+        monkeypatch.setattr(cloud_folder_state.os, "replace", _always_locked)
+
+        with pytest.raises(PermissionError):
+            cloud_folder_state.mark_pack_merged(folder, "job-1", "pack_2.zip")
+
+        assert self._state_file(folder).read_bytes() == original
+        assert cloud_folder_state.list_merged_packs(folder, "job-1") == ["pack_1.zip"]
+        leftovers = [
+            p.name
+            for p in (folder / ".kestrel").iterdir()
+            if p.suffix == ".tmp"
+        ]
+        assert leftovers == []


### PR DESCRIPTION
## Summary

CSV, sidecar, and cloud-merge writers already retry `os.replace` on Windows sharing violations. `settings.json`, `cloud_jobs.json`, and `kestrel_cloudcompute.json` still called bare `os.replace`, so a transient Explorer/Defender lock aborted the save.

Those three canonical writes now use the same `PermissionError` backoff. Copies live in each module so settings/jobs I/O does not import pandas via `database`.

Out of scope: `fsync` on jobs/folder-state, `auth.json` mode, `perch_link.json`, backup rotation, CSV/XMP (already retried).

## Test plan

- `pytest analyzer/tests/unit/test_windows_replace_lock.py analyzer/tests/unit/test_settings.py analyzer/tests/test_security_settings_durability.py analyzer/tests/unit/test_cloud_compute_relocate.py analyzer/tests/unit/test_cloud_compute_list_pending_readonly.py -q`
- 113 passed (6 new lock-retry cases plus neighbor settings/jobs tests)
- Arrange: existing JSON store; first `os.replace` raises `PermissionError(32)`
- Act: `save_persisted_settings` / `update_job` / `mark_pack_merged`
- Assert: retry lands the write; a persistent lock leaves the original bytes and no `.tmp` leftover

Reviewed on https://github.com/wolfgangh/ProjectKestrel/pull/31