### PR TITLE
fix(io): fsync cloud jobs and folder-state JSON before replace

### DIFF
--- a/analyzer/cloud_folder_state.py
+++ b/analyzer/cloud_folder_state.py
@@ -21,10 +21,10 @@ Bootstrap reconciliation reads BOTH this file (folder truth) and the legacy
 set used to compute "packs to download". New merges write here; the legacy
 field is left untouched but no longer the dedup driver.
 
-Atomic-write pattern mirrors `settings_utils.py` and `cloud_jobs_store.py`:
-write to tempfile, then `os.replace` over the canonical file. A per-folder
-in-process lock serializes saves because the live job's `_on_pack_merged`
-callback and the resume worker can both write concurrently.
+Atomic-write pattern mirrors `settings_utils.py` / `_to_csv_atomic`:
+write to tempfile, flush+fsync, then `os.replace` over the canonical file.
+A per-folder in-process lock serializes saves because the live job's
+`_on_pack_merged` callback and the resume worker can both write concurrently.
 """
 
 from __future__ import annotations
@@ -96,6 +96,15 @@ def _write_atomic(folder: Path, data: dict) -> None:
     try:
         with os.fdopen(fd, "w", encoding="utf-8") as f:
             json.dump(data, f, indent=2, sort_keys=False)
+            # flush() errors (ENOSPC, EIO) must propagate: a partial temp
+            # file must not be os.replace'd over a good destination.
+            f.flush()
+            try:
+                os.fsync(f.fileno())
+            except OSError:
+                # fsync can legitimately fail on some network filesystems;
+                # the replace below still gives readers an all-or-nothing view.
+                pass
         os.replace(tmp_path, final_path)
     except Exception:
         try:

--- a/analyzer/cloud_jobs_store.py
+++ b/analyzer/cloud_jobs_store.py
@@ -20,10 +20,10 @@ Schema (JSON):
       ]
     }
 
-Atomic-write pattern mirrors ``settings_utils.py``: write to tempfile, then
-``os.replace`` over the canonical file. A single in-process re-entrant lock
-serializes saves because the JS bridge, the per-job background download
-thread, and startup all write concurrently.
+Atomic-write pattern mirrors ``settings_utils.py`` / ``_to_csv_atomic``:
+write to tempfile, flush+fsync, then ``os.replace`` over the canonical file.
+A single in-process re-entrant lock serializes saves because the JS bridge,
+the per-job background download thread, and startup all write concurrently.
 """
 
 from __future__ import annotations
@@ -167,6 +167,15 @@ def _write_atomic(data: dict) -> None:
     try:
         with os.fdopen(fd, "w", encoding="utf-8") as f:
             json.dump(data, f, indent=2, sort_keys=False)
+            # flush() errors (ENOSPC, EIO) must propagate: a partial temp
+            # file must not be os.replace'd over a good destination.
+            f.flush()
+            try:
+                os.fsync(f.fileno())
+            except OSError:
+                # fsync can legitimately fail on some network filesystems;
+                # the replace below still gives readers an all-or-nothing view.
+                pass
         os.replace(tmp_path, final_path)
     except Exception:
         try:

--- a/analyzer/tests/unit/test_jobs_folder_state_fsync.py
+++ b/analyzer/tests/unit/test_jobs_folder_state_fsync.py
@@ -1,0 +1,169 @@
+"""cloud_jobs.json and kestrel_cloudcompute.json must fsync before replace.
+
+Both stores wrote a tempfile and ``os.replace``'d it without flush/fsync,
+so a crash after replace could leave an empty or half-written ledger. Match
+``_to_csv_atomic``: ``flush()`` errors abort the replace; ``fsync`` OSError
+on network FS still replaces.
+"""
+
+from __future__ import annotations
+
+import errno
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+import cloud_folder_state
+import cloud_jobs_store
+
+
+pytestmark = pytest.mark.unit
+
+
+class _FlushBoom:
+    """Delegates to the real fdopen file; flush is not assignable on TextIOWrapper."""
+
+    def __init__(self, real):
+        self._real = real
+
+    def write(self, *a, **k):
+        return self._real.write(*a, **k)
+
+    def flush(self):
+        raise OSError(errno.ENOSPC, "No space left on device")
+
+    def fileno(self):
+        return self._real.fileno()
+
+    def close(self):
+        return self._real.close()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        self.close()
+        return False
+
+
+def _wrap_fdopen(real_fdopen):
+    def wrapping_fdopen(*a, **k):
+        return _FlushBoom(real_fdopen(*a, **k))
+
+    return wrapping_fdopen
+
+
+def _tmp_leftovers(directory: Path) -> list[str]:
+    return [p.name for p in directory.iterdir() if p.name.endswith(".tmp")]
+
+
+def _job(job_id: str = "job-1", folder: str = "/photos/trip") -> dict:
+    return {
+        "jobId": job_id,
+        "folderPath": folder,
+        "status": "downloading",
+        "ownerId": "owner-1",
+    }
+
+
+class TestCloudJobsFsync:
+    @pytest.fixture
+    def store_dir(self, tmp_path, monkeypatch):
+        data_dir = tmp_path / "userdata"
+        data_dir.mkdir()
+        monkeypatch.setattr(cloud_jobs_store, "_user_data_dir", lambda: str(data_dir))
+        return data_dir
+
+    def test_save_calls_fsync_before_replace(self, store_dir, monkeypatch):
+        seen: list[int] = []
+        real = cloud_jobs_store.os.fsync
+
+        def spy(fd):
+            seen.append(fd)
+            return real(fd)
+
+        monkeypatch.setattr(cloud_jobs_store.os, "fsync", spy)
+        cloud_jobs_store.save_jobs([_job()])
+
+        dest = store_dir / "cloud_jobs.json"
+        assert dest.is_file()
+        assert json.loads(dest.read_text(encoding="utf-8"))["jobs"][0]["jobId"] == "job-1"
+        assert seen, "save_jobs replaced without fsync"
+        assert _tmp_leftovers(store_dir) == []
+
+    def test_flush_error_leaves_existing_jobs_file(self, store_dir, monkeypatch):
+        cloud_jobs_store.save_jobs([_job("job-old")])
+        dest = store_dir / "cloud_jobs.json"
+        original = dest.read_bytes()
+
+        monkeypatch.setattr(
+            cloud_jobs_store.os, "fdopen", _wrap_fdopen(cloud_jobs_store.os.fdopen)
+        )
+        with pytest.raises(OSError, match="No space left on device"):
+            cloud_jobs_store.save_jobs([_job("job-new")])
+
+        assert dest.read_bytes() == original
+        assert _tmp_leftovers(store_dir) == []
+
+    def test_fsync_error_still_replaces(self, store_dir, monkeypatch):
+        def boom(_fd):
+            raise OSError(errno.EINVAL, "Operation not supported")
+
+        monkeypatch.setattr(cloud_jobs_store.os, "fsync", boom)
+        cloud_jobs_store.save_jobs([_job("job-netfs")])
+
+        dest = store_dir / "cloud_jobs.json"
+        assert json.loads(dest.read_text(encoding="utf-8"))["jobs"][0]["jobId"] == "job-netfs"
+        assert _tmp_leftovers(store_dir) == []
+
+
+class TestCloudFolderStateFsync:
+    def test_mark_pack_calls_fsync_before_replace(self, tmp_path, monkeypatch):
+        seen: list[int] = []
+        real = cloud_folder_state.os.fsync
+
+        def spy(fd):
+            seen.append(fd)
+            return real(fd)
+
+        monkeypatch.setattr(cloud_folder_state.os, "fsync", spy)
+        cloud_folder_state.mark_pack_merged(tmp_path, "job-1", "pack-001.zip")
+
+        dest = tmp_path / ".kestrel" / "kestrel_cloudcompute.json"
+        assert dest.is_file()
+        data = json.loads(dest.read_text(encoding="utf-8"))
+        assert data["jobs"]["job-1"]["mergedPacks"] == ["pack-001.zip"]
+        assert seen, "mark_pack_merged replaced without fsync"
+        assert _tmp_leftovers(tmp_path / ".kestrel") == []
+
+    def test_flush_error_leaves_existing_folder_state(self, tmp_path, monkeypatch):
+        cloud_folder_state.mark_pack_merged(tmp_path, "job-1", "pack-old.zip")
+        dest = tmp_path / ".kestrel" / "kestrel_cloudcompute.json"
+        original = dest.read_bytes()
+
+        monkeypatch.setattr(
+            cloud_folder_state.os,
+            "fdopen",
+            _wrap_fdopen(cloud_folder_state.os.fdopen),
+        )
+        with pytest.raises(OSError, match="No space left on device"):
+            cloud_folder_state.mark_pack_merged(tmp_path, "job-1", "pack-new.zip")
+
+        assert dest.read_bytes() == original
+        assert _tmp_leftovers(tmp_path / ".kestrel") == []
+
+    def test_fsync_error_still_replaces(self, tmp_path, monkeypatch):
+        def boom(_fd):
+            raise OSError(errno.EINVAL, "Operation not supported")
+
+        monkeypatch.setattr(cloud_folder_state.os, "fsync", boom)
+        cloud_folder_state.mark_pack_merged(tmp_path, "job-1", "pack-netfs.zip")
+
+        dest = tmp_path / ".kestrel" / "kestrel_cloudcompute.json"
+        data = json.loads(dest.read_text(encoding="utf-8"))
+        assert data["jobs"]["job-1"]["mergedPacks"] == ["pack-netfs.zip"]
+        assert _tmp_leftovers(tmp_path / ".kestrel") == []


### PR DESCRIPTION
## Summary

`cloud_jobs.json` and `kestrel_cloudcompute.json` wrote a tempfile then `os.replace`'d it without flush/fsync, so a crash after replace could leave an empty or half-written ledger.

Both `_write_atomic` paths now match `_to_csv_atomic`: `flush()` errors (ENOSPC, EIO) abort the replace and leave the previous file; `fsync` `OSError` on network filesystems still replaces.

Out of scope: Windows `os.replace` lock retry (WP-18), corrupt-file `.corrupt` renames, other JSON writers, `queue.js` caches.

## Test plan

- `pytest analyzer/tests/unit/test_jobs_folder_state_fsync.py analyzer/tests/unit/test_cloud_compute_relocate.py analyzer/tests/unit/test_cloud_compute_list_pending_readonly.py -q`
- 28 passed (6 new plus neighbor cloud-jobs tests)
- Arrange: existing jobs/folder-state JSON; `flush` raises ENOSPC; `fsync` raises EINVAL
- Act: `save_jobs` / `mark_pack_merged`
- Assert: dest is never replaced on flush failure; fsync is called before replace; fsync OSError still lands the write; no leftover `.tmp`

Reviewed on https://github.com/wolfgangh/ProjectKestrel/pull/34
