### PR TITLE
fix(ui): LRU-cap and revoke scene RAW preview blob URLs

### DIFF
--- a/analyzer/js/scene-zoom.js
+++ b/analyzer/js/scene-zoom.js
@@ -4,7 +4,10 @@
     let sceneZoomThumbEl = null;
     let sceneZoomScale = 5;   // adjustable via scroll or slider
     let zoomLastX = 0, zoomLastY = 0; // last mouse pos for slider re-apply
-    const sceneRawCache = new Map();   // unique row key -> blob URL
+    // unique row key -> blob URL of a full RAW preview JPEG. BlobUrlCache
+    // (blob-zoom.js) LRU-caps and revokes on eviction/clear; a plain Map leaked
+    // createObjectURL bytes for every zoomed image in the session.
+    const sceneRawCache = new BlobUrlCache();
     const sceneRawLoading = new Set(); // (rootPath|filename) currently being fetched
 
     function getRowExposurePipelineMode(row) {
@@ -391,8 +394,14 @@
           console.info('[raw-debug][scene]', row.filename, res.debug);
         }
         if (res && res.success && res.data) {
-          const url = _base64ToBlobUrl(res.data, res.mime || 'image/jpeg');
-          sceneRawCache.set(key, url);
+          // Re-check after await: a concurrent load (or a cache that was filled
+          // while we decoded) must reuse one blob: URL. BlobUrlCache.set does
+          // not revoke an overwritten value.
+          let url = sceneRawCache.has(key) ? sceneRawCache.get(key) : null;
+          if (!url) {
+            url = _base64ToBlobUrl(res.data, res.mime || 'image/jpeg');
+            sceneRawCache.set(key, url);
+          }
           // Upgrade preview if this row is still the active zoom row
           if (sceneZoomActive && sceneZoomRow === row) {
             const box = el('#previewBox');

--- a/analyzer/tests/unit/test_scene_rawcache.py
+++ b/analyzer/tests/unit/test_scene_rawcache.py
@@ -1,0 +1,75 @@
+"""scene-zoom.js sceneRawCache: LRU + revoke via BlobUrlCache (WP-23)."""
+
+from pathlib import Path
+
+import pytest
+
+ANALYZER = Path(__file__).resolve().parents[2]
+SCENE_ZOOM = ANALYZER / "js" / "scene-zoom.js"
+BLOB_ZOOM = ANALYZER / "js" / "blob-zoom.js"
+QUEUE_JS = ANALYZER / "js" / "queue.js"
+VISUALIZER = ANALYZER / "visualizer.html"
+
+
+def _scene() -> str:
+    return SCENE_ZOOM.read_text(encoding="utf-8")
+
+
+def _blob() -> str:
+    return BLOB_ZOOM.read_text(encoding="utf-8")
+
+
+def _queue() -> str:
+    return QUEUE_JS.read_text(encoding="utf-8")
+
+
+def _visualizer() -> str:
+    return VISUALIZER.read_text(encoding="utf-8")
+
+
+@pytest.mark.unit
+def test_scene_raw_cache_is_blob_url_cache_not_a_plain_map():
+    scene = _scene()
+    blob = _blob()
+    assert "const sceneRawCache = new BlobUrlCache();" in scene
+    assert "const sceneRawCache = new Map()" not in scene
+    assert "class BlobUrlCache" in blob
+    assert "URL.revokeObjectURL" in blob
+    assert "BLOB_URL_CACHE_MAX" in blob
+
+
+@pytest.mark.unit
+def test_blob_zoom_loads_before_scene_zoom():
+    html = _visualizer()
+    blob_i = html.find('src="js/blob-zoom.js"')
+    scene_i = html.find('src="js/scene-zoom.js"')
+    assert blob_i != -1 and scene_i != -1
+    assert blob_i < scene_i
+
+
+@pytest.mark.unit
+def test_cleanup_still_clears_scene_raw_cache():
+    src = _queue()
+    start = src.find("function _cleanupCullingCachesForPaths")
+    assert start != -1
+    snippet = src[start : start + 1200]
+    assert "sceneRawCache.clear()" in snippet
+
+
+@pytest.mark.unit
+def test_load_scene_raw_rechecks_cache_after_await():
+    src = _scene()
+    start = src.find("async function loadSceneRawAsync")
+    end = src.find("\nasync function ", start + 1)
+    if end == -1:
+        end = src.find("\nfunction ", start + 1)
+    body = src[start:end]
+    await_i = body.find("await window.pywebview.api.read_raw_full")
+    has_i = body.find("sceneRawCache.has(key)")
+    blob_i = body.find("_base64ToBlobUrl")
+    assert await_i != -1
+    assert has_i != -1
+    assert blob_i != -1
+    assert await_i < has_i < blob_i
+    assert "if (!url)" in body
+    assert "sceneRawCache.set(key, url)" in body


### PR DESCRIPTION
## Summary

Scene-dialog RAW zoom stored `createObjectURL` results from `read_raw_full` in a plain `Map` with no cap and no `revokeObjectURL`. `#119` / WP-22 only covered `blob-zoom.js` / `queue.js`.

`sceneRawCache` is now a `BlobUrlCache` (LRU 512, revoke on eviction/clear). `loadSceneRawAsync` re-checks the cache after `read_raw_full` so concurrent loads reuse one blob URL. `_cleanupCullingCachesForPaths` already called `sceneRawCache.clear()`; that now revokes.

Out of scope: `culling.html` caches, `queue.js` `_thumbCache` (WP-22), `__live_` thumbs.

## Test plan

- `pytest analyzer/tests/unit/test_scene_rawcache.py analyzer/tests/test_security_visualizer_js_xss.py -q`
- 7 passed (4 new plus XSS neighbor)
- Arrange: source of `scene-zoom.js` / `blob-zoom.js` / `visualizer.html` / `queue.js`
- Act: source-level assertions
- Assert: `sceneRawCache` is `new BlobUrlCache()` not `new Map()`; blob-zoom loads before scene-zoom; cleanup still calls `sceneRawCache.clear()`; `loadSceneRawAsync` re-checks after await before `_base64ToBlobUrl`

Reviewed on https://github.com/wolfgangh/ProjectKestrel/pull/36
