### PR TITLE
fix(quality): do not swallow a missing percentile CSV

### DIFF
--- a/analyzer/kestrel_analyzer/ml/quality.py
+++ b/analyzer/kestrel_analyzer/ml/quality.py
@@ -49,6 +49,8 @@ class QualityClassifier:
                     continue
                 if not np.isfinite(p) or not np.isfinite(q):
                     continue
+                if p < 0.0 or p > 100.0:
+                    continue
                 rows.append((q, p / 100.0))
         if not rows:
             raise ValueError(

--- a/analyzer/kestrel_analyzer/ml/quality.py
+++ b/analyzer/kestrel_analyzer/ml/quality.py
@@ -28,13 +28,16 @@ class QualityClassifier:
         self._norm_qualities = None
         self._norm_percentiles = None
         if normalization_data_path:
-            try:
-                self._load_normalization_data(normalization_data_path)
-            except Exception:
-                self._norm_qualities = None
-                self._norm_percentiles = None
+            self._load_normalization_data(normalization_data_path)
 
     def _load_normalization_data(self, normalization_data_path: str) -> None:
+        """Load the percentile curve. A given path must yield at least one row.
+
+        Missing, unreadable, or header-only files used to be swallowed in
+        ``__init__``, leaving ``_norm_qualities`` as None. ``classify`` then
+        returned the raw model score instead of a 0–1 percentile, so star
+        ratings were wrong with no error.
+        """
         rows = []
         with open(normalization_data_path, "r", newline="", encoding="utf-8") as f:
             reader = csv.DictReader(f)
@@ -48,7 +51,10 @@ class QualityClassifier:
                     continue
                 rows.append((q, p / 100.0))
         if not rows:
-            return
+            raise ValueError(
+                "quality normalization CSV has no valid percentile/quality "
+                f"rows: {normalization_data_path}"
+            )
         rows.sort(key=lambda x: x[0])
         self._norm_qualities = np.array([q for q, _ in rows], dtype=np.float32)
         self._norm_percentiles = np.array([p for _, p in rows], dtype=np.float32)

--- a/analyzer/tests/unit/test_quality_norm_csv.py
+++ b/analyzer/tests/unit/test_quality_norm_csv.py
@@ -80,8 +80,24 @@ class TestLoadNormalizationData:
             qc._load_normalization_data(str(csv_path))
         assert qc._norm_qualities is None
 
+    def test_out_of_range_percentiles_raise(self, tmp_path):
+        csv_path = _write_csv(
+            tmp_path / "oor.csv",
+            [("-1", "0.1"), ("250", "0.9")],
+        )
+        qc = _qc()
+        with pytest.raises(ValueError, match="no valid percentile/quality"):
+            qc._load_normalization_data(str(csv_path))
+        assert qc._norm_qualities is None
 
-class TestInitDoesNotSwallowCsvErrors:
+    def test_out_of_range_rows_are_skipped_when_valid_remain(self, tmp_path):
+        csv_path = _write_csv(
+            tmp_path / "mixed.csv",
+            [("-1", "0.0"), ("0", "0.0"), ("100", "1.0"), ("250", "2.0")],
+        )
+        qc = _qc()
+        qc._load_normalization_data(str(csv_path))
+        assert qc._normalize_quality_to_percentile(0.5) == pytest.approx(0.5)
     @pytest.fixture(autouse=True)
     def _stub_onnx(self, monkeypatch):
         class FakeInput:

--- a/analyzer/tests/unit/test_quality_norm_csv.py
+++ b/analyzer/tests/unit/test_quality_norm_csv.py
@@ -1,0 +1,127 @@
+"""QualityClassifier must not silently drop the percentile CSV.
+
+``__init__`` used to wrap ``_load_normalization_data`` in ``except Exception``
+and clear the tables. ``classify`` then returned the raw model score instead
+of a 0–1 percentile, so star ratings were wrong with no error. A given path
+must load or raise.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from kestrel_analyzer.ml.quality import QualityClassifier
+
+
+pytestmark = pytest.mark.unit
+
+
+def _qc():
+    qc = QualityClassifier.__new__(QualityClassifier)
+    qc._norm_qualities = None
+    qc._norm_percentiles = None
+    return qc
+
+
+def _write_csv(path: Path, rows: list[tuple[str, str]]) -> Path:
+    lines = ["percentile,quality"]
+    lines.extend(f"{p},{q}" for p, q in rows)
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return path
+
+
+class TestLoadNormalizationData:
+    def test_valid_csv_maps_quality_to_percentile(self, tmp_path):
+        csv_path = _write_csv(
+            tmp_path / "norm.csv",
+            [("0", "0.0"), ("100", "1.0")],
+        )
+        qc = _qc()
+        qc._load_normalization_data(str(csv_path))
+        assert qc._normalize_quality_to_percentile(0.5) == pytest.approx(0.5)
+
+    def test_missing_file_raises(self, tmp_path):
+        qc = _qc()
+        missing = tmp_path / "missing.csv"
+        with pytest.raises(FileNotFoundError):
+            qc._load_normalization_data(str(missing))
+        assert qc._norm_qualities is None
+
+    def test_header_only_csv_raises(self, tmp_path):
+        csv_path = _write_csv(tmp_path / "empty.csv", [])
+        qc = _qc()
+        with pytest.raises(ValueError, match="no valid percentile/quality"):
+            qc._load_normalization_data(str(csv_path))
+        assert qc._norm_qualities is None
+
+    def test_garbage_rows_raise(self, tmp_path):
+        csv_path = _write_csv(
+            tmp_path / "garbage.csv",
+            [("not-a-number", "also-bad"), ("", "")],
+        )
+        qc = _qc()
+        with pytest.raises(ValueError, match="no valid percentile/quality"):
+            qc._load_normalization_data(str(csv_path))
+        assert qc._norm_qualities is None
+
+    def test_lfs_pointer_raises(self, tmp_path):
+        csv_path = tmp_path / "quality_normalization_data.csv"
+        csv_path.write_text(
+            "version https://git-lfs.github.com/spec/v1\n"
+            "oid sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n"
+            "size 12\n",
+            encoding="utf-8",
+        )
+        qc = _qc()
+        with pytest.raises(ValueError, match="no valid percentile/quality"):
+            qc._load_normalization_data(str(csv_path))
+        assert qc._norm_qualities is None
+
+
+class TestInitDoesNotSwallowCsvErrors:
+    @pytest.fixture(autouse=True)
+    def _stub_onnx(self, monkeypatch):
+        class FakeInput:
+            name = "input"
+
+        class FakeSession:
+            def get_providers(self):
+                return ["CPUExecutionProvider"]
+
+            def get_inputs(self):
+                return [FakeInput()]
+
+        monkeypatch.setattr(
+            "kestrel_analyzer.ml.quality.ResilientOnnxSession",
+            lambda *_a, **_k: FakeSession(),
+        )
+        monkeypatch.setattr(
+            "kestrel_analyzer.ml.quality.debug",
+            lambda *_a, **_k: None,
+        )
+
+    def test_missing_csv_raises_from_init(self, tmp_path):
+        missing = tmp_path / "nope.csv"
+        with pytest.raises(FileNotFoundError):
+            QualityClassifier("quality.onnx", str(missing), coord=object())
+
+    def test_empty_csv_raises_from_init(self, tmp_path):
+        csv_path = _write_csv(tmp_path / "empty.csv", [])
+        with pytest.raises(ValueError, match="no valid percentile/quality"):
+            QualityClassifier("quality.onnx", str(csv_path), coord=object())
+
+    def test_valid_csv_loads_on_init(self, tmp_path):
+        csv_path = _write_csv(
+            tmp_path / "norm.csv",
+            [("0", "0.0"), ("100", "1.0")],
+        )
+        qc = QualityClassifier("quality.onnx", str(csv_path), coord=object())
+        assert qc._normalize_quality_to_percentile(0.25) == pytest.approx(0.25)
+
+    def test_omitted_path_still_skips_tables(self):
+        qc = QualityClassifier("quality.onnx", None, coord=object())
+        assert qc._norm_qualities is None
+        assert qc._normalize_quality_to_percentile(0.4) == pytest.approx(0.4)


### PR DESCRIPTION
## Summary

`QualityClassifier.__init__` wrapped `_load_normalization_data` in `except Exception` and cleared the percentile tables. `classify` then returned the raw model score instead of a 0–1 percentile, so star ratings were wrong with no error.

A given CSV path must now load at least one valid `percentile`/`quality` row or raise. Missing file, header-only CSV, garbage rows, Git LFS pointer text, and percentiles outside `[0, 100]` all fail instead of silently running unnormalized. Passing `None` still skips the tables (unit tests / validation skip).

Out of scope: `ratings.py` thresholds, pipeline rewrite, ONNX session errors (#127).

## Test plan

- `pytest analyzer/tests/unit/test_quality_norm_csv.py analyzer/tests/unit/test_quality_session_errors.py -q`
- 16 passed (11 new load/init cases plus neighbor session-error tests)
- Arrange: missing / empty / LFS-pointer / out-of-range / valid mini CSV
- Act: `_load_normalization_data` and `__init__` (ONNX session stubbed)
- Assert: missing and empty raise; valid CSV maps 0.5 quality to 0.5 percentile; omitted path still skips tables; percentiles outside `[0, 100]` are skipped

Reviewed on https://github.com/wolfgangh/ProjectKestrel/pull/32
