### PR TITLE
fix(culling): LRU-cap preview caches and drop stale UI loads

### DIFF
--- a/analyzer/culling.html
+++ b/analyzer/culling.html
@@ -1361,7 +1361,46 @@
     let header = [];
     let scenes = [];            // [{id, images[], species, ...}]
     let cullingState = new Map(); // filename -> 'accept' | 'reject'
-    let blobUrlCache = new Map();
+    // Same LRU+revoke contract as blob-zoom.js. This page does not load that
+    // file, so the helper lives here. A plain Map of data:/blob: URLs grew
+    // without bound for every thumb and RAW preview in the culling window.
+    const BLOB_URL_CACHE_MAX = 512;
+    function _revokeBlobUrl(url) {
+      if (typeof url === 'string' && url.startsWith('blob:')) {
+        try { URL.revokeObjectURL(url); } catch (_) { /* already revoked */ }
+      }
+    }
+    function _base64ToBlobUrl(b64, mime) {
+      const bin = atob(b64);
+      const buf = new Uint8Array(bin.length);
+      for (let i = 0; i < bin.length; i++) buf[i] = bin.charCodeAt(i);
+      return URL.createObjectURL(new Blob([buf], { type: mime || 'image/jpeg' }));
+    }
+    class BlobUrlCache extends Map {
+      get(key) {
+        if (!super.has(key)) return undefined;
+        const val = super.get(key);
+        super.delete(key);
+        super.set(key, val);
+        return val;
+      }
+      set(key, val) {
+        if (super.has(key)) super.delete(key);
+        super.set(key, val);
+        while (super.size > BLOB_URL_CACHE_MAX) {
+          const oldestKey = super.keys().next().value;
+          _revokeBlobUrl(super.get(oldestKey));
+          super.delete(oldestKey);
+        }
+        return this;
+      }
+      clear() {
+        for (const url of super.values()) _revokeBlobUrl(url);
+        super.clear();
+      }
+    }
+    let blobUrlCache = new BlobUrlCache();
+    let _previewGen = 0;
     let _normalizedRatings = {};   // filename -> auto rating from apply_normalization()
     let _scenedata = { version: '2.0', image_ratings: {}, scenes: {} };
     let _needsLegacyCullOriginUpgrade = false;
@@ -1438,7 +1477,9 @@
       try {
         const res = await window.pywebview.api.read_image_file(relPath, root);
         if (res && res.success && res.data) {
-          const url = `data:${res.mime || 'image/jpeg'};base64,${res.data}`;
+          // Re-check after await: a concurrent load may have filled the cache.
+          if (blobUrlCache.has(key)) return blobUrlCache.get(key);
+          const url = _base64ToBlobUrl(res.data, res.mime || 'image/jpeg');
           blobUrlCache.set(key, url);
           return url;
         }
@@ -1461,7 +1502,11 @@
 
     function lazyLoadImg(img, resolverFn) {
       img._lazyLoader = async () => {
+        // Skip stale loads. renderScene / renderAllScenes replace innerHTML and
+        // detach the old <img> while this loader may still be awaiting IPC.
+        if (!img.isConnected) return;
         const url = await resolverFn();
+        if (!img.isConnected) return;
         if (url) img.src = url;
       };
       _lazyObserver.observe(img);
@@ -2388,6 +2433,7 @@
     // ---- Update preview pane ----
     async function updatePreview(row) {
       if (zoomActive) return; // don't interrupt an active zoom session
+      const gen = ++_previewGen;
       previewRow = row;
       const cropState = getRowActiveCropState(row);
       const activeCrop = cropState.activeCrop;
@@ -2402,6 +2448,7 @@
       const exportBox = el('#previewExport');
       exportBox.innerHTML = '<span class="muted">Loading…</span>';
       const exportUrl = await getBlobUrl(row.export_path, rootPath);
+      if (gen !== _previewGen) return;
       if (exportUrl) {
         exportBox.innerHTML = '';
         const img = document.createElement('img');
@@ -2415,6 +2462,7 @@
       const cropBox = el('#previewCrop');
       cropBox.innerHTML = '<span class="muted">Loading…</span>';
       const cropUrl = await getBlobUrl(activeCropPath, rootPath);
+      if (gen !== _previewGen) return;
       if (cropUrl) {
         cropBox.innerHTML = '';
         const img = document.createElement('img');
@@ -2810,7 +2858,15 @@
           const skipNote = skippedMains.length
             ? `, ${skippedMains.length} skipped`
             : '';
-          setStep('move', 'done', `${movedMains.length} reject${movedMains.length === 1 ? '' : 's'} moved${skipNote}`);
+          // success can be true while all_moved is false (partial batch).
+          // Callers that gate only on success would mark this done; the flag
+          // is what distinguishes a complete move from a name-conflict skip.
+          if (moveRes.all_moved === false) {
+            anyFailed = true;
+            setStep('move', 'failed', `${movedMains.length} reject${movedMains.length === 1 ? '' : 's'} moved${skipNote}`);
+          } else {
+            setStep('move', 'done', `${movedMains.length} reject${movedMains.length === 1 ? '' : 's'} moved${skipNote}`);
+          }
 
           const movedMainSet = new Set(movedMains);
           rows = rows.filter(r => !movedMainSet.has(r.filename));
@@ -3143,7 +3199,7 @@
     let zoomActive = false;
     let zoomRow = null;
     let previewRow = null;       // row currently shown in the preview pane
-    let rawCache = new Map();    // filename -> base64 data URL
+    let rawCache = new BlobUrlCache(); // cacheKey -> blob URL of a full RAW preview
     let rawLoading = new Set();  // filename currently loading
 
     function getRowExposurePipelineMode(row) {
@@ -3297,8 +3353,11 @@
           meterScale
         );
         if (res && res.success && res.data) {
-          const url = `data:image/jpeg;base64,${res.data}`;
-          rawCache.set(cacheKey, url);
+          let url = rawCache.has(cacheKey) ? rawCache.get(cacheKey) : null;
+          if (!url) {
+            url = _base64ToBlobUrl(res.data, res.mime || 'image/jpeg');
+            rawCache.set(cacheKey, url);
+          }
           // If still zooming on this row, swap to the high-res source
           if (zoomActive && zoomRow === row) {
             const img = el('#previewExport')?.querySelector('img');

--- a/analyzer/culling.html
+++ b/analyzer/culling.html
@@ -2765,6 +2765,7 @@
       el('#statusLabel').textContent = 'Processing\u2026';
 
       let anyFailed = false;
+      let xmpFailed = false;
       try {
         // 1. Optional confirm auto-categorizations
         if (doPromoteVerified) {
@@ -2807,6 +2808,7 @@
           if (!firstXmpRes.success) {
             setStep('xmp', 'failed', firstXmpRes.error || '');
             anyFailed = true;
+            xmpFailed = true;
           } else if (firstXmpRes.skipped_conflicts && firstXmpRes.skipped_conflicts.length > 0) {
             // Pause and ask the user about conflicts
             setStep('xmp', 'pending', `${firstXmpRes.skipped_conflicts.length} conflict${firstXmpRes.skipped_conflicts.length === 1 ? '' : 's'} detected`);
@@ -2821,6 +2823,7 @@
               if (!secondXmpRes.success) {
                 setStep('xmp', 'failed', secondXmpRes.error || '');
                 anyFailed = true;
+                xmpFailed = true;
               } else {
                 setStep('xmp', 'done', `${secondXmpRes.written} file${secondXmpRes.written === 1 ? '' : 's'} written${embedSuffix(secondXmpRes)}`);
               }
@@ -2899,8 +2902,9 @@
         el('#dlgProgressIcon').textContent = anyFailed ? '\u26A0\uFE0F' : '\u2705';
         el('#dlgProgressTitle').textContent = anyFailed ? 'Completed with warnings' : 'Complete!';
         const parts = [];
-        if (doXmp && !anyFailed)  parts.push('XMP files written');
-        if (doXmp &&  anyFailed)  parts.push('XMP had errors \u2014 check above');
+        if (doXmp && !xmpFailed)  parts.push('XMP files written');
+        if (doXmp &&  xmpFailed)  parts.push('XMP had errors \u2014 check above');
+        if (doMove && moveRes && moveRes.all_moved === false) parts.push('Some rejects were skipped');
         if (doMove && moveCompleted) parts.push('Undo available via the bottom bar');
         el('#dlgProgressSubtitle').textContent = parts.join(' \u00b7 ');
         el('#dlgProgressActions').style.display = 'flex';

--- a/analyzer/tests/unit/test_culling_html_caches.py
+++ b/analyzer/tests/unit/test_culling_html_caches.py
@@ -1,0 +1,101 @@
+"""culling.html: LRU caches, detached thumbs, stale preview, all_moved (WP-24)."""
+
+from pathlib import Path
+
+import pytest
+
+ANALYZER = Path(__file__).resolve().parents[2]
+CULLING = ANALYZER / "culling.html"
+
+
+def _html() -> str:
+    return CULLING.read_text(encoding="utf-8")
+
+
+def _fn_body(src: str, header: str) -> str:
+    start = src.find(header)
+    assert start != -1, f"missing {header!r}"
+    nxt = src.find("\n    function ", start + len(header))
+    async_nxt = src.find("\n    async function ", start + len(header))
+    candidates = [i for i in (nxt, async_nxt) if i != -1]
+    end = min(candidates) if candidates else len(src)
+    return src[start:end]
+
+
+@pytest.mark.unit
+def test_culling_blob_and_raw_caches_are_blob_url_cache_not_plain_maps():
+    src = _html()
+    assert "let blobUrlCache = new BlobUrlCache();" in src
+    assert "let rawCache = new BlobUrlCache();" in src
+    assert "let blobUrlCache = new Map()" not in src
+    assert "let rawCache = new Map()" not in src
+    assert "class BlobUrlCache" in src
+    assert "URL.revokeObjectURL" in src
+    assert "BLOB_URL_CACHE_MAX" in src
+
+
+@pytest.mark.unit
+def test_get_blob_url_uses_blob_urls_and_rechecks_after_await():
+    body = _fn_body(_html(), "async function getBlobUrl")
+    await_i = body.find("await window.pywebview.api.read_image_file")
+    has_i = body.find("blobUrlCache.has(key)")
+    blob_i = body.find("_base64ToBlobUrl")
+    assert await_i != -1
+    assert has_i != -1
+    assert blob_i != -1
+    assert "data:" not in body or "_base64ToBlobUrl" in body
+    assert await_i < blob_i
+    # Post-await recheck sits between the IPC and createObjectURL.
+    assert body.find("blobUrlCache.has(key)", await_i) != -1
+    assert body.find("blobUrlCache.has(key)", await_i) < blob_i
+
+
+@pytest.mark.unit
+def test_lazy_load_img_skips_detached_elements():
+    body = _fn_body(_html(), "function lazyLoadImg")
+    await_i = body.find("await resolverFn()")
+    assert await_i != -1
+    first = body.find("if (!img.isConnected) return")
+    second = body.find("if (!img.isConnected) return", first + 1)
+    assert first != -1
+    assert second != -1
+    assert first < await_i < second
+
+
+@pytest.mark.unit
+def test_update_preview_drops_stale_generations():
+    body = _fn_body(_html(), "async function updatePreview")
+    assert "_previewGen" in body
+    assert "++_previewGen" in body or "_previewGen++" in body
+    first_await = body.find("await getBlobUrl")
+    assert first_await != -1
+    guard = body.find("gen !== _previewGen", first_await)
+    assert guard != -1
+    second_await = body.find("await getBlobUrl", first_await + 1)
+    assert second_await != -1
+    assert body.find("gen !== _previewGen", second_await) != -1
+
+
+@pytest.mark.unit
+def test_load_raw_rechecks_cache_after_await():
+    body = _fn_body(_html(), "async function loadRawAsync")
+    await_i = body.find("await window.pywebview.api.read_raw_full")
+    has_i = body.find("rawCache.has(cacheKey)", await_i)
+    blob_i = body.find("_base64ToBlobUrl")
+    assert await_i != -1
+    assert has_i != -1
+    assert blob_i != -1
+    assert await_i < has_i < blob_i
+    assert "data:image/jpeg;base64" not in body
+
+
+@pytest.mark.unit
+def test_move_rejects_reads_all_moved():
+    src = _html()
+    start = src.find("window.pywebview.api.move_rejects_to_folder")
+    end = src.find("async function undoMove")
+    assert start != -1
+    assert end != -1
+    block = src[start:end]
+    assert "moveRes.all_moved" in block
+    assert "anyFailed = true" in block

--- a/analyzer/tests/unit/test_culling_html_caches.py
+++ b/analyzer/tests/unit/test_culling_html_caches.py
@@ -99,3 +99,20 @@ def test_move_rejects_reads_all_moved():
     block = src[start:end]
     assert "moveRes.all_moved" in block
     assert "anyFailed = true" in block
+
+
+@pytest.mark.unit
+def test_partial_move_subtitle_does_not_blame_xmp():
+    src = _html()
+    start = src.find("async function executeActions")
+    if start == -1:
+        start = src.find("function executeActions")
+    end = src.find("async function undoMove")
+    assert start != -1
+    body = src[start:end]
+    assert "let xmpFailed = false" in body
+    assert "xmpFailed = true" in body
+    assert "if (doXmp &&  anyFailed)" not in body
+    assert "if (doXmp &&  xmpFailed)" in body or "if (doXmp && xmpFailed)" in body
+    assert "Some rejects were skipped" in body
+    assert "moveRes.all_moved === false" in body


### PR DESCRIPTION
## Summary

The Culling Assistant kept unbounded `Map`s of preview bytes (`blobUrlCache`, `rawCache`), set `src` on detached thumbs after `innerHTML` rebuilds, painted hover-preview results from older IPC calls, and treated a partial reject-move as done because it ignored `all_moved`.

`blobUrlCache` and `rawCache` are now `BlobUrlCache` (LRU 512, blob: URLs, revoke on eviction). `getBlobUrl` / `loadRawAsync` re-check after the IPC await. `lazyLoadImg` bails when `!img.isConnected`. `updatePreview` uses a generation token so a stale hover does not overwrite a newer one. A move with `all_moved === false` sets `anyFailed` instead of marking the step done.

Out of scope: visualizer/queue/scene-zoom caches, XSS lint of `culling.html`, auto-categorize, multiple culling windows.

## Test plan

- `pytest analyzer/tests/unit/test_culling_html_caches.py analyzer/tests/unit/test_culling_quality_cutoff.py analyzer/tests/test_security_visualizer_js_xss.py analyzer/tests/unit/test_reject_move.py -q`
- 67 passed (6 new plus culling/move/XSS neighbors)
- Arrange: source of `culling.html`
- Act: source-level assertions
- Assert: both caches are `new BlobUrlCache()` not `new Map()`; `getBlobUrl` uses `_base64ToBlobUrl` and re-checks after await; `lazyLoadImg` checks `isConnected` before and after await; `updatePreview` drops stale `_previewGen`; move path reads `moveRes.all_moved`

Reviewed on https://github.com/wolfgangh/ProjectKestrel/pull/37
