### PR TITLE
Stop prompting about unclean sessions that ended weeks ago

### DIFF
--- a/analyzer/tests/unit/test_shutdown_tracker_logging.py
+++ b/analyzer/tests/unit/test_shutdown_tracker_logging.py
@@ -28,6 +28,7 @@ try:
         _parse_session_timestamp,
         _pid_is_alive,
         _prior_session_still_running,
+        _prior_session_too_stale_to_prompt,
         _settings_file_hint,
         _utc_now_iso,
         _verify_exit_reason_persisted,
@@ -117,6 +118,35 @@ class TestPriorSessionStillRunning:
         monkeypatch.setattr(visualizer, '_pid_is_alive', lambda _pid: True)
         just_ahead = (visualizer.datetime.utcnow() + timedelta(seconds=5)).isoformat() + 'Z'
         assert _prior_session_still_running(4242, just_ahead) is True
+
+
+class TestPriorSessionTooStaleToPrompt:
+    """A prompt raised weeks after the session it refers to cannot lead
+    anywhere: the user has nothing to describe and the runtime logs the
+    report carries have rotated past it."""
+
+    def test_a_session_from_minutes_ago_is_not_stale(self):
+        assert _prior_session_too_stale_to_prompt(_utc_now_iso()) is False
+
+    def test_a_session_from_weeks_ago_is_stale(self):
+        from datetime import timedelta
+        weeks_ago = (
+            visualizer.datetime.utcnow() - timedelta(days=22)
+        ).isoformat() + 'Z'
+        assert _prior_session_too_stale_to_prompt(weeks_ago) is True
+
+    def test_boundary_is_the_documented_week(self):
+        from datetime import timedelta
+        now = visualizer.datetime.utcnow()
+        just_inside = (now - timedelta(days=7, minutes=-5)).isoformat() + 'Z'
+        just_outside = (now - timedelta(days=7, minutes=5)).isoformat() + 'Z'
+        assert _prior_session_too_stale_to_prompt(just_inside) is False
+        assert _prior_session_too_stale_to_prompt(just_outside) is True
+
+    def test_missing_or_unparseable_timestamp_fails_closed(self):
+        """Fail closed = keep the pre-existing behaviour (still flag)."""
+        assert _prior_session_too_stale_to_prompt('') is False
+        assert _prior_session_too_stale_to_prompt('not-a-timestamp') is False
 
 
 class TestParseSessionTimestamp:
@@ -263,10 +293,16 @@ class TestCleanExit:
 
 
 class TestSessionStartLogging:
-    def test_logs_classification_inputs_and_flags_unclean(self, fake_settings, shutdown_log):
+    def test_logs_classification_inputs_and_flags_unclean(
+        self, monkeypatch, fake_settings, shutdown_log
+    ):
+        # Dead pid and a recent start: the plain flagging path, with neither
+        # the concurrent-instance nor the staleness guard in the way.
+        monkeypatch.setattr(visualizer, '_pid_is_alive', lambda _pid: False)
+        started = _utc_now_iso()
         fake_settings['data'] = {
             EXIT_REASON_KEY: 'unknown',
-            'app_session_started_utc': '2026-07-01T00:00:00Z',
+            'app_session_started_utc': started,
             'app_session_pid': 4242,
         }
         visualizer._mark_session_start()
@@ -274,7 +310,7 @@ class TestSessionStartLogging:
         assert any('classifying prior session' in ln for ln in lines)
         assert any('FLAGGING prior session unclean' in ln for ln in lines)
         assert any('prev_pid=4242' in ln for ln in lines)
-        assert fake_settings['data']['last_unclean_shutdown_utc'] == '2026-07-01T00:00:00Z'
+        assert fake_settings['data']['last_unclean_shutdown_utc'] == started
 
     def test_clean_prior_session_is_not_flagged(self, fake_settings, shutdown_log):
         fake_settings['data'] = {
@@ -324,6 +360,77 @@ class TestSessionStartLogging:
         visualizer._mark_session_start()
         assert any('FLAGGING prior session unclean' in ln for ln in shutdown_log())
         assert fake_settings['data']['last_unclean_shutdown_utc'] == started
+
+    def test_stale_prior_session_is_not_flagged(
+        self, monkeypatch, fake_settings, shutdown_log
+    ):
+        """The reports this guards against: a prompt raised on a session
+        three weeks old, every launch, until some session exits cleanly."""
+        from datetime import timedelta
+        monkeypatch.setattr(visualizer, '_pid_is_alive', lambda _pid: False)
+        stale = (visualizer.datetime.utcnow() - timedelta(days=22)).isoformat() + 'Z'
+        fake_settings['data'] = {
+            EXIT_REASON_KEY: 'unknown',
+            'app_session_started_utc': stale,
+            'app_session_pid': 4242,
+        }
+        visualizer._mark_session_start()
+        lines = shutdown_log()
+        assert any('too stale to prompt' in ln for ln in lines)
+        assert not any('FLAGGING prior session unclean' in ln for ln in lines)
+        assert 'last_unclean_shutdown_utc' not in fake_settings['data']
+
+    def test_stale_prior_session_also_clears_an_older_pending_flag(
+        self, monkeypatch, fake_settings
+    ):
+        """A pending flag points at a session older than this one, so leaving
+        it standing would raise the very prompt this branch suppresses."""
+        from datetime import timedelta
+        monkeypatch.setattr(visualizer, '_pid_is_alive', lambda _pid: False)
+        stale = (visualizer.datetime.utcnow() - timedelta(days=22)).isoformat() + 'Z'
+        fake_settings['data'] = {
+            EXIT_REASON_KEY: 'unknown',
+            'app_session_started_utc': stale,
+            'app_session_pid': 4242,
+            'last_unclean_shutdown_utc': '2026-06-01T00:00:00Z',
+        }
+        visualizer._mark_session_start()
+        assert 'last_unclean_shutdown_utc' not in fake_settings['data']
+
+    def test_a_stale_recorded_crash_is_still_flagged(
+        self, monkeypatch, fake_settings, shutdown_log
+    ):
+        """The staleness guard is scoped to 'unknown'. A prior session
+        classified 'crash' had the top-level handler actually run and write
+        that reason, so it is a real crash however old it is."""
+        from datetime import timedelta
+        monkeypatch.setattr(visualizer, '_pid_is_alive', lambda _pid: False)
+        stale = (visualizer.datetime.utcnow() - timedelta(days=22)).isoformat() + 'Z'
+        fake_settings['data'] = {
+            EXIT_REASON_KEY: 'crash',
+            'app_session_started_utc': stale,
+            'app_session_pid': 4242,
+        }
+        visualizer._mark_session_start()
+        assert any('FLAGGING prior session unclean' in ln for ln in shutdown_log())
+        assert fake_settings['data']['last_unclean_shutdown_utc'] == stale
+
+    def test_a_recent_dead_session_is_unaffected_by_the_staleness_guard(
+        self, monkeypatch, fake_settings, shutdown_log
+    ):
+        """The case that actually produces useful reports: a real process
+        death the user relaunches straight after."""
+        from datetime import timedelta
+        monkeypatch.setattr(visualizer, '_pid_is_alive', lambda _pid: False)
+        recent = (visualizer.datetime.utcnow() - timedelta(hours=2)).isoformat() + 'Z'
+        fake_settings['data'] = {
+            EXIT_REASON_KEY: 'unknown',
+            'app_session_started_utc': recent,
+            'app_session_pid': 4242,
+        }
+        visualizer._mark_session_start()
+        assert any('FLAGGING prior session unclean' in ln for ln in shutdown_log())
+        assert fake_settings['data']['last_unclean_shutdown_utc'] == recent
 
     def test_opens_new_session_as_unknown(self, fake_settings, shutdown_log):
         fake_settings['data'] = {EXIT_REASON_KEY: 'clean'}

--- a/analyzer/visualizer.py
+++ b/analyzer/visualizer.py
@@ -320,6 +320,45 @@ def _prior_session_still_running(prev_pid: int, prev_started: str) -> bool:
     return -60 <= age_s <= _CONCURRENT_INSTANCE_MAX_AGE_S
 
 
+# How long after an ambiguous session a recovery prompt is still worth
+# raising. See _prior_session_too_stale_to_prompt.
+_UNCLEAN_PROMPT_MAX_AGE_S = 7 * 24 * 60 * 60
+
+
+def _prior_session_too_stale_to_prompt(prev_started: str) -> bool:
+    """True when an 'unknown' prior session is too old to prompt about.
+
+    The unclean flag is written at launch and only cleared when some later
+    session records a clean exit, so an ambiguous session that is never
+    followed by a clean one keeps prompting on every launch — reports have
+    arrived for sessions 22, 41 and 45 days old.
+
+    A prompt that stale cannot lead anywhere. The user has no memory of a
+    session from six weeks ago to describe, and the runtime logs attached to
+    the report have long since rotated past it, so the report arrives with
+    neither a traceback nor a usable log tail.
+
+    Age separates the two populations cleanly in the reports received so far:
+    every prompt confirmed to follow a real process death was raised on a
+    session the user had relaunched within minutes, while every prompt raised
+    on a session more than a week old turned out to be a false positive
+    (a clean exit whose marker was lost, or a pid recycled onto an unrelated
+    process). A week is well clear of both clusters.
+
+    Applies to 'unknown' only. A prior session classified 'crash' had the
+    top-level handler actually run and write that reason, so it is a real
+    crash however old it is, and the caller keeps flagging it.
+
+    Fails closed: an unparseable timestamp returns False, i.e. the
+    pre-existing behaviour.
+    """
+    started = _parse_session_timestamp(prev_started)
+    if started is None:
+        return False
+    age_s = (datetime.now(timezone.utc).replace(tzinfo=None) - started).total_seconds()
+    return age_s > _UNCLEAN_PROMPT_MAX_AGE_S
+
+
 def _settings_file_hint() -> Optional[str]:
     """Basename + parent of the settings file, for the session-start line.
 
@@ -430,6 +469,23 @@ def _mark_session_start() -> None:
                 reason=prev_reason,
                 prev_pid=prev_pid or None,
                 prev_started=prev_started,
+            )
+        elif (
+            should_flag
+            and prev_reason == 'unknown'
+            and _prior_session_too_stale_to_prompt(prev_started)
+        ):
+            # Too old to be worth a prompt. Clear any pending flag as well:
+            # it points at a session older still than this one, so leaving it
+            # standing would raise the prompt this branch exists to suppress.
+            had_flag = bool(str(settings.get('last_unclean_shutdown_utc', '') or '').strip())
+            settings.pop('last_unclean_shutdown_utc', None)
+            _log_shutdown_state(
+                'session_start: prior session too stale to prompt, not flagging unclean',
+                reason=prev_reason,
+                prev_started=prev_started,
+                max_age_days=_UNCLEAN_PROMPT_MAX_AGE_S // 86400,
+                cleared_stale_flag=had_flag or None,
             )
         elif should_flag:
             settings['last_unclean_shutdown_utc'] = prev_started


### PR DESCRIPTION
## The problem

The unclean-shutdown flag is written at launch and cleared only when some later session records a clean exit. A session classified `unknown` that is never followed by a clean one therefore keeps raising the recovery prompt on **every** launch, indefinitely.

The result is crash reports about sessions the user finished with weeks earlier. Among the recovery reports received so far, prompts have been raised on sessions 15, 21, 22, 41 and 45 days old.

A prompt that stale cannot lead anywhere useful:

- The user has no memory of a session from six weeks ago to describe.
- The runtime logs bundled with the report have rotated well past the session being reported, so the report arrives with neither a traceback nor a log tail covering the event it is about.

This was flagged as remaining work in #114 ("Even a genuine unclean shutdown is not worth a crash prompt six weeks after the fact") and noted again in triage of several individual reports, but never implemented. It is a distinct cause from #114 (clean-exit marker lost during teardown) and #143 (concurrent second instance); both of those are merged, and neither bounds how old a flagged session may be.

## How to reproduce

Against `dev` before this change:

1. Put settings into the state a launch after an ambiguous session leaves behind — `app_session_exit_reason: 'unknown'`, `app_session_started_utc` set to a synthetic `utcnow() - 22 days`, and a pid that is no longer alive.
2. Call `_mark_session_start()`.
3. `last_unclean_shutdown_utc` is set to that three-week-old timestamp, and `get_recovery_status()`'s prompt condition (`bool(unclean_utc) and exit_reason in ('crash', 'unknown')`) evaluates true — the recovery dialog fires.

Driving both the pre-change and post-change module through exactly that setup:

```
PRE-FIX (dev)   flag=<the 22-day-old timestamp>   recovery dialog shown = True
POST-FIX        flag=None                         recovery dialog shown = False
```

Because nothing clears the flag until a clean exit is recorded, step 3 repeats on every subsequent launch.

## What this PR does

Adds `_prior_session_too_stale_to_prompt()` and gates the unclean flag on the prior session having started within the last week.

**Why a week.** Age separates the two populations cleanly across the recovery reports received so far. Every prompt that was confirmed to follow a real process death was raised on a session the user had relaunched within minutes — the gap between the dead session and the relaunch was under an hour in every case. Every prompt raised on a session more than a week old turned out to be a false positive: either a clean exit whose marker was lost (#114) or a pid recycled onto an unrelated process (#143). A one-week bound sits well clear of both clusters, so it suppresses none of the reports that carried real diagnostic value.

**Scoped to `unknown`.** A prior session classified `crash` had the top-level handler actually run and write that reason, so it is a genuine crash however old it is and is still flagged. The false-positive problem lives entirely in the `unknown` bucket.

**The branch also clears any pending flag.** A flag already sitting in settings points at a session older still than the one being suppressed, so leaving it standing would raise the very prompt this branch exists to suppress.

**Failure modes.** An unparseable or missing timestamp returns `False`, i.e. the pre-existing behaviour. A clock jumped backwards yields a negative age and behaves as before; a clock jumped forwards can suppress a prompt, which is a lost prompt rather than a wrong one. There is no overlap with the concurrent-instance branch, which requires the prior session to be under 24 hours old and so can never also be stale.

The suppression is logged as a `[shutdown] session_start: prior session too stale to prompt` line with the session age bound, so the decision stays visible in future report log tails rather than looking like a prompt that silently failed to appear.

## Testing

- `pytest analyzer/tests/unit` — **877 passed, 5 skipped, 69 subtests passed**. (11 modules excluded from collection: `cv2` and other ML dependencies have no wheels in this container; none touch this path.)
- Reproduced the bug against the pre-change module and confirmed the fix flips it, as shown above.
- 8 new tests: 4 on the helper (recent session, weeks-old session, the week boundary from both sides, unparseable input failing closed) and 4 end to end through `_mark_session_start` (a stale session is not flagged, a stale session also clears an older pending flag, a stale recorded `crash` is still flagged, and a recent dead session is unaffected).
- Updated one existing test, `test_logs_classification_inputs_and_flags_unclean`. Its fixture used a fixed `2026-07-01` timestamp that is now 67 days stale, so the new gate suppressed the flag it asserts on. It now uses a recent timestamp and a dead pid, which is the plain flagging path it was written to cover; all of its original assertions are retained.

All timestamps and pids quoted above are synthetic values generated by the reproduction script; no content from any user's crash report appears in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MCSo7XzVx6ma4HAJQDhnWP