### PR TITLE
fix(culling): skip Ctrl+ZXC; treat X as manual Undecided

### DIFF
--- a/analyzer/js/scene-dialog.js
+++ b/analyzer/js/scene-dialog.js
@@ -26,7 +26,8 @@
     function setCullStatus(row, status) {
       ensureRatingColumns();
       row.culled = status || ''; // 'accept', 'reject', or ''
-      row.culled_origin = status ? 'manual' : '';
+      // Empty is explicit Undecided (X / "none"), not "never touched".
+      row.culled_origin = 'manual';
       markDirty(row);
       // The grid thumbnail is chosen from the user's accept/reject decisions
       // (see _pickSceneRepresentative), so the card behind this dialog is now
@@ -1935,6 +1936,7 @@
         case 'z':
         case 'Z':
         case '7':
+          if (hasSceneModifier) break;
           e.preventDefault();
           if (images[currentImageIndex]) {
             setCullStatus(images[currentImageIndex], 'accept');
@@ -1944,6 +1946,7 @@
         case 'x':
         case 'X':
         case '8':
+          if (hasSceneModifier) break;
           e.preventDefault();
           if (images[currentImageIndex]) {
             setCullStatus(images[currentImageIndex], '');
@@ -1953,6 +1956,7 @@
         case 'c':
         case 'C':
         case '9':
+          if (hasSceneModifier) break;
           e.preventDefault();
           if (images[currentImageIndex]) {
             setCullStatus(images[currentImageIndex], 'reject');

--- a/analyzer/tests/unit/test_cull_keys_undecided.py
+++ b/analyzer/tests/unit/test_cull_keys_undecided.py
@@ -1,0 +1,138 @@
+"""Ctrl+C/Z/X must not cull; auto-categorize must keep explicit Undecided (WP-26).
+
+The scene-dialog Z/X/C keys (and 7/8/9) write accept / empty / reject. Those
+letters are also the browser's copy / undo / cut chords. The handler already
+skips input fields and handles Ctrl+Shift+C before the switch; it must also
+leave Ctrl/Cmd+Z, Ctrl/Cmd+X, and Ctrl/Cmd+C alone so preventDefault does not
+eat the browser shortcut.
+
+Explicit Undecided is the X key (and the filmstrip "none" toggle): culled is
+empty and origin is manual. ``applyAutoCategorize(true)`` already skips
+``isProtectedCull``, which is origin-based, so that empty+manual row stays
+off both assistant piles. Untouched rows (empty cull, empty origin) are still
+backfilled on init.
+
+No JS runner: source-level lints, same shape as ``test_culling_quality_cutoff.py``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+ANALYZER = Path(__file__).resolve().parents[2]
+SCENE_DIALOG = ANALYZER / "js" / "scene-dialog.js"
+CULLING_HTML = ANALYZER / "culling.html"
+
+
+pytestmark = pytest.mark.unit
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def _fn_body(src: str, header: str) -> str:
+    start = src.find(header)
+    assert start != -1, f"missing {header!r}"
+    candidates = [
+        src.find(marker, start + len(header))
+        for marker in ("\n    function ", "\n    async function ")
+    ]
+    nxt = min(i for i in candidates if i != -1)
+    return src[start:nxt]
+
+
+def _cull_key_cases(src: str) -> str:
+    start = src.find("// Cull decisions.")
+    assert start != -1, "cull-decision comment missing"
+    end = src.find("case '1':", start)
+    assert end != -1, "rating-key cases missing after cull keys"
+    return src[start:end]
+
+
+def test_ctrl_shift_c_is_handled_before_the_cull_reject_case():
+    src = _read(SCENE_DIALOG)
+    handler = _fn_body(src, "function _sceneKeyHandler(e)")
+    ctrl_shift_c = handler.find("ctrlShift && lowerKey === 'c'")
+    switch_at = handler.find("switch (e.key)")
+    cull_c = handler.find("case 'c':")
+    assert ctrl_shift_c != -1
+    assert switch_at != -1
+    assert cull_c != -1
+    assert ctrl_shift_c < switch_at < cull_c
+
+
+def test_cull_letter_keys_yield_when_ctrl_or_meta_is_held():
+    """Ctrl/Cmd+Z/X/C must not preventDefault or call setCullStatus."""
+    block = _cull_key_cases(_read(SCENE_DIALOG))
+    groups = [
+        block[block.find("case 'z':"):block.find("case 'x':")],
+        block[block.find("case 'x':"):block.find("case 'c':")],
+        block[block.find("case 'c':"):],
+    ]
+    assert all(g.strip() for g in groups)
+    for group in groups:
+        guard = group.find("if (hasSceneModifier) break;")
+        prevent = group.find("e.preventDefault();")
+        set_cull = group.find("setCullStatus(")
+        assert guard != -1, group
+        assert prevent != -1, group
+        assert set_cull != -1, group
+        assert guard < prevent < set_cull
+
+
+def test_plain_zxc_still_map_to_accept_undecided_reject():
+    block = _cull_key_cases(_read(SCENE_DIALOG))
+    assert "setCullStatus(images[currentImageIndex], 'accept')" in block
+    assert "setCullStatus(images[currentImageIndex], '')" in block
+    assert "setCullStatus(images[currentImageIndex], 'reject')" in block
+
+
+def test_clearing_cull_is_a_manual_origin():
+    """X / none is explicit Undecided, not 'never touched'."""
+    body = _fn_body(_read(SCENE_DIALOG), "function setCullStatus(row, status)")
+    assert "row.culled = status || '';" in body
+    assert "row.culled_origin = 'manual';" in body
+    assert "status ? 'manual' : ''" not in body
+
+
+def test_protected_cull_is_origin_only():
+    """Empty+manual must be protected; do not require accept/reject."""
+    html = _read(CULLING_HTML)
+    body = _fn_body(html, "function isProtectedCull(row)")
+    assert "origin === 'manual'" in body
+    assert "origin === 'verified'" in body
+    assert "hasAnyCull" not in body
+
+
+def test_normalize_keeps_manual_origin_without_accept_or_reject():
+    body = _fn_body(_read(CULLING_HTML), "function normalizeCullOrigin(row)")
+    raw_ok = body.find("raw === 'manual'")
+    status_fallback = body.find("if (status) return 'manual';")
+    empty = body.find("return '';")
+    assert raw_ok != -1
+    assert status_fallback != -1
+    assert empty != -1
+    assert raw_ok < status_fallback < empty
+
+
+def test_apply_auto_preserve_skips_protected_not_empty_without_origin():
+    """Init still backfills untouched rows; explicit Undecided is origin=manual."""
+    body = _fn_body(_read(CULLING_HTML), "function applyAutoCategorize(preserveManual = true)")
+    write = body[body.find("// Write results"):]
+    assert "if (preserveManual && isProtectedCull(r)) continue;" in write
+    assert "!hasAnyCull(r)" not in write
+    assert "setCullState(r, state, 'auto')" in write
+
+
+def test_init_backfill_uses_the_preserve_path():
+    body = _fn_body(_read(CULLING_HTML), "function initCullingState()")
+    assert "applyAutoCategorize(true)" in body
+
+
+def test_reset_still_overwrites_including_undecided():
+    html = _read(CULLING_HTML)
+    assert "applyAutoCategorize(false)" in html
+    assert "el('#resetConfirmOk')" in html


### PR DESCRIPTION
## Summary

Two related cull bugs. The first is mechanical; the second is a **product choice** — please accept or reject that choice, not just the patch.

### 1. Ctrl/Cmd+Z, X, C (mechanical)

Scene-dialog Z/X/C (and 7/8/9) wrote accept / empty / reject even when Ctrl or Cmd was held, so copy / undo / cut hit `preventDefault` and never reached the browser.

Those chords now `break` before `preventDefault`. Ctrl+Shift+C (clear tags) is unchanged and still runs before the switch.

### 2. Explicit Undecided vs assistant columns (please decide)

The Culling Assistant has two piles (accept / reject). On open, `initCullingState` always calls `applyAutoCategorize(true)` so **untouched** rows land in a column. `preserveManual` only skips origin `manual` / `verified`.

On `dev`, the visualizer X key / filmstrip "none" writes `culled=''` **and** `culled_origin=''` — the same bytes as never-touched. Opening the assistant therefore auto-fills images the user already marked Undecided.

**This PR's choice:** X / "none" is a **manual** decision. `setCullStatus` always writes `culled_origin='manual'`, including when status is empty. `applyAutoCategorize` is **unchanged**; `isProtectedCull` already skips that origin, so explicit Undecided stays off both piles. Untouched rows (`culled=''`, origin empty) are still backfilled on init. Reset still clears manuals then calls `applyAutoCategorize(false)` — that path is supposed to overwrite.

**Not in this PR (reject this approach if you want one of these instead):**
- A third Undecided column in the assistant.
- Skipping every empty cull on `preserveManual=true` (init would no longer fill untouched rows).

**Legacy CSV:** rows already saved as empty cull + empty origin cannot be told apart from untouched. They will be auto-filled **once** more. After a new X, origin is `manual` and they stay Undecided.

Out of scope: XSS lint of `culling.html`, `_TeeStream`, CSV-resume case, CI gate changes.

## Test plan

- `pytest analyzer/tests/unit/test_cull_keys_undecided.py analyzer/tests/unit/test_scene_review_state.py analyzer/tests/unit/test_culling_quality_cutoff.py -q`
- 37 passed, 15 subtests (9 new plus neighbors)
- Arrange: source of `scene-dialog.js` and `culling.html`
- Act: source-level asserts on `_sceneKeyHandler` cull cases, `setCullStatus`, `isProtectedCull`, `applyAutoCategorize`
- Assert: modifier guard precedes `preventDefault`/`setCullStatus` on Z/X/C; clearing cull writes origin `manual`; preserve-path skip is origin-only so empty-without-origin still backfills; reset still calls `applyAutoCategorize(false)`

Reviewed on https://github.com/wolfgangh/ProjectKestrel/pull/39