### PR TITLE
fix(ui): LRU-cap and revoke queue.js thumbnail blob URLs

### DIFF
--- a/analyzer/js/queue.js
+++ b/analyzer/js/queue.js
@@ -20,7 +20,9 @@
     // ETA smoothing: exponential moving average to prevent wild per-image swings
     let _etaSmoothed = null;   // smoothed secs/image
     let _etaLastPath = null;   // reset EMA when folder changes
-    const _thumbCache = new Map();    // relPath+'|'+rootPath → dataUrl (avoids reload flash)
+    // relPath+'|'+rootPath → blob: URL. BlobUrlCache (blob-zoom.js) LRU-caps
+    // and revokes on eviction/clear; a plain Map leaked createObjectURL bytes.
+    const _thumbCache = new BlobUrlCache();
     let _liveAnalysisDlgOpen = false;
     let _liveLastThumbKey = '';
     let _liveLastOverlayKey = '';
@@ -375,20 +377,8 @@
       body.appendChild(frag);
 
       // Async: load thumbnails for any img[data-thumb-rel] elements (cache avoids reload flash)
-      body.querySelectorAll('img[data-thumb-rel]').forEach(async img => {
-        try {
-          const rel = img.dataset.thumbRel || '';
-          const root = img.dataset.thumbRoot || '';
-          const key = rel + '|' + root;
-          const isLive = rel.indexOf('__live_') >= 0;
-          if (!isLive && _thumbCache.has(key)) { img.src = _thumbCache.get(key); return; }
-          const result = await window.pywebview.api.read_image_file(rel, root);
-          if (result && result.success && result.data) {
-            const url = _base64ToBlobUrl(result.data, result.mime);
-            if (!isLive) _thumbCache.set(key, url);
-            img.src = url;
-          }
-        } catch (_) { }
+      body.querySelectorAll('img[data-thumb-rel]').forEach(img => {
+        _loadImg(img, img.dataset.thumbRel || '', img.dataset.thumbRoot || '');
       });
 
       // Check if any folder newly finished — refresh tree + auto-reload CSV data
@@ -643,7 +633,9 @@
 
     /**
      * Load an image by relative path + root into an <img> element, using _thumbCache.
-     * Only issues a network/IPC call on cache miss.
+     * Only issues a network/IPC call on cache miss. Re-checks the cache after
+     * the await so concurrent loads for the same key reuse one blob: URL
+     * (BlobUrlCache.set does not revoke an overwritten value).
      */
     async function _loadImg(imgEl, relPath, rootPath) {
       if (!relPath || !rootPath || !hasPywebviewApi) return;
@@ -653,6 +645,7 @@
       try {
         const r = await window.pywebview.api.read_image_file(relPath, rootPath);
         if (r && r.success && r.data) {
+          if (!isLive && _thumbCache.has(key)) { imgEl.src = _thumbCache.get(key); return; }
           const url = _base64ToBlobUrl(r.data, r.mime);
           if (!isLive) _thumbCache.set(key, url);
           imgEl.src = url;
@@ -1178,6 +1171,7 @@
 
       // Also clear in-memory caches so the UI can't show stale previews.
       try { blobUrlCache.clear(); } catch (_) {}
+      try { _thumbCache.clear(); } catch (_) {}
       try { sceneRawCache.clear(); } catch (_) {}
       try { sceneRawLoading.clear(); } catch (_) {}
 

--- a/analyzer/tests/unit/test_queue_thumbcache.py
+++ b/analyzer/tests/unit/test_queue_thumbcache.py
@@ -1,0 +1,87 @@
+"""queue.js _thumbCache must LRU-cap and revoke blob: URLs like #119.
+
+A plain Map stored ``createObjectURL`` results with no cap and no
+``revokeObjectURL``. ``BlobUrlCache`` in blob-zoom.js already does both;
+queue thumbs must use that class, clear it on folder-cache cleanup, and
+not create a second URL when a concurrent load won the race.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+_ANALYZER = Path(__file__).resolve().parents[2]
+_QUEUE_JS = _ANALYZER / "js" / "queue.js"
+_BLOB_ZOOM_JS = _ANALYZER / "js" / "blob-zoom.js"
+_VISUALIZER_HTML = _ANALYZER / "visualizer.html"
+
+
+@pytest.fixture(scope="module")
+def queue_js() -> str:
+    return _QUEUE_JS.read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def blob_zoom_js() -> str:
+    return _BLOB_ZOOM_JS.read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def visualizer_html() -> str:
+    return _VISUALIZER_HTML.read_text(encoding="utf-8")
+
+
+def test_thumb_cache_is_blob_url_cache_not_a_plain_map(queue_js: str, blob_zoom_js: str):
+    assert re.search(r"const _thumbCache\s*=\s*new BlobUrlCache\s*\(\s*\)", queue_js), (
+        "_thumbCache must be a BlobUrlCache so eviction/clear revoke blob: URLs"
+    )
+    assert re.search(r"const _thumbCache\s*=\s*new Map\s*\(", queue_js) is None
+    assert "class BlobUrlCache extends Map" in blob_zoom_js
+    assert "URL.revokeObjectURL" in blob_zoom_js
+    assert "BLOB_URL_CACHE_MAX" in blob_zoom_js
+
+
+def test_blob_zoom_loads_before_queue(visualizer_html: str):
+    blob_i = visualizer_html.find("js/blob-zoom.js")
+    queue_i = visualizer_html.find("js/queue.js")
+    assert blob_i != -1 and queue_i != -1
+    assert blob_i < queue_i, "BlobUrlCache is declared in blob-zoom.js; queue.js must load after"
+
+
+def test_cleanup_clears_thumb_cache(queue_js: str):
+    start = queue_js.find("async function _cleanupCullingCachesForPaths")
+    assert start != -1
+    nxt = queue_js.find("\n    async function ", start + 1)
+    if nxt == -1:
+        nxt = queue_js.find("\n    function ", start + 1)
+    body = queue_js[start : nxt if nxt != -1 else None]
+    assert "_thumbCache.clear()" in body, (
+        "folder uncheck/app close must revoke queue thumbs, not only blobUrlCache"
+    )
+
+
+def test_load_img_is_the_only_thumb_blob_url_creator(queue_js: str):
+    assert queue_js.count("_base64ToBlobUrl") == 1
+    load_start = queue_js.find("async function _loadImg")
+    assert load_start != -1
+    nxt = queue_js.find("\n    function ", load_start + 1)
+    load_fn = queue_js[load_start : nxt if nxt != -1 else None]
+    assert "_base64ToBlobUrl" in load_fn
+    assert "_loadImg(img, img.dataset.thumbRel" in queue_js
+
+
+def test_load_img_rechecks_cache_after_await(queue_js: str):
+    load_start = queue_js.find("async function _loadImg")
+    nxt = queue_js.find("\n    function ", load_start + 1)
+    load_fn = queue_js[load_start : nxt if nxt != -1 else None]
+    await_i = load_fn.find("await window.pywebview.api.read_image_file")
+    assert await_i != -1
+    after = load_fn[await_i:]
+    assert "_thumbCache.has(key)" in after, (
+        "concurrent loads must reuse the first blob: URL; BlobUrlCache.set does not revoke overwrites"
+    )


### PR DESCRIPTION
## Summary

Queue panel thumbs stored `createObjectURL` results in a plain `Map` with no cap and no `revokeObjectURL`. `#119` only covered `blob-zoom.js`.

`_thumbCache` is now a `BlobUrlCache` (LRU 512, revoke on eviction/clear). Panel loads go through `_loadImg`, which re-checks the cache after `read_image_file` so concurrent loads reuse one blob URL. `_cleanupCullingCachesForPaths` clears `_thumbCache` with the other in-memory caches.

Out of scope: `scene-zoom.js` `sceneRawCache`, `culling.html` caches, `__live_` thumbs (still uncached by design).

## Test plan

- `pytest analyzer/tests/unit/test_queue_thumbcache.py analyzer/tests/unit/test_raw_warn_banner.py analyzer/tests/test_security_visualizer_js_xss.py -q`
- 21 passed (5 new plus neighbor JS/source tests)
- Arrange: source of `queue.js` / `blob-zoom.js` / `visualizer.html`
- Act: source-level assertions
- Assert: `_thumbCache` is `new BlobUrlCache()` not `new Map()`; blob-zoom loads before queue; cleanup calls `_thumbCache.clear()`; `_loadImg` is the only `_base64ToBlobUrl` site and re-checks after await

Reviewed on https://github.com/wolfgangh/ProjectKestrel/pull/35
