### PR TITLE
fix(culling): one assistant window (focus/reuse); cap image-load FIFO

### DIFF
--- a/analyzer/api_bridge.py
+++ b/analyzer/api_bridge.py
@@ -521,6 +521,7 @@ class Api:
         # Set externally by visualizer.main() after window/server come up.
         self._main_window = None
         self._culling_window = None
+        self._culling_window_root = None
         self._server_port: int | None = None
         # Async share-with-perch state (job_id -> {progress, cancel_event, thread})
         self._share_jobs: dict = {}
@@ -2935,8 +2936,43 @@ class Api:
     _oauth_cancel_event = None      # threading.Event for the active flow
     _oauth_thread = None            # the active oauth-flow worker thread
 
+    def _culling_window_is_open(self) -> bool:
+        """True if the Culling Assistant webview is still in ``webview.windows``."""
+        win = getattr(self, '_culling_window', None)
+        if win is None:
+            return False
+        try:
+            import webview as _wv
+            windows = getattr(_wv, 'windows', None) or []
+            return win in windows
+        except Exception:
+            return False
+
+    def _on_culling_window_closed(self):
+        self._culling_window = None
+        self._culling_window_root = None
+
+    def _focus_culling_window(self, win) -> None:
+        restore = getattr(win, 'restore', None)
+        if callable(restore):
+            try:
+                restore()
+            except Exception as e:
+                warn(f'[culling] restore failed: {e}')
+        show = getattr(win, 'show', None)
+        if callable(show):
+            try:
+                show()
+            except Exception as e:
+                warn(f'[culling] show failed: {e}')
+
     def open_culling_window(self, root_path: str):
-        """Open a new pywebview window for the Culling Assistant."""
+        """Open a pywebview window for the Culling Assistant.
+
+        One window only: a later click focuses the existing assistant and,
+        if the folder changed, reloads it. Stacking windows shares ``js_api``
+        and would race cull state and IPC.
+        """
         try:
             if not WEBVIEW_IMPORT_SUCCESS:
                 return {'success': False, 'error': 'pywebview not available'}
@@ -2950,15 +2986,35 @@ class Api:
             port = self._server_port or 8765
             from urllib.parse import quote
             culling_url = f'http://{HOST}:{port}/culling.html?root={quote(root_real, safe="")}'
+            title = f'Culling Assistant \u2014 {folder_name}'
+
+            if self._culling_window_is_open():
+                win = self._culling_window
+                if self._culling_window_root != root_real:
+                    win.load_url(culling_url)
+                    self._culling_window_root = root_real
+                    try:
+                        win.title = title
+                    except Exception as e:
+                        warn(f'[culling] set title failed: {e}')
+                self._focus_culling_window(win)
+                return {'success': True}
 
             win = _wv.create_window(
-                f'Culling Assistant \u2014 {folder_name}',
+                title,
                 culling_url,
                 js_api=self,
                 width=1400,
                 height=900,
             )
             self._culling_window = win
+            self._culling_window_root = root_real
+            closed = getattr(getattr(win, 'events', None), 'closed', None)
+            if closed is not None:
+                try:
+                    closed += self._on_culling_window_closed
+                except TypeError:
+                    warn('[culling] closed-handler subscribe failed')
             return {'success': True}
         except Exception as e:
             error(f'[API] open_culling_window error: {e}')

--- a/analyzer/js/image-loader.js
+++ b/analyzer/js/image-loader.js
@@ -4,6 +4,7 @@
     // Concurrency-limited to avoid flooding the Python IPC bridge with dozens of
     // simultaneous read_image_file calls when a large section of the grid scrolls
     // into view.  Excess loads are queued and drained as earlier ones finish.
+    const _IMG_LOAD_QUEUE_MAX = 256;
     const _imgLoadThrottle = { active: 0, max: 100, queue: [] };
     function _scheduleLoad(fn) {
       if (_imgLoadThrottle.active < _imgLoadThrottle.max) {
@@ -13,6 +14,9 @@
           if (_imgLoadThrottle.queue.length) _scheduleLoad(_imgLoadThrottle.queue.shift());
         });
       } else {
+        while (_imgLoadThrottle.queue.length >= _IMG_LOAD_QUEUE_MAX) {
+          _imgLoadThrottle.queue.shift();
+        }
         _imgLoadThrottle.queue.push(fn);
       }
     }
@@ -33,11 +37,9 @@
         // rating keypress the scene dialog does grid.innerHTML='' and recreates
         // every card) the old <img> nodes are detached from the document. Their
         // loaders may still be waiting in the shared FIFO concurrency queue;
-        // running them wastes one read_image_file IPC round-trip each and, since
-        // the queue is global and never pruned, pushes the freshly-rendered,
-        // still-visible thumbnails to the back of an ever-growing backlog. After
-        // rapid switching the visible thumbnails then never get their turn and
-        // appear to "stop loading". Bail out early if the element is gone.
+        // running them wastes one read_image_file IPC round-trip each.
+        // _scheduleLoad drops the oldest queued loaders beyond
+        // _IMG_LOAD_QUEUE_MAX so a rebuild cannot grow the FIFO without bound.
         if (!img.isConnected) return;
         const url = await resolverFn();
         // The element may have been detached while we awaited the IPC read; if so

--- a/analyzer/tests/unit/test_img_load_throttle.py
+++ b/analyzer/tests/unit/test_img_load_throttle.py
@@ -1,0 +1,50 @@
+"""image-loader.js IPC throttle queue is bounded (WP-25)."""
+
+from pathlib import Path
+
+import pytest
+
+ANALYZER = Path(__file__).resolve().parents[2]
+IMAGE_LOADER = ANALYZER / "js" / "image-loader.js"
+
+
+def _src() -> str:
+    return IMAGE_LOADER.read_text(encoding="utf-8")
+
+
+def _schedule_body() -> str:
+    src = _src()
+    start = src.find("function _scheduleLoad")
+    assert start != -1
+    nxt = src.find("\n    function ", start + 1)
+    if nxt == -1:
+        nxt = src.find("\n    const _lazyObserver", start + 1)
+    return src[start:nxt]
+
+
+@pytest.mark.unit
+def test_img_load_queue_has_a_numeric_cap():
+    src = _src()
+    assert "_IMG_LOAD_QUEUE_MAX" in src
+    # Cap must be a finite literal, not a comment-only mention.
+    assert "const _IMG_LOAD_QUEUE_MAX =" in src
+    body = src.split("const _IMG_LOAD_QUEUE_MAX =", 1)[1].split("\n", 1)[0]
+    n = int(body.strip().rstrip(";"))
+    assert 0 < n <= 1024
+
+
+@pytest.mark.unit
+def test_schedule_load_drops_oldest_when_queue_is_full():
+    body = _schedule_body()
+    assert "_imgLoadThrottle.queue.push(fn)" in body
+    assert "_imgLoadThrottle.queue.shift()" in body
+    assert "_IMG_LOAD_QUEUE_MAX" in body
+    push_i = body.find("_imgLoadThrottle.queue.push(fn)")
+    # Oldest-drop sits on the overflow path before the push.
+    overflow = body.find("queue.length >= _IMG_LOAD_QUEUE_MAX")
+    if overflow == -1:
+        overflow = body.find("queue.length > _IMG_LOAD_QUEUE_MAX")
+    assert overflow != -1
+    assert overflow < push_i
+    assert body.find("queue.shift()", overflow) != -1
+    assert body.find("queue.shift()", overflow) < push_i

--- a/analyzer/tests/unit/test_open_culling_window.py
+++ b/analyzer/tests/unit/test_open_culling_window.py
@@ -1,0 +1,118 @@
+"""open_culling_window reuses one window (WP-25)."""
+
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+import api_bridge
+
+
+pytestmark = pytest.mark.unit
+
+
+class _ClosedEvent:
+    def __init__(self):
+        self.handlers = []
+
+    def __iadd__(self, handler):
+        self.handlers.append(handler)
+        return self
+
+
+class FakeCullingWindow:
+    def __init__(self):
+        self.events = types.SimpleNamespace(closed=_ClosedEvent())
+        self.load_url = MagicMock()
+        self.show = MagicMock()
+        self.restore = MagicMock()
+        self.title = ''
+
+
+@pytest.fixture
+def api():
+    return api_bridge.Api()
+
+
+@pytest.fixture
+def fake_webview(monkeypatch):
+    windows: list = []
+    created: list = []
+
+    def _create_window(*_a, **_k):
+        win = FakeCullingWindow()
+        windows.append(win)
+        created.append(win)
+        return win
+
+    fake = types.ModuleType('webview')
+    fake.windows = windows
+    fake.create_window = MagicMock(side_effect=_create_window)
+    monkeypatch.setitem(sys.modules, 'webview', fake)
+    monkeypatch.setattr(api_bridge, 'WEBVIEW_IMPORT_SUCCESS', True)
+    return fake, windows, created
+
+
+def test_first_open_creates_one_window(api, fake_webview, tmp_path):
+    fake, _windows, created = fake_webview
+    root = tmp_path / 'shoot'
+    root.mkdir()
+    res = api.open_culling_window(str(root))
+    assert res['success'] is True
+    assert fake.create_window.call_count == 1
+    assert len(created) == 1
+    assert api._culling_window is created[0]
+    assert created[0].events.closed.handlers
+
+
+def test_second_open_same_root_reuses_without_reload(api, fake_webview, tmp_path):
+    fake, _windows, created = fake_webview
+    root = tmp_path / 'shoot'
+    root.mkdir()
+    first = api.open_culling_window(str(root))
+    second = api.open_culling_window(str(root))
+    assert first['success'] is True
+    assert second['success'] is True
+    assert fake.create_window.call_count == 1
+    win = created[0]
+    win.load_url.assert_not_called()
+    win.show.assert_called()
+    win.restore.assert_called()
+
+
+def test_second_open_different_root_reuses_and_loads_url(api, fake_webview, tmp_path):
+    fake, _windows, created = fake_webview
+    a = tmp_path / 'a'
+    b = tmp_path / 'b'
+    a.mkdir()
+    b.mkdir()
+    api.open_culling_window(str(a))
+    res = api.open_culling_window(str(b))
+    assert res['success'] is True
+    assert fake.create_window.call_count == 1
+    win = created[0]
+    win.load_url.assert_called_once()
+    url = win.load_url.call_args[0][0]
+    assert 'culling.html' in url
+    assert 'b' in url
+
+
+def test_closed_window_allows_a_new_create(api, fake_webview, tmp_path):
+    fake, windows, created = fake_webview
+    root = tmp_path / 'shoot'
+    root.mkdir()
+    api.open_culling_window(str(root))
+    win = created[0]
+    windows.remove(win)
+    for handler in list(win.events.closed.handlers):
+        handler()
+    assert api._culling_window is None
+    res = api.open_culling_window(str(root))
+    assert res['success'] is True
+    assert fake.create_window.call_count == 2


### PR DESCRIPTION
## Summary

Two related issues. The window policy is a **product choice** — please accept or reject that choice, not just the patch. The FIFO cap is a separate IPC bound.

### 1. One Culling Assistant window (please decide)

On `dev`, every "Open Culling Assistant" click calls `webview.create_window`. The new window overwrites `_culling_window`; the previous webview stays on screen. There is no focus/reuse.

Every window is created with `js_api=self` — the **same** Python `Api`. Two assistants are not two sessions: they share cull state, CSV saves, and `read_image_file`. Extra clicks therefore race writes, not "open folder B beside folder A".

**This PR's choice:** one live window. A later click focuses it (`show`/`restore`). Same folder: no reload. Different folder: `load_url` on that window. Close clears the handle so the next open creates again.

**Not in this PR (reject this approach if you want it instead):** N assistant windows with a process-wide image-load throttle. A shared queue would cap IPC but would **not** stop two UIs racing the same `Api`.

### 2. Unbounded image-load FIFO (mechanical, independent of 1)

`_imgLoadThrottle.queue` in `image-loader.js` had no length cap. Grid rebuilds could enqueue unbounded IPC. `_scheduleLoad` now drops the oldest queued loaders once the FIFO reaches 256. Each window already has its own JS queue; the cap is per page, not a substitute for one-window policy.

Out of scope: `culling.html` caches, cull-key shortcuts, auto-categorize, XSS lint.

## Test plan

- `pytest analyzer/tests/unit/test_open_culling_window.py analyzer/tests/unit/test_img_load_throttle.py analyzer/tests/unit/test_api_bridge_pure.py analyzer/tests/test_security_visualizer_js_xss.py -q`
- 74 passed (6 new plus bridge/XSS neighbors)
- Arrange: fake `webview` module / source of `image-loader.js`
- Act: two `open_culling_window` calls; source-level throttle assertions
- Assert: `create_window` once per live window; same root does not `load_url`; different root does; closed window allows a new create; `_IMG_LOAD_QUEUE_MAX` is finite and overflow `shift()`s before `push`

Reviewed on https://github.com/wolfgangh/ProjectKestrel/pull/38